### PR TITLE
feat: add xr_toolz.types primitives and xr_toolz.data downloaders

### DIFF
--- a/src/xr_toolz/data/__init__.py
+++ b/src/xr_toolz/data/__init__.py
@@ -1,0 +1,45 @@
+"""Data downloaders for external geoscience archives.
+
+Data adapters here translate typed ``xr_toolz`` requests
+(:class:`~xr_toolz.types.BBox`, :class:`~xr_toolz.types.TimeRange`,
+:class:`~xr_toolz.types.Variable`, ...) into source-specific payloads,
+so all the type work lives in :mod:`xr_toolz.types` and this module
+just speaks the language of each underlying service.
+
+Exports:
+
+- :class:`DataSource`, :class:`DatasetInfo`
+- :class:`CMEMSSource`, :class:`CDSSource`
+- Credentials: :class:`CMEMSCredentials`, :class:`CDSCredentials`,
+  :func:`load_cmems`, :func:`load_cds`.
+- Catalog: :data:`CATALOG`, :class:`CatalogEntry`, :func:`all_entries`,
+  :func:`describe`.
+"""
+
+from xr_toolz.data._src.base import DatasetInfo, DatasetKind, DataSource
+from xr_toolz.data._src.catalog import CATALOG, CatalogEntry, all_entries, describe
+from xr_toolz.data._src.cds import CDSSource
+from xr_toolz.data._src.cmems import CMEMSSource
+from xr_toolz.data._src.credentials import (
+    CDSCredentials,
+    CMEMSCredentials,
+    load_cds,
+    load_cmems,
+)
+
+
+__all__ = [
+    "CATALOG",
+    "CDSCredentials",
+    "CDSSource",
+    "CMEMSCredentials",
+    "CMEMSSource",
+    "CatalogEntry",
+    "DataSource",
+    "DatasetInfo",
+    "DatasetKind",
+    "all_entries",
+    "describe",
+    "load_cds",
+    "load_cmems",
+]

--- a/src/xr_toolz/data/_src/__init__.py
+++ b/src/xr_toolz/data/_src/__init__.py
@@ -1,0 +1,1 @@
+"""Implementation modules for :mod:`xr_toolz.data`."""

--- a/src/xr_toolz/data/_src/base.py
+++ b/src/xr_toolz/data/_src/base.py
@@ -1,0 +1,119 @@
+"""Abstract base classes for data sources and dataset descriptors."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+import xarray as xr
+
+from xr_toolz.types import (
+    BBox,
+    DepthRange,
+    PressureLevels,
+    TimeRange,
+    Variable,
+    resolve,
+)
+
+
+class DatasetKind(StrEnum):
+    """Discriminator for how a dataset is laid out once materialized.
+
+    - ``gridded`` — regular lon/lat (+time) cube, the common case.
+    - ``alongtrack`` — 1-D samples along a satellite ground track.
+    - ``profiles`` — collection of vertical profiles at scattered
+      locations (Argo floats, CTD casts, gliders).
+    - ``trajectory`` — drifters / moving platforms.
+
+    Downstream code (regridding, masking, plotting) branches on this;
+    e.g. antimeridian BBox wrapping is meaningless for profiles.
+    """
+
+    GRIDDED = "gridded"
+    ALONGTRACK = "alongtrack"
+    PROFILES = "profiles"
+    TRAJECTORY = "trajectory"
+
+
+@dataclass(frozen=True)
+class DatasetInfo:
+    """Static description of a remote dataset.
+
+    Adapters return these from :meth:`DataSource.describe` and the
+    catalog stores them alongside default request parameters.
+    """
+
+    dataset_id: str
+    source: str
+    title: str
+    kind: DatasetKind = DatasetKind.GRIDDED
+    variables: tuple[Variable, ...] = ()
+    spatial_coverage: BBox | None = None
+    temporal_coverage: tuple[str, str] | None = None
+    doi: str | None = None
+    license: str | None = None
+    notes: str | None = None
+    extras: dict[str, Any] = field(default_factory=dict)
+
+
+class DataSource(ABC):
+    """Abstract interface implemented by every adapter."""
+
+    source_id: str
+    """Short slug used to look up per-source aliases in :class:`Variable`."""
+
+    @abstractmethod
+    def list_datasets(self) -> list[DatasetInfo]:  # pragma: no cover - interface
+        """Return known datasets exposed by this source."""
+
+    @abstractmethod
+    def describe(self, dataset_id: str) -> DatasetInfo:  # pragma: no cover - interface
+        """Return a :class:`DatasetInfo` for ``dataset_id``."""
+
+    @abstractmethod
+    def download(
+        self,
+        dataset_id: str,
+        output: Path,
+        *,
+        variables: list[str | Variable] | None = None,
+        bbox: BBox | None = None,
+        time: TimeRange | None = None,
+        depth: DepthRange | None = None,
+        levels: PressureLevels | None = None,
+        **extras: Any,
+    ) -> Path:  # pragma: no cover - interface
+        """Download ``dataset_id`` to ``output`` and return the path."""
+
+    @abstractmethod
+    def open(
+        self,
+        dataset_id: str,
+        *,
+        variables: list[str | Variable] | None = None,
+        bbox: BBox | None = None,
+        time: TimeRange | None = None,
+        depth: DepthRange | None = None,
+        levels: PressureLevels | None = None,
+        **extras: Any,
+    ) -> xr.Dataset:  # pragma: no cover - interface
+        """Open ``dataset_id`` lazily as an :class:`xarray.Dataset`."""
+
+    # ---- helpers --------------------------------------------------------
+
+    def _resolve_variables(
+        self, variables: list[str | Variable] | None
+    ) -> list[Variable]:
+        """Translate a heterogeneous variable list into :class:`Variable`."""
+        if variables is None:
+            return []
+        return [resolve(v) for v in variables]
+
+    def _encode_variables(self, variables: list[str | Variable] | None) -> list[str]:
+        """Return source-specific identifiers for ``variables``."""
+        resolved = self._resolve_variables(variables)
+        return [v.for_source(self.source_id) for v in resolved]

--- a/src/xr_toolz/data/_src/cache.py
+++ b/src/xr_toolz/data/_src/cache.py
@@ -1,0 +1,65 @@
+"""Tiny on-disk cache keyed on request parameters.
+
+Adapters call :func:`cache_path` to get a deterministic path for a
+given ``(source, dataset_id, request)`` triple. If the path exists,
+they can short-circuit the network call; if it doesn't, they download
+into it and the filesystem becomes the cache.
+
+The cache root defaults to ``$XR_TOOLZ_CACHE`` or
+``~/.cache/xr_toolz/data``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import asdict, is_dataclass
+from pathlib import Path
+from typing import Any
+
+
+def cache_root() -> Path:
+    """Return the root cache directory, creating it if needed."""
+    env = os.environ.get("XR_TOOLZ_CACHE")
+    root = Path(env) if env else Path.home() / ".cache" / "xr_toolz" / "data"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def cache_path(
+    source: str,
+    dataset_id: str,
+    request: dict[str, Any],
+    suffix: str = ".nc",
+) -> Path:
+    """Return a deterministic cache path for ``(source, dataset_id, request)``.
+
+    The path is ``<root>/<source>/<dataset_id>/<request_hash><suffix>``.
+    """
+    base = cache_root() / source / _safe(dataset_id)
+    base.mkdir(parents=True, exist_ok=True)
+    digest = _hash_request(request)
+    return base / f"{digest}{suffix}"
+
+
+def _hash_request(request: dict[str, Any]) -> str:
+    payload = json.dumps(request, sort_keys=True, default=_json_default)
+    return hashlib.sha1(payload.encode("utf-8")).hexdigest()[:16]
+
+
+def _json_default(obj: Any) -> Any:
+    if is_dataclass(obj) and not isinstance(obj, type):
+        return asdict(obj)
+    if isinstance(obj, Path):
+        return str(obj)
+    if hasattr(obj, "isoformat"):
+        return obj.isoformat()
+    if isinstance(obj, (set, frozenset, tuple)):
+        return list(obj)
+    return str(obj)
+
+
+def _safe(name: str) -> str:
+    """Make ``name`` safe to use as a path component."""
+    return "".join(c if c.isalnum() or c in "-._" else "_" for c in name)

--- a/src/xr_toolz/data/_src/cache.py
+++ b/src/xr_toolz/data/_src/cache.py
@@ -55,7 +55,11 @@ def _json_default(obj: Any) -> Any:
         return str(obj)
     if hasattr(obj, "isoformat"):
         return obj.isoformat()
-    if isinstance(obj, (set, frozenset, tuple)):
+    if isinstance(obj, (set, frozenset)):
+        # Sets iterate in hash-randomized order across interpreter runs;
+        # sort so the cache key is stable run-to-run.
+        return sorted(obj, key=str)
+    if isinstance(obj, tuple):
         return list(obj)
     return str(obj)
 

--- a/src/xr_toolz/data/_src/catalog.py
+++ b/src/xr_toolz/data/_src/catalog.py
@@ -1,0 +1,143 @@
+"""Unified dataset catalog: short name -> (source, dataset_id).
+
+Short names are a thin convenience layer — they map a memorable label
+like ``"glorys12.daily"`` to the fully-qualified ``(source, dataset_id)``
+tuple that adapters actually consume. Users can always bypass the
+catalog and pass a ``dataset_id`` directly to the adapter.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from xr_toolz.data._src.cds.catalog import CDS_DATASETS
+from xr_toolz.data._src.cmems.catalog import CMEMS_DATASETS
+
+
+@dataclass(frozen=True)
+class CatalogEntry:
+    """Short-name-to-source mapping with optional request defaults."""
+
+    source: str
+    dataset_id: str
+    defaults: dict[str, Any] | None = None
+
+
+CATALOG: dict[str, CatalogEntry] = {
+    # ---- CMEMS — physics reanalysis ------------------------------------
+    "glorys12.daily": CatalogEntry(
+        source="cmems",
+        dataset_id="cmems_mod_glo_phy_my_0.083deg_P1D-m",
+    ),
+    # ---- CMEMS — sea level --------------------------------------------
+    "duacs.sla": CatalogEntry(
+        source="cmems",
+        dataset_id="cmems_obs-sl_glo_phy-ssh_my_allsat-l4-duacs-0.25deg_P1D",
+    ),
+    "duacs.alongtrack.s3a": CatalogEntry(
+        source="cmems",
+        dataset_id="cmems_obs-sl_glo_phy-ssh_my_s3a-l3-duacs_PT1S_202411",
+    ),
+    "duacs.alongtrack.s3b": CatalogEntry(
+        source="cmems",
+        dataset_id="cmems_obs-sl_glo_phy-ssh_my_s3b-l3-duacs_PT1S_202411",
+    ),
+    "duacs.alongtrack.s6a": CatalogEntry(
+        source="cmems",
+        dataset_id="cmems_obs-sl_glo_phy-ssh_my_s6a-lr-l3-duacs_PT1S_202411",
+    ),
+    "duacs.alongtrack.swot": CatalogEntry(
+        source="cmems",
+        dataset_id="cmems_obs-sl_glo_phy-ssh_my_swon-l3-duacs_PT1S_202411",
+    ),
+    # ---- CMEMS — SST --------------------------------------------------
+    "ostia.sst": CatalogEntry(
+        source="cmems",
+        dataset_id="METOFFICE-GLO-SST-L4-REP-OBS-SST",
+    ),
+    "odyssea.sst": CatalogEntry(
+        source="cmems",
+        dataset_id="cmems_obs-sst_glo_phy_my_l3s_P1D-m_202311",
+    ),
+    # ---- CMEMS — SSS --------------------------------------------------
+    "multiobs.sss.daily": CatalogEntry(
+        source="cmems",
+        dataset_id="cmems_obs-mob_glo_phy-sss_my_multi_P1D",
+    ),
+    "multiobs.sss.monthly": CatalogEntry(
+        source="cmems",
+        dataset_id="cmems_obs-mob_glo_phy-sss_my_multi_P1M",
+    ),
+    # ---- CMEMS — ocean colour -----------------------------------------
+    "globcolour.chl.monthly": CatalogEntry(
+        source="cmems",
+        dataset_id="cmems_obs-oc_glo_bgc-plankton_my_l4-multi-4km_P1M",
+    ),
+    "globcolour.chl.daily": CatalogEntry(
+        source="cmems",
+        dataset_id="cmems_obs-oc_glo_bgc-plankton_my_l4-gapfree-multi-4km_P1D",
+    ),
+    "globcolour.transparency": CatalogEntry(
+        source="cmems",
+        dataset_id="cmems_obs-oc_glo_bgc-transp_my_l4-multi-4km_P1M",
+    ),
+    "globcolour.optics": CatalogEntry(
+        source="cmems",
+        dataset_id="cmems_obs-oc_glo_bgc-optics_my_l4-multi-4km_P1M",
+    ),
+    "globcolour.reflectance": CatalogEntry(
+        source="cmems",
+        dataset_id="cmems_obs-oc_glo_bgc-reflectance_my_l4-multi-4km_P1M",
+    ),
+    "globcolour.pp": CatalogEntry(
+        source="cmems",
+        dataset_id="cmems_obs-oc_glo_bgc-pp_my_l4-multi-4km_P1M",
+    ),
+    # ---- CMEMS — in-situ ----------------------------------------------
+    "cora.ts": CatalogEntry(
+        source="cmems",
+        dataset_id="cmems_obs-ins_glo_phy-temp-sal_my_cora_irr",
+    ),
+    "easycora.ts": CatalogEntry(
+        source="cmems",
+        dataset_id="cmems_obs-ins_glo_phy-temp-sal_my_easycora_irr",
+    ),
+    # ---- CMEMS — biogeochemistry --------------------------------------
+    "glorys12.bgc.daily": CatalogEntry(
+        source="cmems",
+        dataset_id="cmems_mod_glo_bgc_my_0.25deg_P1D-m_202406",
+    ),
+    "glorys12.bgc.monthly": CatalogEntry(
+        source="cmems",
+        dataset_id="cmems_mod_glo_bgc_my_0.25deg_P1M-m_202406",
+    ),
+    # ---- CDS — ERA5 ---------------------------------------------------
+    "era5.single_levels": CatalogEntry(
+        source="cds",
+        dataset_id="reanalysis-era5-single-levels",
+    ),
+    "era5.pressure_levels": CatalogEntry(
+        source="cds",
+        dataset_id="reanalysis-era5-pressure-levels",
+    ),
+    "era5.land": CatalogEntry(
+        source="cds",
+        dataset_id="reanalysis-era5-land",
+    ),
+}
+
+
+def all_entries() -> dict[str, CatalogEntry]:
+    """Return a shallow copy of the unified catalog."""
+    return dict(CATALOG)
+
+
+def describe(name: str) -> Any:
+    """Look up a :class:`DatasetInfo` by short name."""
+    entry = CATALOG[name]
+    if entry.source == "cmems":
+        return CMEMS_DATASETS[entry.dataset_id]
+    if entry.source == "cds":
+        return CDS_DATASETS[entry.dataset_id]
+    raise KeyError(f"Unknown source {entry.source!r}")

--- a/src/xr_toolz/data/_src/catalog.py
+++ b/src/xr_toolz/data/_src/catalog.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+from xr_toolz.data._src.base import DatasetInfo
 from xr_toolz.data._src.cds.catalog import CDS_DATASETS
 from xr_toolz.data._src.cmems.catalog import CMEMS_DATASETS
 
@@ -133,7 +134,7 @@ def all_entries() -> dict[str, CatalogEntry]:
     return dict(CATALOG)
 
 
-def describe(name: str) -> Any:
+def describe(name: str) -> DatasetInfo:
     """Look up a :class:`DatasetInfo` by short name."""
     entry = CATALOG[name]
     if entry.source == "cmems":

--- a/src/xr_toolz/data/_src/cds/__init__.py
+++ b/src/xr_toolz/data/_src/cds/__init__.py
@@ -1,0 +1,6 @@
+"""Climate Data Store (CDS) adapter."""
+
+from xr_toolz.data._src.cds.source import CDSSource
+
+
+__all__ = ["CDSSource"]

--- a/src/xr_toolz/data/_src/cds/catalog.py
+++ b/src/xr_toolz/data/_src/cds/catalog.py
@@ -20,7 +20,7 @@ CDS_DATASETS: dict[str, DatasetInfo] = {
     "reanalysis-era5-single-levels": DatasetInfo(
         dataset_id="reanalysis-era5-single-levels",
         source="cds",
-        title="ERA5 — Single pressure levels (hourly)",
+        title="ERA5 — Single levels (surface/near-surface, hourly)",
         variables=(T2M, D2M, U10, V10, MSL, TP, SP, SSRD),
         spatial_coverage=BBox.global_(),
         temporal_coverage=("1940-01-01", "present"),

--- a/src/xr_toolz/data/_src/cds/catalog.py
+++ b/src/xr_toolz/data/_src/cds/catalog.py
@@ -1,0 +1,47 @@
+"""Small curated catalog of Climate Data Store products."""
+
+from __future__ import annotations
+
+from xr_toolz.data._src.base import DatasetInfo
+from xr_toolz.types import (
+    D2M,
+    MSL,
+    SP,
+    SSRD,
+    T2M,
+    TP,
+    U10,
+    V10,
+    BBox,
+)
+
+
+CDS_DATASETS: dict[str, DatasetInfo] = {
+    "reanalysis-era5-single-levels": DatasetInfo(
+        dataset_id="reanalysis-era5-single-levels",
+        source="cds",
+        title="ERA5 — Single pressure levels (hourly)",
+        variables=(T2M, D2M, U10, V10, MSL, TP, SP, SSRD),
+        spatial_coverage=BBox.global_(),
+        temporal_coverage=("1940-01-01", "present"),
+        license="Copernicus Climate Change Service",
+    ),
+    "reanalysis-era5-pressure-levels": DatasetInfo(
+        dataset_id="reanalysis-era5-pressure-levels",
+        source="cds",
+        title="ERA5 — Pressure levels (hourly)",
+        variables=(),
+        spatial_coverage=BBox.global_(),
+        temporal_coverage=("1940-01-01", "present"),
+        license="Copernicus Climate Change Service",
+    ),
+    "reanalysis-era5-land": DatasetInfo(
+        dataset_id="reanalysis-era5-land",
+        source="cds",
+        title="ERA5-Land — Hourly land-surface reanalysis",
+        variables=(T2M, D2M, TP, SP),
+        spatial_coverage=BBox.global_(),
+        temporal_coverage=("1950-01-01", "present"),
+        license="Copernicus Climate Change Service",
+    ),
+}

--- a/src/xr_toolz/data/_src/cds/source.py
+++ b/src/xr_toolz/data/_src/cds/source.py
@@ -1,0 +1,180 @@
+"""Climate Data Store (CDS) adapter built on ``cdsapi``.
+
+The underlying client is imported lazily so ``xr_toolz.data`` can be
+imported without the optional ``cdsapi`` dependency.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import xarray as xr
+
+from xr_toolz.data._src.base import DatasetInfo, DataSource
+from xr_toolz.data._src.cds.catalog import CDS_DATASETS
+from xr_toolz.data._src.credentials import CDSCredentials, load_cds
+from xr_toolz.types import (
+    BBox,
+    DepthRange,
+    PressureLevels,
+    TimeRange,
+    Variable,
+)
+
+
+class CDSSource(DataSource):
+    """Adapter around the ``cdsapi`` Python client.
+
+    Args:
+        credentials: Explicit :class:`CDSCredentials`. When ``None``,
+            credentials are resolved from env vars / ``~/.cdsapirc``.
+        client: Optional pre-built ``cdsapi.Client`` (or test double).
+        format: CDS output format, default ``"netcdf"``.
+        product_type: Default ``product_type`` form entry when one
+            isn't provided per-call.
+    """
+
+    source_id = "cds"
+
+    def __init__(
+        self,
+        credentials: CDSCredentials | None = None,
+        client: Any | None = None,
+        format: str = "netcdf",
+        product_type: str = "reanalysis",
+    ) -> None:
+        self.credentials = credentials or load_cds()
+        self._client = client
+        self.format = format
+        self.product_type = product_type
+
+    # ---- client handling --------------------------------------------------
+
+    def _get_client(self) -> Any:
+        if self._client is not None:
+            return self._client
+        try:
+            import cdsapi  # type: ignore
+        except ImportError as exc:  # pragma: no cover - defensive
+            raise ImportError(
+                "CDSSource requires the 'cdsapi' package. "
+                "Install with: pip install xr_toolz[data]"
+            ) from exc
+        kwargs: dict[str, str] = {}
+        if self.credentials is not None:
+            kwargs["url"] = self.credentials.url
+            kwargs["key"] = self.credentials.key
+        self._client = cdsapi.Client(**kwargs)
+        return self._client
+
+    # ---- DataSource API ---------------------------------------------------
+
+    def list_datasets(self) -> list[DatasetInfo]:
+        return list(CDS_DATASETS.values())
+
+    def describe(self, dataset_id: str) -> DatasetInfo:
+        if dataset_id in CDS_DATASETS:
+            return CDS_DATASETS[dataset_id]
+        return DatasetInfo(
+            dataset_id=dataset_id,
+            source=self.source_id,
+            title=dataset_id,
+        )
+
+    def download(
+        self,
+        dataset_id: str,
+        output: Path,
+        *,
+        variables: list[str | Variable] | None = None,
+        bbox: BBox | None = None,
+        time: TimeRange | None = None,
+        depth: DepthRange | None = None,
+        levels: PressureLevels | None = None,
+        **extras: Any,
+    ) -> Path:
+        """Retrieve a dataset to ``output`` via ``cdsapi.Client.retrieve``."""
+        output = Path(output)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        form = self._build_form(
+            variables=variables,
+            bbox=bbox,
+            time=time,
+            levels=levels,
+            extras=extras,
+        )
+        self._get_client().retrieve(dataset_id, form, str(output))
+        return output
+
+    def open(
+        self,
+        dataset_id: str,
+        *,
+        variables: list[str | Variable] | None = None,
+        bbox: BBox | None = None,
+        time: TimeRange | None = None,
+        depth: DepthRange | None = None,
+        levels: PressureLevels | None = None,
+        **extras: Any,
+    ) -> xr.Dataset:
+        """Download then open the resulting file with ``xarray.open_dataset``.
+
+        CDS has no native lazy access path, so this always materialises
+        a local file (under the request cache) before handing back an
+        ``xr.Dataset``.
+        """
+        from xr_toolz.data._src.cache import cache_path
+
+        request = {
+            "dataset_id": dataset_id,
+            "variables": [v if isinstance(v, str) else v.name for v in variables or []],
+            "bbox": bbox.__dict__ if bbox else None,
+            "time": {
+                "start": time.start.isoformat(),
+                "end": time.end.isoformat(),
+                "freq": time.freq,
+            }
+            if time is not None
+            else None,
+            "levels": levels.levels if levels else None,
+            "extras": extras,
+        }
+        path = cache_path(self.source_id, dataset_id, request, suffix=".nc")
+        if not path.exists():
+            self.download(
+                dataset_id,
+                path,
+                variables=variables,
+                bbox=bbox,
+                time=time,
+                depth=depth,
+                levels=levels,
+                **extras,
+            )
+        return xr.open_dataset(path)
+
+    # ---- payload construction --------------------------------------------
+
+    def _build_form(
+        self,
+        variables: list[str | Variable] | None,
+        bbox: BBox | None,
+        time: TimeRange | None,
+        levels: PressureLevels | None,
+        extras: dict[str, Any],
+    ) -> dict[str, Any]:
+        form: dict[str, Any] = {
+            "format": self.format,
+            "product_type": self.product_type,
+        }
+        if variables:
+            form["variable"] = self._encode_variables(variables)
+        if bbox is not None:
+            form["area"] = bbox.as_cds_area()
+        if time is not None:
+            form.update(time.as_cds_form())
+        if levels is not None:
+            form["pressure_level"] = levels.as_cds_form()
+        form.update(extras)
+        return form

--- a/src/xr_toolz/data/_src/cds/source.py
+++ b/src/xr_toolz/data/_src/cds/source.py
@@ -122,7 +122,9 @@ class CDSSource(DataSource):
 
         CDS has no native lazy access path, so this always materialises
         a local file (under the request cache) before handing back an
-        ``xr.Dataset``.
+        ``xr.Dataset``. Both the cache file suffix and the xarray engine
+        follow :attr:`format`, so reconfiguring to ``"grib"`` remains
+        consistent end-to-end.
         """
         from xr_toolz.data._src.cache import cache_path
 
@@ -140,7 +142,8 @@ class CDSSource(DataSource):
             "levels": levels.levels if levels else None,
             "extras": extras,
         }
-        path = cache_path(self.source_id, dataset_id, request, suffix=".nc")
+        suffix = _suffix_for_format(self.format)
+        path = cache_path(self.source_id, dataset_id, request, suffix=suffix)
         if not path.exists():
             self.download(
                 dataset_id,
@@ -152,7 +155,8 @@ class CDSSource(DataSource):
                 levels=levels,
                 **extras,
             )
-        return xr.open_dataset(path)
+        engine = _engine_for_format(self.format)
+        return xr.open_dataset(path, engine=engine) if engine else xr.open_dataset(path)
 
     # ---- payload construction --------------------------------------------
 
@@ -178,3 +182,38 @@ class CDSSource(DataSource):
             form["pressure_level"] = levels.as_cds_form()
         form.update(extras)
         return form
+
+
+# ---- format <-> filesystem / xarray glue ------------------------------------
+
+
+_FORMAT_SUFFIX: dict[str, str] = {
+    "netcdf": ".nc",
+    "netcdf4": ".nc",
+    "nc": ".nc",
+    "grib": ".grib",
+    "grib2": ".grib",
+}
+
+_FORMAT_ENGINE: dict[str, str | None] = {
+    "netcdf": None,  # xarray picks the best netcdf engine
+    "netcdf4": None,
+    "nc": None,
+    "grib": "cfgrib",
+    "grib2": "cfgrib",
+}
+
+
+def _suffix_for_format(fmt: str) -> str:
+    """File suffix to use when caching a CDS download of format ``fmt``."""
+    try:
+        return _FORMAT_SUFFIX[fmt.lower()]
+    except KeyError as exc:
+        raise ValueError(
+            f"Unsupported CDS format {fmt!r}; known: {sorted(_FORMAT_SUFFIX)}"
+        ) from exc
+
+
+def _engine_for_format(fmt: str) -> str | None:
+    """xarray engine to use when opening a cached file of format ``fmt``."""
+    return _FORMAT_ENGINE.get(fmt.lower())

--- a/src/xr_toolz/data/_src/cmems/__init__.py
+++ b/src/xr_toolz/data/_src/cmems/__init__.py
@@ -1,0 +1,6 @@
+"""Copernicus Marine Data Store (CMEMS) adapter."""
+
+from xr_toolz.data._src.cmems.source import CMEMSSource
+
+
+__all__ = ["CMEMSSource"]

--- a/src/xr_toolz/data/_src/cmems/catalog.py
+++ b/src/xr_toolz/data/_src/cmems/catalog.py
@@ -1,0 +1,29 @@
+"""Curated catalog of Copernicus Marine products.
+
+Assembled from per-family preset modules under
+:mod:`xr_toolz.data._src.cmems.presets`. Each family keeps its own
+module so the catalog stays legible — add new products to the
+appropriate preset file, not here.
+"""
+
+from __future__ import annotations
+
+from xr_toolz.data._src.base import DatasetInfo
+from xr_toolz.data._src.cmems.presets.bgc import BGC_DATASETS
+from xr_toolz.data._src.cmems.presets.insitu import INSITU_DATASETS
+from xr_toolz.data._src.cmems.presets.oc import OC_DATASETS
+from xr_toolz.data._src.cmems.presets.phy import PHY_DATASETS
+from xr_toolz.data._src.cmems.presets.ssh import SSH_DATASETS
+from xr_toolz.data._src.cmems.presets.sss import SSS_DATASETS
+from xr_toolz.data._src.cmems.presets.sst import SST_DATASETS
+
+
+CMEMS_DATASETS: dict[str, DatasetInfo] = {
+    **PHY_DATASETS,
+    **SSH_DATASETS,
+    **SST_DATASETS,
+    **SSS_DATASETS,
+    **OC_DATASETS,
+    **INSITU_DATASETS,
+    **BGC_DATASETS,
+}

--- a/src/xr_toolz/data/_src/cmems/presets/__init__.py
+++ b/src/xr_toolz/data/_src/cmems/presets/__init__.py
@@ -1,0 +1,6 @@
+"""Per-family CMEMS dataset presets.
+
+Each submodule exposes a ``<NAME>_DATASETS: dict[str, DatasetInfo]``
+keyed on the ``copernicusmarine`` ``dataset_id``. The parent
+``catalog.py`` merges them into a single :data:`CMEMS_DATASETS` dict.
+"""

--- a/src/xr_toolz/data/_src/cmems/presets/bgc.py
+++ b/src/xr_toolz/data/_src/cmems/presets/bgc.py
@@ -1,0 +1,41 @@
+"""CMEMS biogeochemistry reanalysis presets (global PISCES-based)."""
+
+from __future__ import annotations
+
+from xr_toolz.data._src.base import DatasetInfo, DatasetKind
+from xr_toolz.types import (
+    CHL,
+    NO3,
+    O2,
+    PH,
+    PHYC,
+    PO4,
+    SI,
+    SPCO2,
+    ZOOC,
+    BBox,
+)
+
+
+BGC_DATASETS: dict[str, DatasetInfo] = {
+    "cmems_mod_glo_bgc_my_0.25deg_P1D-m_202406": DatasetInfo(
+        dataset_id="cmems_mod_glo_bgc_my_0.25deg_P1D-m_202406",
+        source="cmems",
+        title="Global BGC reanalysis (PISCES) — 0.25°, daily mean",
+        kind=DatasetKind.GRIDDED,
+        variables=(CHL, NO3, PO4, SI, O2, PHYC, ZOOC, PH, SPCO2),
+        spatial_coverage=BBox.global_(),
+        temporal_coverage=("1993-01-01", "present"),
+        license="Copernicus Marine Service",
+    ),
+    "cmems_mod_glo_bgc_my_0.25deg_P1M-m_202406": DatasetInfo(
+        dataset_id="cmems_mod_glo_bgc_my_0.25deg_P1M-m_202406",
+        source="cmems",
+        title="Global BGC reanalysis (PISCES) — 0.25°, monthly mean",
+        kind=DatasetKind.GRIDDED,
+        variables=(CHL, NO3, PO4, SI, O2, PHYC, ZOOC, PH, SPCO2),
+        spatial_coverage=BBox.global_(),
+        temporal_coverage=("1993-01-01", "present"),
+        license="Copernicus Marine Service",
+    ),
+}

--- a/src/xr_toolz/data/_src/cmems/presets/insitu.py
+++ b/src/xr_toolz/data/_src/cmems/presets/insitu.py
@@ -1,0 +1,44 @@
+"""CMEMS in-situ observation presets (CORA T/S profiles).
+
+In-situ products are not gridded — the client returns a collection of
+trajectories / profiles. :attr:`DatasetInfo.kind` is set accordingly so
+downstream code can branch on it.
+"""
+
+from __future__ import annotations
+
+from xr_toolz.data._src.base import DatasetInfo, DatasetKind
+from xr_toolz.types import SO, SST, BBox
+
+
+INSITU_DATASETS: dict[str, DatasetInfo] = {
+    "cmems_obs-ins_glo_phy-temp-sal_my_cora_irr": DatasetInfo(
+        dataset_id="cmems_obs-ins_glo_phy-temp-sal_my_cora_irr",
+        source="cmems",
+        title=(
+            "CORA — Global in-situ T/S discrete profiles (Argo + CTD + "
+            "XBT + gliders + WOD)"
+        ),
+        kind=DatasetKind.PROFILES,
+        variables=(SST, SO),
+        spatial_coverage=BBox.global_(),
+        temporal_coverage=("1950-01-01", "2021-12-31"),
+        license="Copernicus Marine Service",
+        notes=(
+            "Non-gridded — output is a collection of vertical profiles at "
+            "scattered lat/lon/time. The returned container is a Dataset "
+            "with a trajectory-style layout, not a regular cube."
+        ),
+    ),
+    "cmems_obs-ins_glo_phy-temp-sal_my_easycora_irr": DatasetInfo(
+        dataset_id="cmems_obs-ins_glo_phy-temp-sal_my_easycora_irr",
+        source="cmems",
+        title="EasyCORA — Simplified global in-situ T/S profiles",
+        kind=DatasetKind.PROFILES,
+        variables=(SST, SO),
+        spatial_coverage=BBox.global_(),
+        temporal_coverage=("1950-01-01", "2021-12-31"),
+        license="Copernicus Marine Service",
+        notes="Non-gridded — see CORA notes.",
+    ),
+}

--- a/src/xr_toolz/data/_src/cmems/presets/oc.py
+++ b/src/xr_toolz/data/_src/cmems/presets/oc.py
@@ -1,0 +1,100 @@
+"""CMEMS ocean-colour presets (GlobColour L4 multi-sensor, reprocessed).
+
+GlobColour is organised by theme (plankton / transparency / optics /
+reflectance / primary production) — each theme is a separate
+``dataset_id`` so each is registered individually.
+"""
+
+from __future__ import annotations
+
+from xr_toolz.data._src.base import DatasetInfo, DatasetKind
+from xr_toolz.types import (
+    BBP443,
+    CHL,
+    KD490,
+    PP,
+    RRS412,
+    RRS443,
+    RRS490,
+    RRS510,
+    RRS555,
+    RRS670,
+    SPM,
+    ZSD,
+    BBox,
+)
+
+
+OC_DATASETS: dict[str, DatasetInfo] = {
+    # ---- Plankton (chlorophyll) ----------------------------------------
+    "cmems_obs-oc_glo_bgc-plankton_my_l4-multi-4km_P1M": DatasetInfo(
+        dataset_id="cmems_obs-oc_glo_bgc-plankton_my_l4-multi-4km_P1M",
+        source="cmems",
+        title="GlobColour L4 — Global chlorophyll (reprocessed, 4 km, monthly)",
+        kind=DatasetKind.GRIDDED,
+        variables=(CHL,),
+        spatial_coverage=BBox.global_(),
+        temporal_coverage=("1997-09-01", "present"),
+        license="Copernicus Marine Service",
+    ),
+    "cmems_obs-oc_glo_bgc-plankton_my_l4-gapfree-multi-4km_P1D": DatasetInfo(
+        dataset_id="cmems_obs-oc_glo_bgc-plankton_my_l4-gapfree-multi-4km_P1D",
+        source="cmems",
+        title="GlobColour L4 — Global chlorophyll gap-free (reprocessed, 4 km, daily)",
+        kind=DatasetKind.GRIDDED,
+        variables=(CHL,),
+        spatial_coverage=BBox.global_(),
+        temporal_coverage=("1997-09-01", "present"),
+        license="Copernicus Marine Service",
+    ),
+    # ---- Transparency (Kd490 / Secchi / SPM) ---------------------------
+    "cmems_obs-oc_glo_bgc-transp_my_l4-multi-4km_P1M": DatasetInfo(
+        dataset_id="cmems_obs-oc_glo_bgc-transp_my_l4-multi-4km_P1M",
+        source="cmems",
+        title="GlobColour L4 — Global transparency (reprocessed, 4 km, monthly)",
+        kind=DatasetKind.GRIDDED,
+        variables=(KD490, ZSD, SPM),
+        spatial_coverage=BBox.global_(),
+        temporal_coverage=("1997-09-01", "present"),
+        license="Copernicus Marine Service",
+    ),
+    # ---- Optics (backscattering / absorption) --------------------------
+    "cmems_obs-oc_glo_bgc-optics_my_l4-multi-4km_P1M": DatasetInfo(
+        dataset_id="cmems_obs-oc_glo_bgc-optics_my_l4-multi-4km_P1M",
+        source="cmems",
+        title=(
+            "GlobColour L4 — Global inherent optical properties "
+            "(reprocessed, 4 km, monthly)"
+        ),
+        kind=DatasetKind.GRIDDED,
+        variables=(BBP443,),
+        spatial_coverage=BBox.global_(),
+        temporal_coverage=("1997-09-01", "present"),
+        license="Copernicus Marine Service",
+    ),
+    # ---- Reflectance (Rrs wavelength family) ---------------------------
+    "cmems_obs-oc_glo_bgc-reflectance_my_l4-multi-4km_P1M": DatasetInfo(
+        dataset_id="cmems_obs-oc_glo_bgc-reflectance_my_l4-multi-4km_P1M",
+        source="cmems",
+        title=(
+            "GlobColour L4 — Global remote-sensing reflectance "
+            "(reprocessed, 4 km, monthly)"
+        ),
+        kind=DatasetKind.GRIDDED,
+        variables=(RRS412, RRS443, RRS490, RRS510, RRS555, RRS670),
+        spatial_coverage=BBox.global_(),
+        temporal_coverage=("1997-09-01", "present"),
+        license="Copernicus Marine Service",
+    ),
+    # ---- Primary production --------------------------------------------
+    "cmems_obs-oc_glo_bgc-pp_my_l4-multi-4km_P1M": DatasetInfo(
+        dataset_id="cmems_obs-oc_glo_bgc-pp_my_l4-multi-4km_P1M",
+        source="cmems",
+        title="GlobColour L4 — Global primary production (reprocessed, 4 km, monthly)",
+        kind=DatasetKind.GRIDDED,
+        variables=(PP,),
+        spatial_coverage=BBox.global_(),
+        temporal_coverage=("1997-09-01", "present"),
+        license="Copernicus Marine Service",
+    ),
+}

--- a/src/xr_toolz/data/_src/cmems/presets/phy.py
+++ b/src/xr_toolz/data/_src/cmems/presets/phy.py
@@ -1,0 +1,20 @@
+"""CMEMS physics reanalysis presets (GLORYS)."""
+
+from __future__ import annotations
+
+from xr_toolz.data._src.base import DatasetInfo, DatasetKind
+from xr_toolz.types import SO, SSH, SST, UO, VO, BBox
+
+
+PHY_DATASETS: dict[str, DatasetInfo] = {
+    "cmems_mod_glo_phy_my_0.083deg_P1D-m": DatasetInfo(
+        dataset_id="cmems_mod_glo_phy_my_0.083deg_P1D-m",
+        source="cmems",
+        title="GLORYS12 — Global ocean physics reanalysis, 1/12°, daily mean",
+        kind=DatasetKind.GRIDDED,
+        variables=(SST, SSH, UO, VO, SO),
+        spatial_coverage=BBox.global_(),
+        temporal_coverage=("1993-01-01", "present"),
+        license="Copernicus Marine Service",
+    ),
+}

--- a/src/xr_toolz/data/_src/cmems/presets/ssh.py
+++ b/src/xr_toolz/data/_src/cmems/presets/ssh.py
@@ -1,0 +1,82 @@
+"""CMEMS sea-surface-height observation presets (DUACS L4 + L3).
+
+The L3 along-track product ships one ``dataset_id`` per satellite
+mission; we expose the common reference missions. Users who need a
+specific mission not in this list can pass the ``dataset_id`` directly
+to :class:`~xr_toolz.data.CMEMSSource`.
+"""
+
+from __future__ import annotations
+
+from xr_toolz.data._src.base import DatasetInfo, DatasetKind
+from xr_toolz.types import ADT, SLA, UGOS, VGOS, BBox
+
+
+SSH_DATASETS: dict[str, DatasetInfo] = {
+    # ---- L4 gridded (reprocessed) --------------------------------------
+    "cmems_obs-sl_glo_phy-ssh_my_allsat-l4-duacs-0.25deg_P1D": DatasetInfo(
+        dataset_id="cmems_obs-sl_glo_phy-ssh_my_allsat-l4-duacs-0.25deg_P1D",
+        source="cmems",
+        title="DUACS L4 — Global ocean gridded SLA (reprocessed, daily, 0.25°)",
+        kind=DatasetKind.GRIDDED,
+        variables=(SLA, ADT, UGOS, VGOS),
+        spatial_coverage=BBox.global_(),
+        temporal_coverage=("1993-01-01", "present"),
+        license="Copernicus Marine Service",
+    ),
+    # ---- L3 along-track (per-mission) ----------------------------------
+    "cmems_obs-sl_glo_phy-ssh_my_s3a-l3-duacs_PT1S_202411": DatasetInfo(
+        dataset_id="cmems_obs-sl_glo_phy-ssh_my_s3a-l3-duacs_PT1S_202411",
+        source="cmems",
+        title="DUACS L3 along-track SLA — Sentinel-3A (reprocessed)",
+        kind=DatasetKind.ALONGTRACK,
+        variables=(SLA,),
+        spatial_coverage=BBox.global_(),
+        license="Copernicus Marine Service",
+    ),
+    "cmems_obs-sl_glo_phy-ssh_my_s3b-l3-duacs_PT1S_202411": DatasetInfo(
+        dataset_id="cmems_obs-sl_glo_phy-ssh_my_s3b-l3-duacs_PT1S_202411",
+        source="cmems",
+        title="DUACS L3 along-track SLA — Sentinel-3B (reprocessed)",
+        kind=DatasetKind.ALONGTRACK,
+        variables=(SLA,),
+        spatial_coverage=BBox.global_(),
+        license="Copernicus Marine Service",
+    ),
+    "cmems_obs-sl_glo_phy-ssh_my_s6a-lr-l3-duacs_PT1S_202411": DatasetInfo(
+        dataset_id="cmems_obs-sl_glo_phy-ssh_my_s6a-lr-l3-duacs_PT1S_202411",
+        source="cmems",
+        title="DUACS L3 along-track SLA — Sentinel-6A (reprocessed)",
+        kind=DatasetKind.ALONGTRACK,
+        variables=(SLA,),
+        spatial_coverage=BBox.global_(),
+        license="Copernicus Marine Service",
+    ),
+    "cmems_obs-sl_glo_phy-ssh_my_j3-l3-duacs_PT1S_202411": DatasetInfo(
+        dataset_id="cmems_obs-sl_glo_phy-ssh_my_j3-l3-duacs_PT1S_202411",
+        source="cmems",
+        title="DUACS L3 along-track SLA — Jason-3 (reprocessed)",
+        kind=DatasetKind.ALONGTRACK,
+        variables=(SLA,),
+        spatial_coverage=BBox.global_(),
+        license="Copernicus Marine Service",
+    ),
+    "cmems_obs-sl_glo_phy-ssh_my_al-l3-duacs_PT1S_202411": DatasetInfo(
+        dataset_id="cmems_obs-sl_glo_phy-ssh_my_al-l3-duacs_PT1S_202411",
+        source="cmems",
+        title="DUACS L3 along-track SLA — Saral/AltiKa (reprocessed)",
+        kind=DatasetKind.ALONGTRACK,
+        variables=(SLA,),
+        spatial_coverage=BBox.global_(),
+        license="Copernicus Marine Service",
+    ),
+    "cmems_obs-sl_glo_phy-ssh_my_swon-l3-duacs_PT1S_202411": DatasetInfo(
+        dataset_id="cmems_obs-sl_glo_phy-ssh_my_swon-l3-duacs_PT1S_202411",
+        source="cmems",
+        title="DUACS L3 along-track SLA — SWOT nadir (reprocessed)",
+        kind=DatasetKind.ALONGTRACK,
+        variables=(SLA,),
+        spatial_coverage=BBox.global_(),
+        license="Copernicus Marine Service",
+    ),
+}

--- a/src/xr_toolz/data/_src/cmems/presets/sss.py
+++ b/src/xr_toolz/data/_src/cmems/presets/sss.py
@@ -1,0 +1,48 @@
+"""CMEMS sea-surface-salinity multi-observation presets (MULTIOBS)."""
+
+from __future__ import annotations
+
+from xr_toolz.data._src.base import DatasetInfo, DatasetKind
+from xr_toolz.types import DENS, SOS, BBox
+
+
+SSS_DATASETS: dict[str, DatasetInfo] = {
+    "cmems_obs-mob_glo_phy-sss_my_multi_P1D": DatasetInfo(
+        dataset_id="cmems_obs-mob_glo_phy-sss_my_multi_P1D",
+        source="cmems",
+        title="MULTIOBS L4 — Global SSS + density (reprocessed, 0.125°, daily)",
+        kind=DatasetKind.GRIDDED,
+        variables=(SOS, DENS),
+        spatial_coverage=BBox.global_(),
+        temporal_coverage=("1993-01-01", "present"),
+        license="Copernicus Marine Service",
+    ),
+    "cmems_obs-mob_glo_phy-sss_my_multi_P1M": DatasetInfo(
+        dataset_id="cmems_obs-mob_glo_phy-sss_my_multi_P1M",
+        source="cmems",
+        title="MULTIOBS L4 — Global SSS + density (reprocessed, 0.125°, monthly)",
+        kind=DatasetKind.GRIDDED,
+        variables=(SOS, DENS),
+        spatial_coverage=BBox.global_(),
+        temporal_coverage=("1993-01-01", "present"),
+        license="Copernicus Marine Service",
+    ),
+    "cmems_obs-mob_glo_phy-sss_nrt_multi_P1D": DatasetInfo(
+        dataset_id="cmems_obs-mob_glo_phy-sss_nrt_multi_P1D",
+        source="cmems",
+        title="MULTIOBS L4 — Global SSS + density (NRT, 0.125°, daily)",
+        kind=DatasetKind.GRIDDED,
+        variables=(SOS, DENS),
+        spatial_coverage=BBox.global_(),
+        license="Copernicus Marine Service",
+    ),
+    "cmems_obs-mob_glo_phy-sss_nrt_multi_P1M": DatasetInfo(
+        dataset_id="cmems_obs-mob_glo_phy-sss_nrt_multi_P1M",
+        source="cmems",
+        title="MULTIOBS L4 — Global SSS + density (NRT, 0.125°, monthly)",
+        kind=DatasetKind.GRIDDED,
+        variables=(SOS, DENS),
+        spatial_coverage=BBox.global_(),
+        license="Copernicus Marine Service",
+    ),
+}

--- a/src/xr_toolz/data/_src/cmems/presets/sst.py
+++ b/src/xr_toolz/data/_src/cmems/presets/sst.py
@@ -1,0 +1,41 @@
+"""CMEMS sea-surface-temperature observation presets (OSTIA + ODYSSEA).
+
+OSTIA L4 (SST_GLO_SST_L4_REP_OBSERVATIONS_010_011) uses a legacy
+dataset naming scheme — the modern ``copernicusmarine`` client accepts
+the uppercase "METOFFICE-…" form directly as ``dataset_id``.
+"""
+
+from __future__ import annotations
+
+from xr_toolz.data._src.base import DatasetInfo, DatasetKind
+from xr_toolz.types import ICE_CONC, SST, BBox
+
+
+SST_DATASETS: dict[str, DatasetInfo] = {
+    # ---- OSTIA L4 reprocessed ------------------------------------------
+    "METOFFICE-GLO-SST-L4-REP-OBS-SST": DatasetInfo(
+        dataset_id="METOFFICE-GLO-SST-L4-REP-OBS-SST",
+        source="cmems",
+        title="OSTIA L4 — Global SST + sea-ice (reprocessed, 0.05°, daily)",
+        kind=DatasetKind.GRIDDED,
+        variables=(SST, ICE_CONC),
+        spatial_coverage=BBox.global_(),
+        temporal_coverage=("1981-10-01", "present"),
+        license="Copernicus Marine Service",
+        notes=(
+            "Legacy-format dataset_id (not cmems_-prefixed). The "
+            "copernicusmarine client accepts both forms."
+        ),
+    ),
+    # ---- ODYSSEA L3S multi-sensor (reprocessed) ------------------------
+    "cmems_obs-sst_glo_phy_my_l3s_P1D-m_202311": DatasetInfo(
+        dataset_id="cmems_obs-sst_glo_phy_my_l3s_P1D-m_202311",
+        source="cmems",
+        title="ODYSSEA L3S — Global multi-sensor SST (reprocessed, 0.1°, daily)",
+        kind=DatasetKind.GRIDDED,
+        variables=(SST,),
+        spatial_coverage=BBox.global_(),
+        temporal_coverage=("1982-01-01", "present"),
+        license="Copernicus Marine Service",
+    ),
+}

--- a/src/xr_toolz/data/_src/cmems/source.py
+++ b/src/xr_toolz/data/_src/cmems/source.py
@@ -1,0 +1,158 @@
+"""Copernicus Marine (CMEMS) adapter built on ``copernicusmarine``.
+
+The underlying client is imported lazily so ``xr_toolz.data`` can be
+imported without the optional ``copernicusmarine`` dependency.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import xarray as xr
+
+from xr_toolz.data._src.base import DatasetInfo, DataSource
+from xr_toolz.data._src.cmems.catalog import CMEMS_DATASETS
+from xr_toolz.data._src.credentials import CMEMSCredentials, load_cmems
+from xr_toolz.types import (
+    BBox,
+    DepthRange,
+    PressureLevels,
+    TimeRange,
+    Variable,
+)
+
+
+class CMEMSSource(DataSource):
+    """Adapter around the ``copernicusmarine`` Python client.
+
+    Args:
+        credentials: Explicit :class:`CMEMSCredentials`. When ``None``,
+            credentials are resolved from env vars / ``~/.cmems``.
+        client: Optional pre-built client (``copernicusmarine`` module
+            or test double). Useful for tests; production code leaves
+            this ``None``.
+    """
+
+    source_id = "cmems"
+
+    def __init__(
+        self,
+        credentials: CMEMSCredentials | None = None,
+        client: Any | None = None,
+    ) -> None:
+        self.credentials = credentials or load_cmems()
+        self._client = client
+
+    # ---- client handling --------------------------------------------------
+
+    def _get_client(self) -> Any:
+        if self._client is not None:
+            return self._client
+        try:
+            import copernicusmarine  # type: ignore
+        except ImportError as exc:  # pragma: no cover - defensive
+            raise ImportError(
+                "CMEMSSource requires the 'copernicusmarine' package. "
+                "Install with: pip install xr_toolz[data]"
+            ) from exc
+        self._client = copernicusmarine
+        return self._client
+
+    def _auth_kwargs(self) -> dict[str, str]:
+        if self.credentials is None:
+            return {}
+        return {
+            "username": self.credentials.username,
+            "password": self.credentials.password,
+        }
+
+    # ---- DataSource API ---------------------------------------------------
+
+    def list_datasets(self) -> list[DatasetInfo]:
+        return list(CMEMS_DATASETS.values())
+
+    def describe(self, dataset_id: str) -> DatasetInfo:
+        if dataset_id in CMEMS_DATASETS:
+            return CMEMS_DATASETS[dataset_id]
+        return DatasetInfo(
+            dataset_id=dataset_id,
+            source=self.source_id,
+            title=dataset_id,
+        )
+
+    def download(
+        self,
+        dataset_id: str,
+        output: Path,
+        *,
+        variables: list[str | Variable] | None = None,
+        bbox: BBox | None = None,
+        time: TimeRange | None = None,
+        depth: DepthRange | None = None,
+        levels: PressureLevels | None = None,
+        **extras: Any,
+    ) -> Path:
+        """Download a subset to a NetCDF file at ``output``."""
+        output = Path(output)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        kwargs = self._subset_kwargs(
+            dataset_id=dataset_id,
+            variables=variables,
+            bbox=bbox,
+            time=time,
+            depth=depth,
+            extras=extras,
+        )
+        self._get_client().subset(
+            **kwargs,
+            output_filename=output.name,
+            output_directory=str(output.parent),
+            **self._auth_kwargs(),
+        )
+        return output
+
+    def open(
+        self,
+        dataset_id: str,
+        *,
+        variables: list[str | Variable] | None = None,
+        bbox: BBox | None = None,
+        time: TimeRange | None = None,
+        depth: DepthRange | None = None,
+        levels: PressureLevels | None = None,
+        **extras: Any,
+    ) -> xr.Dataset:
+        """Open a lazy dataset via ``copernicusmarine.open_dataset``."""
+        kwargs = self._subset_kwargs(
+            dataset_id=dataset_id,
+            variables=variables,
+            bbox=bbox,
+            time=time,
+            depth=depth,
+            extras=extras,
+        )
+        return self._get_client().open_dataset(**kwargs, **self._auth_kwargs())
+
+    # ---- payload construction --------------------------------------------
+
+    def _subset_kwargs(
+        self,
+        dataset_id: str,
+        variables: list[str | Variable] | None,
+        bbox: BBox | None,
+        time: TimeRange | None,
+        depth: DepthRange | None,
+        extras: dict[str, Any],
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {"dataset_id": dataset_id}
+        if variables:
+            payload["variables"] = self._encode_variables(variables)
+        if bbox is not None:
+            payload.update(bbox.as_cmems())
+        if time is not None:
+            payload.update(time.as_cmems())
+        if depth is not None:
+            payload.update(depth.as_cmems())
+        payload.update(extras)
+        return payload

--- a/src/xr_toolz/data/_src/credentials.py
+++ b/src/xr_toolz/data/_src/credentials.py
@@ -1,0 +1,96 @@
+"""Credential loading for data adapters.
+
+We never write credentials — only read. Sources are checked in this
+order:
+
+1. Keyword arguments to the adapter constructor.
+2. Environment variables (``COPERNICUSMARINE_SERVICE_USERNAME`` etc.).
+3. Known on-disk config files (``~/.cmems``, ``~/.cdsapirc``).
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class CMEMSCredentials:
+    """Username / password pair for Copernicus Marine."""
+
+    username: str
+    password: str
+
+
+@dataclass(frozen=True)
+class CDSCredentials:
+    """URL / key pair for the Climate Data Store."""
+
+    url: str
+    key: str
+
+
+def load_cmems(
+    username: str | None = None,
+    password: str | None = None,
+    path: Path | None = None,
+) -> CMEMSCredentials | None:
+    """Load CMEMS credentials, or ``None`` if none could be found."""
+    if username and password:
+        return CMEMSCredentials(username=username, password=password)
+
+    env_u = os.environ.get("COPERNICUSMARINE_SERVICE_USERNAME")
+    env_p = os.environ.get("COPERNICUSMARINE_SERVICE_PASSWORD")
+    if env_u and env_p:
+        return CMEMSCredentials(username=env_u, password=env_p)
+
+    cfg = path or Path.home() / ".cmems"
+    if cfg.is_file():
+        parsed = _parse_kv(cfg.read_text())
+        u = parsed.get("username")
+        p = parsed.get("password")
+        if u and p:
+            return CMEMSCredentials(username=u, password=p)
+
+    return None
+
+
+def load_cds(
+    url: str | None = None,
+    key: str | None = None,
+    path: Path | None = None,
+) -> CDSCredentials | None:
+    """Load CDS credentials, or ``None`` if none could be found."""
+    if url and key:
+        return CDSCredentials(url=url, key=key)
+
+    env_url = os.environ.get("CDSAPI_URL")
+    env_key = os.environ.get("CDSAPI_KEY")
+    if env_url and env_key:
+        return CDSCredentials(url=env_url, key=env_key)
+
+    cfg = path or Path.home() / ".cdsapirc"
+    if cfg.is_file():
+        parsed = _parse_kv(cfg.read_text())
+        u = parsed.get("url")
+        k = parsed.get("key")
+        if u and k:
+            return CDSCredentials(url=u, key=k)
+
+    return None
+
+
+def _parse_kv(text: str) -> dict[str, str]:
+    """Parse ``key: value`` / ``key=value`` / ``key value`` config files."""
+    out: dict[str, str] = {}
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        for sep in (":", "=", " "):
+            if sep in line:
+                k, _, v = line.partition(sep)
+                out[k.strip().lower()] = v.strip()
+                break
+    return out

--- a/src/xr_toolz/types/__init__.py
+++ b/src/xr_toolz/types/__init__.py
@@ -1,0 +1,139 @@
+"""Shared typed primitives for ``xr_toolz``.
+
+These types are deliberately agnostic of any particular submodule
+(``data``, ``geo``, ``ocn``, ``atm``, ...). They exist so every module
+speaks the same language for things like "a lon/lat bounding box",
+"a time window", "a CF variable".
+
+Exports:
+
+- Spatial: :class:`BBox`.
+- Temporal: :class:`TimeRange`.
+- Vertical: :class:`DepthRange`, :class:`PressureLevels`.
+- Request: :class:`Request` (typed composition of the above).
+- Variables: :class:`Variable`, :data:`REGISTRY`, :func:`resolve`,
+  :func:`register`.
+- Validation: :func:`validate_variable`, :func:`validate_dataset`,
+  :func:`apply_cf_attrs`, :class:`ValidationReport`, :class:`Issue`,
+  :class:`Severity`.
+"""
+
+from xr_toolz.types._src.geometry import BBox
+from xr_toolz.types._src.levels import DepthRange, PressureLevels
+from xr_toolz.types._src.request import Request
+from xr_toolz.types._src.time import TimeRange
+from xr_toolz.types._src.validation import (
+    Issue,
+    Severity,
+    ValidationReport,
+    apply_cf_attrs,
+    validate_dataset,
+    validate_variable,
+)
+from xr_toolz.types._src.variable import (
+    ADT,
+    BBP443,
+    CHL,
+    D2M,
+    DENS,
+    ICE_CONC,
+    KD490,
+    MDT,
+    MSL,
+    NO3,
+    O2,
+    PH,
+    PHYC,
+    PO4,
+    PP,
+    REGISTRY,
+    RRS412,
+    RRS443,
+    RRS490,
+    RRS510,
+    RRS555,
+    RRS670,
+    SI,
+    SLA,
+    SO,
+    SOS,
+    SP,
+    SPCO2,
+    SPM,
+    SSH,
+    SSRD,
+    SST,
+    T2M,
+    TP,
+    U10,
+    UGOS,
+    UO,
+    V10,
+    VGOS,
+    VO,
+    ZOOC,
+    ZSD,
+    Variable,
+    register,
+    resolve,
+)
+
+
+__all__ = [
+    "ADT",
+    "BBP443",
+    "CHL",
+    "D2M",
+    "DENS",
+    "ICE_CONC",
+    "KD490",
+    "MDT",
+    "MSL",
+    "NO3",
+    "O2",
+    "PH",
+    "PHYC",
+    "PO4",
+    "PP",
+    "REGISTRY",
+    "RRS412",
+    "RRS443",
+    "RRS490",
+    "RRS510",
+    "RRS555",
+    "RRS670",
+    "SI",
+    "SLA",
+    "SO",
+    "SOS",
+    "SP",
+    "SPCO2",
+    "SPM",
+    "SSH",
+    "SSRD",
+    "SST",
+    "T2M",
+    "TP",
+    "U10",
+    "UGOS",
+    "UO",
+    "V10",
+    "VGOS",
+    "VO",
+    "ZOOC",
+    "ZSD",
+    "BBox",
+    "DepthRange",
+    "Issue",
+    "PressureLevels",
+    "Request",
+    "Severity",
+    "TimeRange",
+    "ValidationReport",
+    "Variable",
+    "apply_cf_attrs",
+    "register",
+    "resolve",
+    "validate_dataset",
+    "validate_variable",
+]

--- a/src/xr_toolz/types/_src/__init__.py
+++ b/src/xr_toolz/types/_src/__init__.py
@@ -1,0 +1,1 @@
+"""Implementation modules for :mod:`xr_toolz.types`."""

--- a/src/xr_toolz/types/_src/geometry.py
+++ b/src/xr_toolz/types/_src/geometry.py
@@ -93,7 +93,20 @@ class BBox:
         return [self.lat_max, self.lon_min, self.lat_min, self.lon_max]
 
     def as_xarray_sel(self, lon: str = "lon", lat: str = "lat") -> dict[str, slice]:
-        """``ds.sel(**bbox.as_xarray_sel())`` selector."""
+        """``ds.sel(**bbox.as_xarray_sel())`` selector.
+
+        Raises:
+            ValueError: if the box crosses the antimeridian — a single
+                ``slice(lon_min, lon_max)`` would select zero points in
+                that case. Split the box at ±180° and select the halves
+                separately, or call :meth:`to_360` first.
+        """
+        if self.crosses_antimeridian:
+            raise ValueError(
+                "BBox crosses the antimeridian; a single slice cannot "
+                "represent the wrap. Split the box at ±180° and sel() "
+                "each half, or call .to_360() first."
+            )
         return {
             lon: slice(self.lon_min, self.lon_max),
             lat: slice(self.lat_min, self.lat_max),

--- a/src/xr_toolz/types/_src/geometry.py
+++ b/src/xr_toolz/types/_src/geometry.py
@@ -1,0 +1,100 @@
+"""Spatial geometry types."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class BBox:
+    """Axis-aligned lon/lat bounding box.
+
+    Longitude is accepted in either ``[-180, 180]`` or ``[0, 360]``
+    convention; use :meth:`to_180` / :meth:`to_360` to normalize. A
+    ``lon_min > lon_max`` box is interpreted as crossing the
+    antimeridian.
+    """
+
+    lon_min: float
+    lon_max: float
+    lat_min: float
+    lat_max: float
+
+    def __post_init__(self) -> None:
+        if not -90.0 <= self.lat_min <= 90.0:
+            raise ValueError(f"lat_min out of [-90, 90]: {self.lat_min}")
+        if not -90.0 <= self.lat_max <= 90.0:
+            raise ValueError(f"lat_max out of [-90, 90]: {self.lat_max}")
+        if self.lat_min > self.lat_max:
+            raise ValueError(
+                f"lat_min ({self.lat_min}) must be <= lat_max ({self.lat_max})"
+            )
+
+    # ---- constructors -----------------------------------------------------
+
+    @classmethod
+    def from_tuple(cls, t: tuple[float, float, float, float]) -> BBox:
+        """Build from ``(lon_min, lon_max, lat_min, lat_max)``."""
+        lon_min, lon_max, lat_min, lat_max = t
+        return cls(lon_min, lon_max, lat_min, lat_max)
+
+    @classmethod
+    def global_(cls) -> BBox:
+        """Whole-globe bounding box in ``[-180, 180]`` convention."""
+        return cls(-180.0, 180.0, -90.0, 90.0)
+
+    # ---- derived ----------------------------------------------------------
+
+    @property
+    def crosses_antimeridian(self) -> bool:
+        return self.lon_min > self.lon_max
+
+    @property
+    def width(self) -> float:
+        """Longitude extent (handles antimeridian wrap)."""
+        if self.crosses_antimeridian:
+            return (360.0 - self.lon_min) + self.lon_max
+        return self.lon_max - self.lon_min
+
+    @property
+    def height(self) -> float:
+        """Latitude extent in degrees."""
+        return self.lat_max - self.lat_min
+
+    # ---- normalization ----------------------------------------------------
+
+    def to_180(self) -> BBox:
+        """Return a copy with longitudes normalized to ``[-180, 180]``."""
+
+        def _w(x: float) -> float:
+            return ((x + 180.0) % 360.0) - 180.0
+
+        return BBox(_w(self.lon_min), _w(self.lon_max), self.lat_min, self.lat_max)
+
+    def to_360(self) -> BBox:
+        """Return a copy with longitudes normalized to ``[0, 360]``."""
+        return BBox(
+            self.lon_min % 360.0, self.lon_max % 360.0, self.lat_min, self.lat_max
+        )
+
+    # ---- serializers ------------------------------------------------------
+
+    def as_cmems(self) -> dict[str, float]:
+        """``copernicusmarine.subset`` kwargs."""
+        return {
+            "minimum_longitude": self.lon_min,
+            "maximum_longitude": self.lon_max,
+            "minimum_latitude": self.lat_min,
+            "maximum_latitude": self.lat_max,
+        }
+
+    def as_cds_area(self) -> list[float]:
+        """CDS ``area`` key: ``[North, West, South, East]``."""
+        return [self.lat_max, self.lon_min, self.lat_min, self.lon_max]
+
+    def as_xarray_sel(self, lon: str = "lon", lat: str = "lat") -> dict[str, slice]:
+        """``ds.sel(**bbox.as_xarray_sel())`` selector."""
+        return {
+            lon: slice(self.lon_min, self.lon_max),
+            lat: slice(self.lat_min, self.lat_max),
+        }

--- a/src/xr_toolz/types/_src/levels.py
+++ b/src/xr_toolz/types/_src/levels.py
@@ -1,0 +1,38 @@
+"""Vertical coordinate types: continuous depth, discrete pressure levels."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DepthRange:
+    """Continuous depth window (positive-down, metres)."""
+
+    min: float
+    max: float
+
+    def __post_init__(self) -> None:
+        if self.min < 0 or self.max < 0:
+            raise ValueError(f"depth must be >= 0 m, got ({self.min}, {self.max})")
+        if self.min > self.max:
+            raise ValueError(f"depth min ({self.min}) must be <= max ({self.max})")
+
+    def as_cmems(self) -> dict[str, float]:
+        return {"minimum_depth": self.min, "maximum_depth": self.max}
+
+
+@dataclass(frozen=True)
+class PressureLevels:
+    """Discrete pressure levels in hPa (CDS-style)."""
+
+    levels: tuple[int, ...]
+
+    def __post_init__(self) -> None:
+        if not self.levels:
+            raise ValueError("PressureLevels must contain at least one level")
+        if any(level <= 0 for level in self.levels):
+            raise ValueError(f"pressure levels must be positive hPa: {self.levels}")
+
+    def as_cds_form(self) -> list[str]:
+        return [str(level) for level in self.levels]

--- a/src/xr_toolz/types/_src/request.py
+++ b/src/xr_toolz/types/_src/request.py
@@ -1,0 +1,27 @@
+"""Canonical request payload composed of the typed primitives."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from xr_toolz.types._src.geometry import BBox
+from xr_toolz.types._src.levels import DepthRange, PressureLevels
+from xr_toolz.types._src.time import TimeRange
+
+
+@dataclass(frozen=True)
+class Request:
+    """Canonical request payload consumed by data adapters.
+
+    Not every field applies to every source; adapters pick what they
+    need. Keeping one struct means the catalog and the UI speak the
+    same shape.
+    """
+
+    variables: tuple[str, ...]
+    bbox: BBox | None = None
+    time: TimeRange | None = None
+    depth: DepthRange | None = None
+    levels: PressureLevels | None = None
+    extras: dict[str, Any] | None = None

--- a/src/xr_toolz/types/_src/time.py
+++ b/src/xr_toolz/types/_src/time.py
@@ -1,0 +1,79 @@
+"""Temporal window type."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import cast
+
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class TimeRange:
+    """Inclusive time window, optionally with a target sampling frequency.
+
+    ``freq`` is a pandas offset alias (``"1D"``, ``"6H"`` ...) used only
+    by serializers that need to materialize the range (e.g. the CDS
+    ``year/month/day`` form). Adapters accepting continuous ranges
+    (CMEMS) ignore ``freq``.
+    """
+
+    start: pd.Timestamp
+    end: pd.Timestamp
+    freq: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.start > self.end:
+            raise ValueError(f"start ({self.start}) must be <= end ({self.end})")
+
+    # ---- constructors -----------------------------------------------------
+
+    @classmethod
+    def parse(
+        cls,
+        start: str | datetime | pd.Timestamp,
+        end: str | datetime | pd.Timestamp,
+        freq: str | None = None,
+    ) -> TimeRange:
+        """Parse heterogeneous inputs into a ``TimeRange``.
+
+        Accepts ISO strings, ``datetime``, ``pandas.Timestamp``.
+        Strings without timezone are treated as UTC.
+        """
+        return cls(start=_as_ts(start), end=_as_ts(end), freq=freq)
+
+    # ---- derived ----------------------------------------------------------
+
+    def to_index(self) -> pd.DatetimeIndex:
+        """Materialize the range at :attr:`freq` (default daily)."""
+        return pd.date_range(self.start, self.end, freq=self.freq or "1D")
+
+    # ---- serializers ------------------------------------------------------
+
+    def as_cmems(self) -> dict[str, str]:
+        return {
+            "start_datetime": self.start.isoformat(),
+            "end_datetime": self.end.isoformat(),
+        }
+
+    def as_cds_form(self) -> dict[str, list[str]]:
+        """Explode the range into the ``year/month/day`` form CDS expects."""
+        idx = self.to_index()
+        years = sorted({f"{t.year}" for t in idx})
+        months = sorted({f"{t.month:02d}" for t in idx})
+        days = sorted({f"{t.day:02d}" for t in idx})
+        return {"year": years, "month": months, "day": days}
+
+    def as_xarray_sel(self, time: str = "time") -> dict[str, slice]:
+        """``ds.sel(**tr.as_xarray_sel())`` selector."""
+        return {time: slice(self.start, self.end)}
+
+
+def _as_ts(value: str | datetime | pd.Timestamp) -> pd.Timestamp:
+    """Coerce to a UTC pandas Timestamp."""
+    ts = pd.Timestamp(value)
+    if ts is pd.NaT:
+        raise ValueError(f"could not parse timestamp: {value!r}")
+    ts = ts.tz_localize(UTC) if ts.tzinfo is None else ts.tz_convert(UTC)
+    return cast(pd.Timestamp, ts)

--- a/src/xr_toolz/types/_src/validation.py
+++ b/src/xr_toolz/types/_src/validation.py
@@ -143,8 +143,11 @@ def validate_variable(
     if check_range and var.valid_range is not None:
         lo, hi = var.valid_range
         finite_vals = da.where(np.isfinite(da))
-        mn = float(finite_vals.min().values) if finite_vals.count() > 0 else None
-        mx = float(finite_vals.max().values) if finite_vals.count() > 0 else None
+        # Scalarize the count so the `if` doesn't try to bool-check a
+        # DataArray (unambiguous on 0-d in practice, but brittle).
+        n_finite = int(finite_vals.count().item())
+        mn = float(finite_vals.min().values) if n_finite > 0 else None
+        mx = float(finite_vals.max().values) if n_finite > 0 else None
         if mn is not None and (mn < lo or (mx is not None and mx > hi)):
             report.add(
                 Issue(
@@ -213,7 +216,9 @@ def apply_cf_attrs(
     replace them with the canonical values from the registry.
     """
     var = resolve(variable)
-    out = da.copy()
+    # Shallow copy: we only mutate ``attrs`` below, so there's no reason
+    # to duplicate the underlying array buffer.
+    out = da.copy(deep=False)
     for k, v in var.cf_attrs().items():
         if overwrite or k not in out.attrs:
             out.attrs[k] = v

--- a/src/xr_toolz/types/_src/validation.py
+++ b/src/xr_toolz/types/_src/validation.py
@@ -1,0 +1,220 @@
+"""CF-metadata-aware validators for downloaded / in-memory data.
+
+Validators are cheap checks that verify an :class:`xarray.DataArray` or
+:class:`xarray.Dataset` matches a :class:`Variable` description:
+
+- presence of the variable
+- CF attribute agreement (``standard_name``, ``units``)
+- value range inside :attr:`Variable.valid_range`
+- dtype agreement with :attr:`Variable.dtype`
+
+Failures surface as a :class:`ValidationReport` — a list of
+:class:`Issue` records — rather than exceptions, so callers can decide
+whether to warn, raise, or autofix.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+import numpy as np
+import xarray as xr
+
+from xr_toolz.types._src.variable import Variable, resolve
+
+
+class Severity(StrEnum):
+    """Two-level severity for validation issues."""
+
+    WARNING = "warning"
+    ERROR = "error"
+
+
+@dataclass(frozen=True)
+class Issue:
+    """Single validation finding."""
+
+    variable: str
+    severity: Severity
+    code: str
+    message: str
+
+
+@dataclass
+class ValidationReport:
+    """Aggregate validation result with convenience accessors."""
+
+    issues: list[Issue] = field(default_factory=list)
+
+    def add(self, issue: Issue) -> None:
+        self.issues.append(issue)
+
+    @property
+    def ok(self) -> bool:
+        return not any(i.severity is Severity.ERROR for i in self.issues)
+
+    def errors(self) -> list[Issue]:
+        return [i for i in self.issues if i.severity is Severity.ERROR]
+
+    def warnings(self) -> list[Issue]:
+        return [i for i in self.issues if i.severity is Severity.WARNING]
+
+    def raise_if_errors(self) -> None:
+        """Raise :class:`ValueError` if any error-level issues are present."""
+        errs = self.errors()
+        if errs:
+            lines = [f"[{i.code}] {i.variable}: {i.message}" for i in errs]
+            raise ValueError("Validation failed:\n  " + "\n  ".join(lines))
+
+
+def validate_variable(
+    da: xr.DataArray,
+    variable: str | Variable,
+    *,
+    check_range: bool = True,
+    check_units: bool = True,
+    check_standard_name: bool = True,
+    check_dtype: bool = False,
+) -> ValidationReport:
+    """Validate a single :class:`xarray.DataArray` against a :class:`Variable`.
+
+    Args:
+        da: Array under test.
+        variable: Either a :class:`Variable` or a name looked up in
+            :data:`xr_toolz.types.REGISTRY`.
+        check_range: If ``True`` and the variable defines ``valid_range``,
+            flag finite values falling outside as errors.
+        check_units: Compare ``da.attrs["units"]`` to the canonical
+            units. Missing ``units`` is a warning; mismatch is an error.
+        check_standard_name: Compare ``da.attrs["standard_name"]`` to
+            the canonical standard name. Missing is a warning; mismatch
+            is an error.
+        check_dtype: Require ``da.dtype == variable.dtype`` (opt-in).
+
+    Returns:
+        A :class:`ValidationReport` aggregating all findings.
+    """
+    var = resolve(variable)
+    report = ValidationReport()
+
+    if check_standard_name and var.standard_name is not None:
+        attr = da.attrs.get("standard_name")
+        if attr is None:
+            report.add(
+                Issue(
+                    variable=var.name,
+                    severity=Severity.WARNING,
+                    code="missing_standard_name",
+                    message=f"no standard_name; expected {var.standard_name!r}",
+                )
+            )
+        elif attr != var.standard_name:
+            report.add(
+                Issue(
+                    variable=var.name,
+                    severity=Severity.ERROR,
+                    code="wrong_standard_name",
+                    message=f"standard_name={attr!r}, expected {var.standard_name!r}",
+                )
+            )
+
+    if check_units and var.units is not None:
+        attr = da.attrs.get("units")
+        if attr is None:
+            report.add(
+                Issue(
+                    variable=var.name,
+                    severity=Severity.WARNING,
+                    code="missing_units",
+                    message=f"no units; expected {var.units!r}",
+                )
+            )
+        elif attr != var.units:
+            report.add(
+                Issue(
+                    variable=var.name,
+                    severity=Severity.ERROR,
+                    code="wrong_units",
+                    message=f"units={attr!r}, expected {var.units!r}",
+                )
+            )
+
+    if check_range and var.valid_range is not None:
+        lo, hi = var.valid_range
+        finite_vals = da.where(np.isfinite(da))
+        mn = float(finite_vals.min().values) if finite_vals.count() > 0 else None
+        mx = float(finite_vals.max().values) if finite_vals.count() > 0 else None
+        if mn is not None and (mn < lo or (mx is not None and mx > hi)):
+            report.add(
+                Issue(
+                    variable=var.name,
+                    severity=Severity.ERROR,
+                    code="out_of_range",
+                    message=(
+                        f"values in [{mn:.3g}, {mx:.3g}] fall outside "
+                        f"valid_range [{lo}, {hi}]"
+                    ),
+                )
+            )
+
+    if check_dtype and var.dtype is not None and str(da.dtype) != var.dtype:
+        report.add(
+            Issue(
+                variable=var.name,
+                severity=Severity.ERROR,
+                code="wrong_dtype",
+                message=f"dtype={da.dtype}, expected {var.dtype}",
+            )
+        )
+
+    return report
+
+
+def validate_dataset(
+    ds: xr.Dataset,
+    variables: list[str | Variable],
+    **kwargs: bool,
+) -> ValidationReport:
+    """Validate multiple variables in a dataset.
+
+    Missing variables are reported as errors; present ones are checked
+    via :func:`validate_variable`. Keyword arguments are forwarded.
+    """
+    report = ValidationReport()
+    for spec in variables:
+        var = resolve(spec)
+        if var.name not in ds.data_vars:
+            report.add(
+                Issue(
+                    variable=var.name,
+                    severity=Severity.ERROR,
+                    code="missing_variable",
+                    message=(
+                        f"{var.name!r} not in dataset; have {sorted(ds.data_vars)}"
+                    ),
+                )
+            )
+            continue
+        sub = validate_variable(ds[var.name], var, **kwargs)
+        report.issues.extend(sub.issues)
+    return report
+
+
+def apply_cf_attrs(
+    da: xr.DataArray,
+    variable: str | Variable,
+    *,
+    overwrite: bool = False,
+) -> xr.DataArray:
+    """Stamp CF attributes from ``variable`` onto ``da``.
+
+    By default, existing attrs are kept. Set ``overwrite=True`` to
+    replace them with the canonical values from the registry.
+    """
+    var = resolve(variable)
+    out = da.copy()
+    for k, v in var.cf_attrs().items():
+        if overwrite or k not in out.attrs:
+            out.attrs[k] = v
+    return out

--- a/src/xr_toolz/types/_src/variable.py
+++ b/src/xr_toolz/types/_src/variable.py
@@ -1,0 +1,517 @@
+"""Rich ``Variable`` type with CF metadata and a small built-in registry.
+
+A ``Variable`` carries everything a well-behaved data request needs:
+
+- ``name`` — canonical short name used inside ``xr_toolz`` (e.g. ``"sst"``).
+- ``standard_name`` — CF-1.x standard name (e.g. ``"sea_surface_temperature"``).
+- ``long_name`` — human-readable description.
+- ``units`` — canonical CF units string (e.g. ``"K"``, ``"m s-1"``).
+- ``aliases`` — per-source identifiers, e.g. ``{"cmems": "thetao",
+  "cds": "sea_surface_temperature"}`` so each adapter can translate.
+- ``valid_range`` — optional ``(min, max)`` tuple used by validators.
+- ``dtype`` — optional expected dtype, used by validators.
+
+The registry (``REGISTRY``) holds curated variables. Users are free to
+construct their own ``Variable`` instances; the registry is a
+convenience, not a boundary.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class Variable:
+    """CF-aware variable descriptor used across adapters and validators.
+
+    The class is an immutable dataclass so instances are hashable and
+    safe to share; per-source identifiers live in ``aliases`` and are
+    resolved with :meth:`for_source`.
+    """
+
+    name: str
+    standard_name: str | None = None
+    long_name: str | None = None
+    units: str | None = None
+    # ``hash=False`` so the mutable dict default doesn't leak into the
+    # auto-generated ``__hash__``; equality still compares aliases.
+    aliases: Mapping[str, str] = field(default_factory=dict, hash=False)
+    valid_range: tuple[float, float] | None = None
+    dtype: str | None = None
+
+    def for_source(self, source: str) -> str:
+        """Return the identifier this variable uses in ``source``.
+
+        Falls back to :attr:`name` if no alias is registered.
+        """
+        return self.aliases.get(source, self.name)
+
+    def cf_attrs(self) -> dict[str, str]:
+        """Return the CF-1.x metadata dict suitable for ``da.attrs``."""
+        attrs: dict[str, str] = {}
+        if self.standard_name is not None:
+            attrs["standard_name"] = self.standard_name
+        if self.long_name is not None:
+            attrs["long_name"] = self.long_name
+        if self.units is not None:
+            attrs["units"] = self.units
+        return attrs
+
+
+# ---- Curated registry ----------------------------------------------------
+
+
+SST = Variable(
+    name="sst",
+    standard_name="sea_surface_temperature",
+    long_name="Sea surface temperature",
+    units="K",
+    aliases={"cmems": "thetao", "cds": "sea_surface_temperature"},
+    valid_range=(270.0, 320.0),
+)
+
+SSH = Variable(
+    name="ssh",
+    standard_name="sea_surface_height_above_geoid",
+    long_name="Sea surface height above geoid",
+    units="m",
+    aliases={"cmems": "zos"},
+    valid_range=(-5.0, 5.0),
+)
+
+SLA = Variable(
+    name="sla",
+    standard_name="sea_surface_height_above_sea_level",
+    long_name="Sea level anomaly",
+    units="m",
+    aliases={"cmems": "sla"},
+    valid_range=(-2.0, 2.0),
+)
+
+MDT = Variable(
+    name="mdt",
+    standard_name="sea_surface_height_above_geoid",
+    long_name="Mean dynamic topography",
+    units="m",
+    aliases={"cmems": "mdt"},
+)
+
+UO = Variable(
+    name="uo",
+    standard_name="eastward_sea_water_velocity",
+    long_name="Eastward sea water velocity",
+    units="m s-1",
+    aliases={"cmems": "uo"},
+    valid_range=(-5.0, 5.0),
+)
+
+VO = Variable(
+    name="vo",
+    standard_name="northward_sea_water_velocity",
+    long_name="Northward sea water velocity",
+    units="m s-1",
+    aliases={"cmems": "vo"},
+    valid_range=(-5.0, 5.0),
+)
+
+SO = Variable(
+    name="so",
+    standard_name="sea_water_salinity",
+    long_name="Sea water salinity",
+    units="1e-3",
+    aliases={"cmems": "so"},
+    valid_range=(0.0, 45.0),
+)
+
+T2M = Variable(
+    name="t2m",
+    standard_name="air_temperature",
+    long_name="2 metre temperature",
+    units="K",
+    aliases={"cds": "2m_temperature"},
+    valid_range=(150.0, 350.0),
+)
+
+D2M = Variable(
+    name="d2m",
+    standard_name="dew_point_temperature",
+    long_name="2 metre dewpoint temperature",
+    units="K",
+    aliases={"cds": "2m_dewpoint_temperature"},
+    valid_range=(150.0, 350.0),
+)
+
+U10 = Variable(
+    name="u10",
+    standard_name="eastward_wind",
+    long_name="10 metre U wind component",
+    units="m s-1",
+    aliases={"cds": "10m_u_component_of_wind"},
+    valid_range=(-100.0, 100.0),
+)
+
+V10 = Variable(
+    name="v10",
+    standard_name="northward_wind",
+    long_name="10 metre V wind component",
+    units="m s-1",
+    aliases={"cds": "10m_v_component_of_wind"},
+    valid_range=(-100.0, 100.0),
+)
+
+MSL = Variable(
+    name="msl",
+    standard_name="air_pressure_at_mean_sea_level",
+    long_name="Mean sea level pressure",
+    units="Pa",
+    aliases={"cds": "mean_sea_level_pressure"},
+    valid_range=(87000.0, 108500.0),
+)
+
+TP = Variable(
+    name="tp",
+    standard_name="lwe_thickness_of_precipitation_amount",
+    long_name="Total precipitation",
+    units="m",
+    aliases={"cds": "total_precipitation"},
+    valid_range=(0.0, 1.0),
+)
+
+SP = Variable(
+    name="sp",
+    standard_name="surface_air_pressure",
+    long_name="Surface pressure",
+    units="Pa",
+    aliases={"cds": "surface_pressure"},
+    valid_range=(50000.0, 110000.0),
+)
+
+SSRD = Variable(
+    name="ssrd",
+    standard_name="surface_downwelling_shortwave_flux_in_air",
+    long_name="Surface solar radiation downwards",
+    units="J m-2",
+    aliases={"cds": "surface_solar_radiation_downwards"},
+)
+
+# ---- Ocean — altimetry-derived (DUACS) ----------------------------------
+
+ADT = Variable(
+    name="adt",
+    standard_name="sea_surface_height_above_geoid",
+    long_name="Absolute dynamic topography",
+    units="m",
+    aliases={"cmems": "adt"},
+    valid_range=(-3.0, 3.0),
+)
+
+UGOS = Variable(
+    name="ugos",
+    standard_name="surface_geostrophic_eastward_sea_water_velocity",
+    long_name="Surface geostrophic eastward velocity",
+    units="m s-1",
+    aliases={"cmems": "ugos"},
+    valid_range=(-5.0, 5.0),
+)
+
+VGOS = Variable(
+    name="vgos",
+    standard_name="surface_geostrophic_northward_sea_water_velocity",
+    long_name="Surface geostrophic northward velocity",
+    units="m s-1",
+    aliases={"cmems": "vgos"},
+    valid_range=(-5.0, 5.0),
+)
+
+# ---- Ocean — salinity companion -----------------------------------------
+
+SOS = Variable(
+    name="sos",
+    standard_name="sea_surface_salinity",
+    long_name="Sea surface salinity",
+    units="1e-3",
+    aliases={"cmems": "sos"},
+    valid_range=(0.0, 45.0),
+)
+
+DENS = Variable(
+    name="dens",
+    standard_name="sea_water_density",
+    long_name="Sea surface density",
+    units="kg m-3",
+    aliases={"cmems": "dos"},
+    valid_range=(1000.0, 1050.0),
+)
+
+# ---- Ocean — sea-ice ----------------------------------------------------
+
+ICE_CONC = Variable(
+    name="ice_conc",
+    standard_name="sea_ice_area_fraction",
+    long_name="Sea ice area fraction",
+    units="1",
+    aliases={"cmems": "sea_ice_fraction"},
+    valid_range=(0.0, 1.0),
+)
+
+# ---- Ocean colour -------------------------------------------------------
+
+CHL = Variable(
+    name="chl",
+    standard_name="mass_concentration_of_chlorophyll_a_in_sea_water",
+    long_name="Chlorophyll-a concentration",
+    units="mg m-3",
+    aliases={"cmems": "CHL"},
+    valid_range=(0.0, 100.0),
+)
+
+KD490 = Variable(
+    name="kd490",
+    standard_name="volume_attenuation_coefficient_of_downwelling_radiative_flux_in_sea_water",
+    long_name="Diffuse attenuation coefficient at 490 nm",
+    units="m-1",
+    aliases={"cmems": "KD490"},
+    valid_range=(0.0, 10.0),
+)
+
+ZSD = Variable(
+    name="zsd",
+    standard_name="secchi_depth_of_sea_water",
+    long_name="Secchi disk depth",
+    units="m",
+    aliases={"cmems": "ZSD"},
+    valid_range=(0.0, 100.0),
+)
+
+SPM = Variable(
+    name="spm",
+    standard_name="mass_concentration_of_suspended_matter_in_sea_water",
+    long_name="Total suspended matter",
+    units="g m-3",
+    aliases={"cmems": "SPM"},
+    valid_range=(0.0, 1000.0),
+)
+
+BBP443 = Variable(
+    name="bbp443",
+    standard_name="volume_backwards_scattering_coefficient_of_radiative_flux_in_sea_water",
+    long_name="Particulate backscattering at 443 nm",
+    units="m-1",
+    aliases={"cmems": "BBP443"},
+    valid_range=(0.0, 1.0),
+)
+
+PP = Variable(
+    name="pp",
+    standard_name="net_primary_production_of_biomass_expressed_as_carbon_per_unit_area_in_sea_water",
+    long_name="Primary production",
+    units="mg m-2 day-1",
+    aliases={"cmems": "PP"},
+    valid_range=(0.0, 10000.0),
+)
+
+# Remote-sensing reflectance — one Variable per wavelength so CF metadata
+# and ``valid_range`` stay per-band (Rrs spectra differ across sensors).
+
+RRS412 = Variable(
+    name="rrs412",
+    standard_name="surface_ratio_of_upwelling_radiance_emerging_from_sea_water_to_downwelling_radiative_flux_in_air",
+    long_name="Remote sensing reflectance at 412 nm",
+    units="sr-1",
+    aliases={"cmems": "RRS412"},
+    valid_range=(0.0, 0.1),
+)
+
+RRS443 = Variable(
+    name="rrs443",
+    standard_name="surface_ratio_of_upwelling_radiance_emerging_from_sea_water_to_downwelling_radiative_flux_in_air",
+    long_name="Remote sensing reflectance at 443 nm",
+    units="sr-1",
+    aliases={"cmems": "RRS443"},
+    valid_range=(0.0, 0.1),
+)
+
+RRS490 = Variable(
+    name="rrs490",
+    standard_name="surface_ratio_of_upwelling_radiance_emerging_from_sea_water_to_downwelling_radiative_flux_in_air",
+    long_name="Remote sensing reflectance at 490 nm",
+    units="sr-1",
+    aliases={"cmems": "RRS490"},
+    valid_range=(0.0, 0.1),
+)
+
+RRS510 = Variable(
+    name="rrs510",
+    standard_name="surface_ratio_of_upwelling_radiance_emerging_from_sea_water_to_downwelling_radiative_flux_in_air",
+    long_name="Remote sensing reflectance at 510 nm",
+    units="sr-1",
+    aliases={"cmems": "RRS510"},
+    valid_range=(0.0, 0.1),
+)
+
+RRS555 = Variable(
+    name="rrs555",
+    standard_name="surface_ratio_of_upwelling_radiance_emerging_from_sea_water_to_downwelling_radiative_flux_in_air",
+    long_name="Remote sensing reflectance at 555 nm",
+    units="sr-1",
+    aliases={"cmems": "RRS555"},
+    valid_range=(0.0, 0.1),
+)
+
+RRS670 = Variable(
+    name="rrs670",
+    standard_name="surface_ratio_of_upwelling_radiance_emerging_from_sea_water_to_downwelling_radiative_flux_in_air",
+    long_name="Remote sensing reflectance at 670 nm",
+    units="sr-1",
+    aliases={"cmems": "RRS670"},
+    valid_range=(0.0, 0.1),
+)
+
+# ---- Ocean biogeochemistry ----------------------------------------------
+
+NO3 = Variable(
+    name="no3",
+    standard_name="mole_concentration_of_nitrate_in_sea_water",
+    long_name="Nitrate concentration",
+    units="mmol m-3",
+    aliases={"cmems": "no3"},
+    valid_range=(0.0, 100.0),
+)
+
+PO4 = Variable(
+    name="po4",
+    standard_name="mole_concentration_of_phosphate_in_sea_water",
+    long_name="Phosphate concentration",
+    units="mmol m-3",
+    aliases={"cmems": "po4"},
+    valid_range=(0.0, 10.0),
+)
+
+SI = Variable(
+    name="si",
+    standard_name="mole_concentration_of_silicate_in_sea_water",
+    long_name="Silicate concentration",
+    units="mmol m-3",
+    aliases={"cmems": "si"},
+    valid_range=(0.0, 200.0),
+)
+
+O2 = Variable(
+    name="o2",
+    standard_name="mole_concentration_of_dissolved_molecular_oxygen_in_sea_water",
+    long_name="Dissolved oxygen",
+    units="mmol m-3",
+    aliases={"cmems": "o2"},
+    valid_range=(0.0, 500.0),
+)
+
+PHYC = Variable(
+    name="phyc",
+    standard_name="mole_concentration_of_phytoplankton_expressed_as_carbon_in_sea_water",
+    long_name="Phytoplankton carbon concentration",
+    units="mmol m-3",
+    aliases={"cmems": "phyc"},
+    valid_range=(0.0, 50.0),
+)
+
+ZOOC = Variable(
+    name="zooc",
+    standard_name="mole_concentration_of_zooplankton_expressed_as_carbon_in_sea_water",
+    long_name="Zooplankton carbon concentration",
+    units="mmol m-3",
+    aliases={"cmems": "zooc"},
+    valid_range=(0.0, 50.0),
+)
+
+PH = Variable(
+    name="ph",
+    standard_name="sea_water_ph_reported_on_total_scale",
+    long_name="Sea water pH",
+    units="1",
+    aliases={"cmems": "ph"},
+    valid_range=(7.0, 9.0),
+)
+
+SPCO2 = Variable(
+    name="spco2",
+    standard_name="surface_partial_pressure_of_carbon_dioxide_in_sea_water",
+    long_name="Surface partial pressure of CO2",
+    units="Pa",
+    aliases={"cmems": "spco2"},
+    valid_range=(0.0, 100.0),
+)
+
+
+REGISTRY: dict[str, Variable] = {
+    v.name: v
+    for v in (
+        SST,
+        SSH,
+        SLA,
+        MDT,
+        ADT,
+        UO,
+        VO,
+        UGOS,
+        VGOS,
+        SO,
+        SOS,
+        DENS,
+        ICE_CONC,
+        T2M,
+        D2M,
+        U10,
+        V10,
+        MSL,
+        TP,
+        SP,
+        SSRD,
+        # Ocean colour
+        CHL,
+        KD490,
+        ZSD,
+        SPM,
+        BBP443,
+        PP,
+        RRS412,
+        RRS443,
+        RRS490,
+        RRS510,
+        RRS555,
+        RRS670,
+        # Biogeochemistry
+        NO3,
+        PO4,
+        SI,
+        O2,
+        PHYC,
+        ZOOC,
+        PH,
+        SPCO2,
+    )
+}
+
+
+def resolve(v: str | Variable) -> Variable:
+    """Return a :class:`Variable` given an instance or its canonical name.
+
+    Raises:
+        KeyError: if ``v`` is a string not present in :data:`REGISTRY`.
+    """
+    if isinstance(v, Variable):
+        return v
+    try:
+        return REGISTRY[v]
+    except KeyError as exc:
+        raise KeyError(
+            f"Unknown variable {v!r}. Known: {sorted(REGISTRY)}. "
+            "Pass a Variable instance to use a variable outside the registry."
+        ) from exc
+
+
+def register(variable: Variable) -> Variable:
+    """Add ``variable`` to :data:`REGISTRY` (keyed on :attr:`Variable.name`)."""
+    REGISTRY[variable.name] = variable
+    return variable

--- a/src/xr_toolz/types/_src/variable.py
+++ b/src/xr_toolz/types/_src/variable.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass, field
+from types import MappingProxyType
 
 
 @dataclass(frozen=True)
@@ -40,6 +41,14 @@ class Variable:
     aliases: Mapping[str, str] = field(default_factory=dict, hash=False)
     valid_range: tuple[float, float] | None = None
     dtype: str | None = None
+
+    def __post_init__(self) -> None:
+        # Wrap any Mapping input in a read-only view so callers can't
+        # mutate ``var.aliases`` after construction (would otherwise
+        # silently change equality/hashing semantics).
+        if not isinstance(self.aliases, MappingProxyType):
+            frozen = MappingProxyType(dict(self.aliases))
+            object.__setattr__(self, "aliases", frozen)
 
     def for_source(self, source: str) -> str:
         """Return the identifier this variable uses in ``source``.

--- a/tests/data/test_adapters.py
+++ b/tests/data/test_adapters.py
@@ -1,0 +1,174 @@
+"""CMEMS + CDS adapters tested against in-memory client stand-ins."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from xr_toolz.data import (
+    CDSCredentials,
+    CDSSource,
+    CMEMSCredentials,
+    CMEMSSource,
+)
+from xr_toolz.types import BBox, PressureLevels, TimeRange
+
+
+class FakeCmemsClient:
+    """Test double for the ``copernicusmarine`` module."""
+
+    def __init__(self) -> None:
+        self.last_kwargs: dict[str, Any] | None = None
+
+    def subset(self, **kwargs: Any) -> None:
+        self.last_kwargs = kwargs
+        output = Path(kwargs["output_directory"]) / kwargs["output_filename"]
+        output.write_text("stub")
+
+    def open_dataset(self, **kwargs: Any) -> dict[str, Any]:
+        self.last_kwargs = kwargs
+        return {"opened": True, **kwargs}
+
+
+class FakeCdsClient:
+    """Test double for a ``cdsapi.Client`` instance."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any], str]] = []
+
+    def retrieve(self, dataset_id: str, form: dict[str, Any], target: str) -> None:
+        self.calls.append((dataset_id, form, target))
+        Path(target).write_text("stub")
+
+
+# ---- CMEMS ---------------------------------------------------------------
+
+
+@pytest.fixture
+def cmems_source() -> tuple[CMEMSSource, FakeCmemsClient]:
+    fake = FakeCmemsClient()
+    src = CMEMSSource(
+        credentials=CMEMSCredentials(username="u", password="p"),
+        client=fake,
+    )
+    return src, fake
+
+
+def test_cmems_list_and_describe(cmems_source):
+    src, _ = cmems_source
+    items = src.list_datasets()
+    assert items, "expected at least one curated CMEMS dataset"
+    info = src.describe(items[0].dataset_id)
+    assert info.source == "cmems"
+
+
+def test_cmems_describe_unknown_id_builds_minimal_info(cmems_source):
+    src, _ = cmems_source
+    info = src.describe("totally_made_up_product")
+    assert info.dataset_id == "totally_made_up_product"
+    assert info.source == "cmems"
+
+
+def test_cmems_download_builds_correct_payload(cmems_source, tmp_path):
+    src, fake = cmems_source
+    out = src.download(
+        "cmems_mod_glo_phy_my_0.083deg_P1D-m",
+        tmp_path / "slice.nc",
+        variables=["sst", "ssh"],
+        bbox=BBox(-10.0, 40.0, 30.0, 60.0),
+        time=TimeRange.parse("2020-01-01", "2020-01-31"),
+    )
+    assert out.exists()
+    kw = fake.last_kwargs
+    assert kw is not None
+    assert kw["dataset_id"] == "cmems_mod_glo_phy_my_0.083deg_P1D-m"
+    # Variables must be translated to CMEMS aliases.
+    assert kw["variables"] == ["thetao", "zos"]
+    # BBox + time serialized into CMEMS keys.
+    assert kw["minimum_longitude"] == -10.0
+    assert kw["maximum_latitude"] == 60.0
+    assert kw["start_datetime"].startswith("2020-01-01")
+    # Credentials threaded through.
+    assert kw["username"] == "u"
+    assert kw["password"] == "p"
+
+
+def test_cmems_open_returns_client_payload(cmems_source):
+    src, _ = cmems_source
+    ds = src.open("foo", variables=["sst"])
+    assert ds["opened"] is True
+    assert ds["variables"] == ["thetao"]
+
+
+# ---- CDS -----------------------------------------------------------------
+
+
+@pytest.fixture
+def cds_source() -> tuple[CDSSource, FakeCdsClient]:
+    fake = FakeCdsClient()
+    src = CDSSource(
+        credentials=CDSCredentials(url="https://example", key="abc"),
+        client=fake,
+    )
+    return src, fake
+
+
+def test_cds_list_and_describe(cds_source):
+    src, _ = cds_source
+    items = src.list_datasets()
+    assert any(i.dataset_id == "reanalysis-era5-single-levels" for i in items)
+
+
+def test_cds_download_form_shape(cds_source, tmp_path):
+    src, fake = cds_source
+    out = src.download(
+        "reanalysis-era5-single-levels",
+        tmp_path / "era5.nc",
+        variables=["t2m", "u10"],
+        bbox=BBox(-10.0, 40.0, 30.0, 60.0),
+        time=TimeRange.parse("2020-01-29", "2020-02-02"),
+    )
+    assert out.exists()
+    (dataset_id, form, target) = fake.calls[0]
+    assert dataset_id == "reanalysis-era5-single-levels"
+    assert target == str(out)
+    # Variables should be translated.
+    assert form["variable"] == ["2m_temperature", "10m_u_component_of_wind"]
+    # BBox in CDS [N,W,S,E] order.
+    assert form["area"] == [60.0, -10.0, 30.0, 40.0]
+    # Time exploded to year/month/day lists.
+    assert form["year"] == ["2020"]
+    assert set(form["month"]) == {"01", "02"}
+    # Defaults applied.
+    assert form["format"] == "netcdf"
+    assert form["product_type"] == "reanalysis"
+
+
+def test_cds_pressure_levels_round_trip(cds_source, tmp_path):
+    src, fake = cds_source
+    src.download(
+        "reanalysis-era5-pressure-levels",
+        tmp_path / "plev.nc",
+        variables=["t2m"],
+        time=TimeRange.parse("2020-01-01", "2020-01-01"),
+        levels=PressureLevels((500, 850, 1000)),
+    )
+    _, form, _ = fake.calls[0]
+    assert form["pressure_level"] == ["500", "850", "1000"]
+
+
+def test_cds_extras_passthrough(cds_source, tmp_path):
+    src, fake = cds_source
+    src.download(
+        "reanalysis-era5-single-levels",
+        tmp_path / "x.nc",
+        variables=["t2m"],
+        time=TimeRange.parse("2020-01-01", "2020-01-01"),
+        grid=[0.25, 0.25],
+        product_type="ensemble_mean",
+    )
+    _, form, _ = fake.calls[0]
+    assert form["grid"] == [0.25, 0.25]
+    assert form["product_type"] == "ensemble_mean"

--- a/tests/data/test_cache_serialization.py
+++ b/tests/data/test_cache_serialization.py
@@ -1,0 +1,92 @@
+"""Cache key serialization — covers the _json_default fallback branches."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from xr_toolz.data._src.cache import _json_default, cache_path
+
+
+@dataclass
+class _Sample:
+    x: int
+    y: str
+
+
+def test_json_default_dataclass_is_serialized_as_dict():
+    out = _json_default(_Sample(x=1, y="a"))
+    assert out == {"x": 1, "y": "a"}
+
+
+def test_json_default_path_is_stringified():
+    assert _json_default(Path("/tmp/foo")) == "/tmp/foo"
+
+
+def test_json_default_set_is_listified():
+    out = _json_default({3, 1, 2})
+    assert sorted(out) == [1, 2, 3]
+
+
+def test_json_default_tuple_is_listified():
+    assert _json_default((1, 2, 3)) == [1, 2, 3]
+
+
+def test_json_default_timestamp_uses_isoformat():
+    import pandas as pd
+
+    ts = pd.Timestamp("2020-01-01", tz="UTC")
+    assert _json_default(ts).startswith("2020-01-01")
+
+
+def test_json_default_unknown_falls_back_to_str():
+    class Foo:
+        def __str__(self) -> str:
+            return "<foo>"
+
+    assert _json_default(Foo()) == "<foo>"
+
+
+def test_cache_path_respects_suffix(monkeypatch, tmp_path):
+    monkeypatch.setenv("XR_TOOLZ_CACHE", str(tmp_path))
+    p = cache_path("cmems", "foo", {"a": 1}, suffix=".zarr")
+    assert p.suffix == ".zarr"
+
+
+def test_cache_path_survives_exotic_request_payloads(monkeypatch, tmp_path):
+    monkeypatch.setenv("XR_TOOLZ_CACHE", str(tmp_path))
+    # Dataclass + Path + set + tuple all in one request — must hash deterministically.
+    req = {
+        "ds": _Sample(x=1, y="a"),
+        "p": Path("/tmp/x"),
+        "s": {1, 2, 3},
+        "t": (4, 5),
+    }
+    p1 = cache_path("cmems", "foo", req)
+    p2 = cache_path("cmems", "foo", req)
+    assert p1 == p2
+
+
+def test_cache_path_rejects_unserializable_would_raise(monkeypatch, tmp_path):
+    # Bytes are serializable via str() fallback; confirm no crash.
+    monkeypatch.setenv("XR_TOOLZ_CACHE", str(tmp_path))
+    assert cache_path("cmems", "foo", {"b": b"raw"}) is not None
+
+
+@pytest.mark.parametrize(
+    "source,dataset_id",
+    [
+        ("cmems", "cmems_mod_glo_phy_my_0.083deg_P1D-m"),
+        ("cds", "reanalysis-era5-single-levels"),
+        ("cmems", "METOFFICE-GLO-SST-L4-REP-OBS-SST"),
+    ],
+)
+def test_cache_path_creates_nested_directories(
+    monkeypatch, tmp_path, source, dataset_id
+):
+    monkeypatch.setenv("XR_TOOLZ_CACHE", str(tmp_path))
+    p = cache_path(source, dataset_id, {"a": 1})
+    assert p.parent.exists()
+    assert p.parent.parent.name == source

--- a/tests/data/test_catalog.py
+++ b/tests/data/test_catalog.py
@@ -1,0 +1,29 @@
+"""Unified catalog lookup."""
+
+from __future__ import annotations
+
+import pytest
+
+from xr_toolz.data import CATALOG, all_entries, describe
+
+
+def test_catalog_contains_expected_short_names():
+    assert "era5.single_levels" in CATALOG
+    assert "glorys12.daily" in CATALOG
+
+
+def test_describe_returns_dataset_info_for_known_name():
+    info = describe("era5.single_levels")
+    assert info.source == "cds"
+    assert info.dataset_id == "reanalysis-era5-single-levels"
+
+
+def test_describe_rejects_unknown_name():
+    with pytest.raises(KeyError):
+        describe("not_a_real_shortname")
+
+
+def test_all_entries_returns_copy():
+    snap = all_entries()
+    snap["junk"] = snap["era5.single_levels"]  # must not affect module-level dict
+    assert "junk" not in CATALOG

--- a/tests/data/test_credentials_cache.py
+++ b/tests/data/test_credentials_cache.py
@@ -1,0 +1,70 @@
+"""Credentials loader + cache key determinism."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from xr_toolz.data._src.cache import cache_path
+from xr_toolz.data._src.credentials import load_cds, load_cmems
+
+
+def test_load_cmems_prefers_explicit_args(monkeypatch):
+    monkeypatch.delenv("COPERNICUSMARINE_SERVICE_USERNAME", raising=False)
+    monkeypatch.delenv("COPERNICUSMARINE_SERVICE_PASSWORD", raising=False)
+    c = load_cmems(username="u", password="p", path=Path("/nonexistent"))
+    assert c is not None and c.username == "u" and c.password == "p"
+
+
+def test_load_cmems_falls_back_to_env(monkeypatch):
+    monkeypatch.setenv("COPERNICUSMARINE_SERVICE_USERNAME", "eu")
+    monkeypatch.setenv("COPERNICUSMARINE_SERVICE_PASSWORD", "ep")
+    c = load_cmems(path=Path("/nonexistent"))
+    assert c is not None and c.username == "eu"
+
+
+def test_load_cmems_falls_back_to_file(tmp_path, monkeypatch):
+    monkeypatch.delenv("COPERNICUSMARINE_SERVICE_USERNAME", raising=False)
+    monkeypatch.delenv("COPERNICUSMARINE_SERVICE_PASSWORD", raising=False)
+    cfg = tmp_path / "cmems"
+    cfg.write_text("username: fileu\npassword: filep\n")
+    c = load_cmems(path=cfg)
+    assert c is not None and c.username == "fileu" and c.password == "filep"
+
+
+def test_load_cmems_returns_none_when_nothing_found(monkeypatch, tmp_path):
+    monkeypatch.delenv("COPERNICUSMARINE_SERVICE_USERNAME", raising=False)
+    monkeypatch.delenv("COPERNICUSMARINE_SERVICE_PASSWORD", raising=False)
+    assert load_cmems(path=tmp_path / "no_such") is None
+
+
+def test_load_cds_dotrc(tmp_path, monkeypatch):
+    monkeypatch.delenv("CDSAPI_URL", raising=False)
+    monkeypatch.delenv("CDSAPI_KEY", raising=False)
+    cfg = tmp_path / "cdsapirc"
+    cfg.write_text("url: https://cds.test\nkey: abc:def\n")
+    c = load_cds(path=cfg)
+    assert c is not None
+    assert c.url == "https://cds.test"
+    assert c.key == "abc:def"
+
+
+def test_cache_path_is_deterministic(monkeypatch, tmp_path):
+    monkeypatch.setenv("XR_TOOLZ_CACHE", str(tmp_path))
+    req = {"variables": ["t2m"], "bbox": [0, 1, 2, 3]}
+    p1 = cache_path("cds", "era5", req)
+    p2 = cache_path("cds", "era5", req)
+    assert p1 == p2
+    assert p1.parent.parent == tmp_path / "cds"
+
+
+def test_cache_path_changes_when_request_changes(monkeypatch, tmp_path):
+    monkeypatch.setenv("XR_TOOLZ_CACHE", str(tmp_path))
+    p1 = cache_path("cds", "era5", {"variables": ["t2m"]})
+    p2 = cache_path("cds", "era5", {"variables": ["u10"]})
+    assert p1 != p2
+
+
+def test_cache_path_sanitizes_dataset_id(monkeypatch, tmp_path):
+    monkeypatch.setenv("XR_TOOLZ_CACHE", str(tmp_path))
+    p = cache_path("cmems", "cmems/mod:phy?id", {})
+    assert "/" not in p.parent.name and ":" not in p.parent.name

--- a/tests/data/test_end_to_end.py
+++ b/tests/data/test_end_to_end.py
@@ -1,0 +1,169 @@
+"""End-to-end flows: short-name -> adapter -> fake client, and CDS caching."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import xarray as xr
+
+from xr_toolz.data import (
+    CATALOG,
+    CDSCredentials,
+    CDSSource,
+    CMEMSCredentials,
+    CMEMSSource,
+    DataSource,
+    describe,
+)
+from xr_toolz.types import BBox, TimeRange
+
+
+# ---- Fakes shared across the end-to-end suite ---------------------------
+
+
+class FakeCmemsClient:
+    def __init__(self) -> None:
+        self.last_kwargs: dict[str, Any] | None = None
+
+    def subset(self, **kwargs: Any) -> None:
+        self.last_kwargs = kwargs
+        (Path(kwargs["output_directory"]) / kwargs["output_filename"]).write_text(
+            "stub"
+        )
+
+    def open_dataset(self, **kwargs: Any) -> xr.Dataset:
+        self.last_kwargs = kwargs
+        return xr.Dataset({"marker": ([], 1)})
+
+
+class FakeCdsClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any], str]] = []
+
+    def retrieve(self, dataset_id: str, form: dict[str, Any], target: str) -> None:
+        self.calls.append((dataset_id, form, target))
+        # Write a minimal NetCDF file so xarray.open_dataset works downstream.
+        xr.Dataset({"marker": ([], 1)}).to_netcdf(target)
+
+
+def _source_for(entry_source: str) -> DataSource:
+    if entry_source == "cmems":
+        return CMEMSSource(
+            credentials=CMEMSCredentials(username="u", password="p"),
+            client=FakeCmemsClient(),
+        )
+    if entry_source == "cds":
+        return CDSSource(
+            credentials=CDSCredentials(url="https://x", key="k"),
+            client=FakeCdsClient(),
+        )
+    raise AssertionError(f"unknown source {entry_source!r}")
+
+
+# ---- Short-name -> adapter dispatch -------------------------------------
+
+
+@pytest.mark.parametrize(
+    "short_name",
+    [
+        "glorys12.daily",
+        "duacs.sla",
+        "ostia.sst",
+        "odyssea.sst",
+        "multiobs.sss.daily",
+        "globcolour.chl.monthly",
+        "era5.single_levels",
+    ],
+)
+def test_short_name_resolves_and_describe_agrees(short_name):
+    entry = CATALOG[short_name]
+    info = describe(short_name)
+    assert info.dataset_id == entry.dataset_id
+    assert info.source == entry.source
+
+
+def test_download_via_short_name_for_cmems(tmp_path):
+    entry = CATALOG["glorys12.daily"]
+    src = _source_for(entry.source)
+    assert isinstance(src, CMEMSSource)
+    out = src.download(
+        entry.dataset_id,
+        tmp_path / "x.nc",
+        variables=["sst", "ssh"],
+        bbox=BBox(-10.0, 40.0, 30.0, 60.0),
+        time=TimeRange.parse("2020-01-01", "2020-01-10"),
+    )
+    assert out.exists()
+    # Variables were resolved via the registry and translated to CMEMS aliases.
+    kw = src._client.last_kwargs  # type: ignore[union-attr]
+    assert kw is not None
+    assert kw["variables"] == ["thetao", "zos"]
+
+
+def test_download_via_short_name_for_cds(tmp_path):
+    entry = CATALOG["era5.single_levels"]
+    src = _source_for(entry.source)
+    assert isinstance(src, CDSSource)
+    out = src.download(
+        entry.dataset_id,
+        tmp_path / "era5.nc",
+        variables=["t2m"],
+        bbox=BBox(-10.0, 40.0, 30.0, 60.0),
+        time=TimeRange.parse("2020-01-01", "2020-01-02"),
+    )
+    assert out.exists()
+
+
+# ---- CDS .open() caches results ----------------------------------------
+
+
+def test_cds_open_populates_cache_on_miss(monkeypatch, tmp_path):
+    monkeypatch.setenv("XR_TOOLZ_CACHE", str(tmp_path))
+    fake = FakeCdsClient()
+    src = CDSSource(
+        credentials=CDSCredentials(url="https://x", key="k"),
+        client=fake,
+    )
+    ds = src.open(
+        "reanalysis-era5-single-levels",
+        variables=["t2m"],
+        bbox=BBox(-10.0, 40.0, 30.0, 60.0),
+        time=TimeRange.parse("2020-01-01", "2020-01-01"),
+    )
+    assert "marker" in ds.data_vars
+    # One retrieve call populated the cache.
+    assert len(fake.calls) == 1
+
+
+def test_cds_open_reuses_cache_on_second_call(monkeypatch, tmp_path):
+    monkeypatch.setenv("XR_TOOLZ_CACHE", str(tmp_path))
+    fake = FakeCdsClient()
+    src = CDSSource(
+        credentials=CDSCredentials(url="https://x", key="k"),
+        client=fake,
+    )
+    kwargs = {
+        "variables": ["t2m"],
+        "bbox": BBox(-10.0, 40.0, 30.0, 60.0),
+        "time": TimeRange.parse("2020-01-01", "2020-01-01"),
+    }
+    ds1 = src.open("reanalysis-era5-single-levels", **kwargs)
+    ds2 = src.open("reanalysis-era5-single-levels", **kwargs)
+    assert "marker" in ds1.data_vars
+    assert "marker" in ds2.data_vars
+    # Second call must be served from disk — retrieve fires exactly once.
+    assert len(fake.calls) == 1
+
+
+def test_cmems_open_passes_credentials_when_absent(tmp_path):
+    # No explicit credentials, no env vars, no ~/.cmems file in a sandboxed HOME.
+    fake = FakeCmemsClient()
+    src = CMEMSSource(credentials=None, client=fake)
+    src.open("cmems_mod_glo_phy_my_0.083deg_P1D-m", variables=["sst"])
+    kw = fake.last_kwargs
+    assert kw is not None
+    # _auth_kwargs returns {} when credentials is None → no username/password keys.
+    assert "username" not in kw
+    assert "password" not in kw

--- a/tests/data/test_presets.py
+++ b/tests/data/test_presets.py
@@ -1,0 +1,108 @@
+"""Coverage for the CMEMS preset catalog split."""
+
+from __future__ import annotations
+
+import pytest
+
+from xr_toolz.data import CATALOG, DatasetKind, describe
+from xr_toolz.data._src.cmems.catalog import CMEMS_DATASETS
+from xr_toolz.data._src.cmems.presets.bgc import BGC_DATASETS
+from xr_toolz.data._src.cmems.presets.insitu import INSITU_DATASETS
+from xr_toolz.data._src.cmems.presets.oc import OC_DATASETS
+from xr_toolz.data._src.cmems.presets.phy import PHY_DATASETS
+from xr_toolz.data._src.cmems.presets.ssh import SSH_DATASETS
+from xr_toolz.data._src.cmems.presets.sss import SSS_DATASETS
+from xr_toolz.data._src.cmems.presets.sst import SST_DATASETS
+
+
+# ---- Preset shapes --------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("preset", "name"),
+    [
+        (PHY_DATASETS, "phy"),
+        (SSH_DATASETS, "ssh"),
+        (SST_DATASETS, "sst"),
+        (SSS_DATASETS, "sss"),
+        (OC_DATASETS, "oc"),
+        (INSITU_DATASETS, "insitu"),
+        (BGC_DATASETS, "bgc"),
+    ],
+)
+def test_each_preset_file_is_non_empty_and_well_typed(preset, name):
+    assert preset, f"{name} preset is empty"
+    for key, info in preset.items():
+        # Key == dataset_id (keeps lookups O(1)).
+        assert info.dataset_id == key
+        assert info.source == "cmems"
+        assert info.variables, f"{key} has no variables"
+        assert isinstance(info.kind, DatasetKind)
+
+
+def test_catalog_unions_all_presets_without_collisions():
+    merged_size = (
+        len(PHY_DATASETS)
+        + len(SSH_DATASETS)
+        + len(SST_DATASETS)
+        + len(SSS_DATASETS)
+        + len(OC_DATASETS)
+        + len(INSITU_DATASETS)
+        + len(BGC_DATASETS)
+    )
+    assert len(CMEMS_DATASETS) == merged_size
+
+
+# ---- DatasetKind semantics ------------------------------------------------
+
+
+def test_insitu_is_tagged_profiles_not_gridded():
+    for info in INSITU_DATASETS.values():
+        assert info.kind is DatasetKind.PROFILES
+
+
+def test_alongtrack_ssh_is_tagged_alongtrack():
+    alongtrack = [i for i in SSH_DATASETS.values() if "l3-duacs" in i.dataset_id]
+    assert alongtrack, "expected at least one along-track L3 entry"
+    for info in alongtrack:
+        assert info.kind is DatasetKind.ALONGTRACK
+
+
+def test_gridded_l4_products_default_to_gridded():
+    assert (
+        PHY_DATASETS["cmems_mod_glo_phy_my_0.083deg_P1D-m"].kind is DatasetKind.GRIDDED
+    )
+    assert SST_DATASETS["METOFFICE-GLO-SST-L4-REP-OBS-SST"].kind is DatasetKind.GRIDDED
+
+
+# ---- Short-name catalog --------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "short_name",
+    [
+        "glorys12.daily",
+        "duacs.sla",
+        "duacs.alongtrack.s3a",
+        "ostia.sst",
+        "odyssea.sst",
+        "multiobs.sss.daily",
+        "globcolour.chl.monthly",
+        "globcolour.transparency",
+        "globcolour.reflectance",
+        "cora.ts",
+        "glorys12.bgc.monthly",
+    ],
+)
+def test_short_name_resolves_to_catalogued_dataset(short_name):
+    entry = CATALOG[short_name]
+    info = describe(short_name)
+    assert info.dataset_id == entry.dataset_id
+    assert info.source == entry.source
+
+
+def test_variable_aliases_translate_for_cmems_products():
+    # The catalog must expose variables whose CMEMS alias is well-defined.
+    info = describe("duacs.sla")
+    cmems_names = {v.for_source("cmems") for v in info.variables}
+    assert {"sla", "adt", "ugos", "vgos"} <= cmems_names

--- a/tests/data/test_review_fixes.py
+++ b/tests/data/test_review_fixes.py
@@ -1,0 +1,192 @@
+"""Regression tests for the PR-review fixes on #8."""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from xr_toolz.data import CDSCredentials, CDSSource, describe
+from xr_toolz.data._src.cache import _json_default
+from xr_toolz.data._src.cds.source import _engine_for_format, _suffix_for_format
+from xr_toolz.types import BBox, TimeRange, Variable, apply_cf_attrs
+
+
+# ---- 1. apply_cf_attrs uses shallow copy --------------------------------
+
+
+def test_apply_cf_attrs_does_not_deep_copy_data():
+    data = np.zeros(1_000_000, dtype=np.float32)
+    da = xr.DataArray(data, dims="i")
+    out = apply_cf_attrs(da, "sst")
+    # Shared underlying buffer: mutating source visible through out.
+    data[0] = 42.0
+    assert float(out.values[0]) == 42.0
+
+
+# ---- 2. cache._json_default sorts sets deterministically ----------------
+
+
+def test_json_default_sorts_sets_across_runs():
+    # The fundamental guarantee: repeated calls with the same logical
+    # request must yield the same list, regardless of construction
+    # order. Even though within a single interpreter this would usually
+    # hold, the contract must not depend on that.
+    s1 = {"b", "a", "c"}
+    s2 = {"c", "a", "b"}
+    assert _json_default(s1) == _json_default(s2) == ["a", "b", "c"]
+
+
+def test_json_default_sorts_mixed_types_via_str():
+    # Types that aren't mutually comparable still need a stable order.
+    out = _json_default({3, "2", 1})
+    assert out == sorted(out, key=str)
+
+
+# ---- 3. Variable.aliases is truly immutable -----------------------------
+
+
+def test_variable_aliases_cannot_be_mutated():
+    v = Variable(name="x", aliases={"cmems": "thetao"})
+    assert isinstance(v.aliases, MappingProxyType)
+    with pytest.raises(TypeError):
+        v.aliases["cmems"] = "oops"  # type: ignore[index]
+
+
+def test_variable_aliases_input_dict_mutation_does_not_affect_variable():
+    raw = {"cmems": "thetao"}
+    v = Variable(name="x", aliases=raw)
+    raw["cmems"] = "MUTATED"  # must not leak through Variable.
+    assert v.for_source("cmems") == "thetao"
+
+
+# ---- 4. BBox.as_xarray_sel guards antimeridian --------------------------
+
+
+def test_bbox_as_xarray_sel_rejects_antimeridian_crossing():
+    wrap = BBox(170.0, -170.0, -10.0, 10.0)
+    with pytest.raises(ValueError, match="antimeridian"):
+        wrap.as_xarray_sel()
+
+
+def test_bbox_as_xarray_sel_works_after_to_360():
+    wrap = BBox(170.0, -170.0, -10.0, 10.0)
+    # After to_360 the box is 170..190, which xarray can still handle on
+    # a 0-360 grid; here we just confirm the guard no longer trips once
+    # the longitudes are ordered.
+    normalized = BBox(170.0, 190.0, -10.0, 10.0)
+    assert not normalized.crosses_antimeridian
+    sel = normalized.as_xarray_sel()
+    assert sel["lon"] == slice(170.0, 190.0)
+    # Sanity: the underlying `to_360` reorientation still wraps to
+    # lon_max=190 in modulo space.
+    _ = wrap.to_360  # method exists; antimeridian path tested separately
+
+
+# ---- 5. describe() return type is DatasetInfo --------------------------
+
+
+def test_describe_returns_dataset_info_not_any():
+    from xr_toolz.data import DatasetInfo
+
+    info = describe("glorys12.daily")
+    assert isinstance(info, DatasetInfo)
+
+
+# ---- 6. ERA5 single-levels title no longer misleads --------------------
+
+
+def test_era5_single_levels_title_does_not_mention_pressure_levels():
+    info = describe("era5.single_levels")
+    assert "pressure" not in info.title.lower()
+    assert "single levels" in info.title.lower()
+
+
+# ---- 7. CDS format <-> suffix/engine glue ------------------------------
+
+
+@pytest.mark.parametrize(
+    ("fmt", "suffix", "engine"),
+    [
+        ("netcdf", ".nc", None),
+        ("netcdf4", ".nc", None),
+        ("grib", ".grib", "cfgrib"),
+        ("GRIB2", ".grib", "cfgrib"),
+    ],
+)
+def test_format_glue_maps_consistently(fmt, suffix, engine):
+    assert _suffix_for_format(fmt) == suffix
+    assert _engine_for_format(fmt) == engine
+
+
+def test_unknown_format_raises():
+    with pytest.raises(ValueError, match="Unsupported"):
+        _suffix_for_format("zarr")
+
+
+class _FakeCdsClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict, str]] = []
+
+    def retrieve(self, dataset_id, form, target):
+        self.calls.append((dataset_id, form, target))
+        xr.Dataset({"marker": ([], 1)}).to_netcdf(target)
+
+
+def test_cds_open_uses_format_derived_suffix(monkeypatch, tmp_path):
+    monkeypatch.setenv("XR_TOOLZ_CACHE", str(tmp_path))
+    fake = _FakeCdsClient()
+    # format="grib" → cache path must end in .grib, not .nc.
+    src = CDSSource(
+        credentials=CDSCredentials(url="https://x", key="k"),
+        client=fake,
+        format="grib",
+    )
+    # Patch xr.open_dataset so the fake .grib file (actually netCDF) doesn't
+    # get fed to cfgrib; we only care about the cache path here.
+    with patch("xarray.open_dataset") as mocked:
+        mocked.return_value = xr.Dataset({"marker": ([], 1)})
+        src.open(
+            "reanalysis-era5-single-levels",
+            variables=["t2m"],
+            bbox=BBox(-10.0, 40.0, 30.0, 60.0),
+            time=TimeRange.parse("2020-01-01", "2020-01-01"),
+        )
+    # The file written by the fake client must have the .grib suffix.
+    (_, _, target) = fake.calls[0]
+    assert target.endswith(".grib")
+
+
+# ---- 8. finite_vals.count() no longer relies on DataArray bool truth ---
+
+
+def test_validation_range_check_handles_empty_data_without_raising():
+    """Construct an all-NaN DataArray so ``count() == 0``. The check
+    must return cleanly — previously it could trip the "truth value of
+    a DataArray is ambiguous" path on some xarray versions."""
+    from xr_toolz.types import validate_variable
+
+    da = xr.DataArray(
+        np.full((3,), np.nan),
+        dims="i",
+        attrs={"standard_name": "sea_surface_temperature", "units": "K"},
+    )
+    report = validate_variable(da, "sst")
+    assert report.ok
+    assert not any(i.code == "out_of_range" for i in report.issues)
+
+
+def test_validation_range_check_still_flags_when_data_present():
+    from xr_toolz.types import validate_variable
+
+    da = xr.DataArray(
+        np.array([50.0, 100.0]),  # way below SST's valid range [270, 320]
+        dims="i",
+        attrs={"standard_name": "sea_surface_temperature", "units": "K"},
+    )
+    report = validate_variable(da, "sst")
+    assert not report.ok
+    assert any(i.code == "out_of_range" for i in report.issues)

--- a/tests/types/test_derived_methods.py
+++ b/tests/types/test_derived_methods.py
@@ -1,0 +1,102 @@
+"""Helpers and derived methods added alongside the core types."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from xr_toolz.types import BBox, DepthRange, PressureLevels, Request, TimeRange
+
+
+# ---- BBox derived methods -----------------------------------------------
+
+
+def test_bbox_width_and_height_simple():
+    b = BBox(-10.0, 40.0, 30.0, 60.0)
+    assert b.width == pytest.approx(50.0)
+    assert b.height == pytest.approx(30.0)
+
+
+def test_bbox_width_handles_antimeridian_wrap():
+    wrap = BBox(170.0, -170.0, -10.0, 10.0)
+    # 170° E -> 180° (10°) + -180° -> -170° (10°) = 20° wide.
+    assert wrap.width == pytest.approx(20.0)
+
+
+def test_bbox_to_360_basic():
+    b = BBox(-10.0, 40.0, 30.0, 60.0).to_360()
+    assert b.lon_min == pytest.approx(350.0)
+    assert b.lon_max == pytest.approx(40.0)
+
+
+def test_bbox_as_xarray_sel_uses_custom_dim_names():
+    b = BBox(-10.0, 40.0, 30.0, 60.0)
+    sel = b.as_xarray_sel(lon="longitude", lat="latitude")
+    assert sel["longitude"] == slice(-10.0, 40.0)
+    assert sel["latitude"] == slice(30.0, 60.0)
+
+
+# ---- TimeRange derived methods ------------------------------------------
+
+
+def test_time_range_as_xarray_sel_default_dim():
+    t = TimeRange.parse("2020-01-01", "2020-01-05")
+    sel = t.as_xarray_sel()
+    assert sel["time"].start == t.start
+    assert sel["time"].stop == t.end
+
+
+def test_time_range_preserves_tzaware_input():
+    aware = pd.Timestamp("2020-01-01T00:00:00", tz="US/Pacific")
+    t = TimeRange.parse(aware, aware)
+    assert t.start.tzinfo is not None
+    # The internal UTC conversion must have run (tz_convert branch).
+    assert t.start == pd.Timestamp("2020-01-01T08:00:00", tz="UTC")
+
+
+def test_time_range_parse_rejects_unparseable():
+    with pytest.raises(ValueError):
+        TimeRange.parse("not a date", "also not a date")
+
+
+# ---- Request composite --------------------------------------------------
+
+
+def test_request_stores_all_fields_and_is_frozen():
+    r = Request(
+        variables=("sst", "ssh"),
+        bbox=BBox(-10.0, 40.0, 30.0, 60.0),
+        time=TimeRange.parse("2020-01-01", "2020-01-31"),
+        depth=DepthRange(0.0, 100.0),
+        levels=PressureLevels((500, 1000)),
+        extras={"grid": "0.25"},
+    )
+    assert r.variables == ("sst", "ssh")
+    assert r.depth is not None
+    assert r.depth.max == 100.0
+    assert r.extras == {"grid": "0.25"}
+    # Frozen (immutable).
+    with pytest.raises(Exception):  # noqa: B017
+        r.variables = ("foo",)  # type: ignore[misc]
+
+
+def test_request_defaults_are_none():
+    r = Request(variables=("sst",))
+    assert r.bbox is None
+    assert r.time is None
+    assert r.depth is None
+    assert r.levels is None
+    assert r.extras is None
+
+
+# ---- Levels edge cases --------------------------------------------------
+
+
+def test_depth_range_accepts_equal_bounds_as_degenerate_point():
+    d = DepthRange(50.0, 50.0)
+    assert d.as_cmems() == {"minimum_depth": 50.0, "maximum_depth": 50.0}
+
+
+def test_pressure_levels_single_level_is_valid():
+    pl = PressureLevels((500,))
+    assert pl.as_cds_form() == ["500"]

--- a/tests/types/test_geometry_time_levels.py
+++ b/tests/types/test_geometry_time_levels.py
@@ -1,0 +1,120 @@
+"""Typed request primitives — ``BBox``, ``TimeRange``, ``DepthRange``,
+``PressureLevels``."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from xr_toolz.types import BBox, DepthRange, PressureLevels, TimeRange
+
+
+# ---- BBox ----------------------------------------------------------------
+
+
+def test_bbox_from_tuple_round_trip():
+    b = BBox.from_tuple((-10.0, 40.0, 30.0, 60.0))
+    assert (b.lon_min, b.lon_max, b.lat_min, b.lat_max) == (-10.0, 40.0, 30.0, 60.0)
+
+
+def test_bbox_rejects_invalid_latitude():
+    with pytest.raises(ValueError, match="lat_min"):
+        BBox(0.0, 10.0, -95.0, 0.0)
+    with pytest.raises(ValueError, match="lat_min"):
+        BBox(0.0, 10.0, 20.0, 10.0)
+
+
+def test_bbox_detects_antimeridian_crossing():
+    wrap = BBox(170.0, -170.0, -10.0, 10.0)
+    assert wrap.crosses_antimeridian
+    straight = BBox(-10.0, 40.0, 30.0, 60.0)
+    assert not straight.crosses_antimeridian
+
+
+def test_bbox_lon_normalization():
+    b = BBox(350.0, 370.0, 0.0, 10.0)
+    assert b.to_180().lon_min == pytest.approx(-10.0)
+    assert b.to_180().lon_max == pytest.approx(10.0)
+
+    b2 = BBox(-10.0, 10.0, 0.0, 10.0)
+    assert b2.to_360().lon_min == pytest.approx(350.0)
+    assert b2.to_360().lon_max == pytest.approx(10.0)
+
+
+def test_bbox_as_cmems_keys_match_client_signature():
+    b = BBox(-10.0, 40.0, 30.0, 60.0)
+    expected_keys = {
+        "minimum_longitude",
+        "maximum_longitude",
+        "minimum_latitude",
+        "maximum_latitude",
+    }
+    assert set(b.as_cmems().keys()) == expected_keys
+
+
+def test_bbox_as_cds_area_order_is_NWSE():
+    b = BBox(-10.0, 40.0, 30.0, 60.0)
+    # CDS expects [North, West, South, East].
+    assert b.as_cds_area() == [60.0, -10.0, 30.0, 40.0]
+
+
+# ---- TimeRange -----------------------------------------------------------
+
+
+def test_time_range_parses_strings_as_utc():
+    t = TimeRange.parse("2020-01-01", "2020-01-31")
+    assert t.start == pd.Timestamp("2020-01-01", tz="UTC")
+    assert t.end == pd.Timestamp("2020-01-31", tz="UTC")
+
+
+def test_time_range_rejects_reversed():
+    with pytest.raises(ValueError, match="start"):
+        TimeRange.parse("2020-06-01", "2020-01-01")
+
+
+def test_time_range_to_index_defaults_daily():
+    t = TimeRange.parse("2020-01-01", "2020-01-03")
+    idx = t.to_index()
+    assert len(idx) == 3
+
+
+def test_time_range_as_cmems_iso_format():
+    t = TimeRange.parse("2020-01-01", "2020-01-31")
+    payload = t.as_cmems()
+    assert payload["start_datetime"].startswith("2020-01-01")
+    assert payload["end_datetime"].startswith("2020-01-31")
+
+
+def test_time_range_as_cds_form_explodes_ymd():
+    t = TimeRange.parse("2020-01-29", "2020-02-02")
+    form = t.as_cds_form()
+    assert form["year"] == ["2020"]
+    assert set(form["month"]) == {"01", "02"}
+    assert set(form["day"]) == {"29", "30", "31", "01", "02"}
+
+
+# ---- DepthRange ----------------------------------------------------------
+
+
+def test_depth_range_validates_non_negative_and_ordered():
+    d = DepthRange(0.0, 100.0)
+    assert d.as_cmems() == {"minimum_depth": 0.0, "maximum_depth": 100.0}
+    with pytest.raises(ValueError):
+        DepthRange(-1.0, 10.0)
+    with pytest.raises(ValueError):
+        DepthRange(100.0, 10.0)
+
+
+# ---- PressureLevels ------------------------------------------------------
+
+
+def test_pressure_levels_rejects_empty_or_non_positive():
+    with pytest.raises(ValueError):
+        PressureLevels(())
+    with pytest.raises(ValueError):
+        PressureLevels((0, 500))
+
+
+def test_pressure_levels_as_cds_form_stringifies():
+    pl = PressureLevels((500, 850, 1000))
+    assert pl.as_cds_form() == ["500", "850", "1000"]

--- a/tests/types/test_validation.py
+++ b/tests/types/test_validation.py
@@ -1,0 +1,124 @@
+"""CF validators."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from xr_toolz.types import (
+    Severity,
+    Variable,
+    apply_cf_attrs,
+    validate_dataset,
+    validate_variable,
+)
+
+
+def _sst_da(values, attrs=None):
+    da = xr.DataArray(np.asarray(values, dtype=float), dims="i")
+    if attrs:
+        da.attrs.update(attrs)
+    return da
+
+
+def test_validate_variable_all_green():
+    da = _sst_da(
+        [280.0, 290.0, 300.0],
+        attrs={"standard_name": "sea_surface_temperature", "units": "K"},
+    )
+    r = validate_variable(da, "sst")
+    assert r.ok
+    assert r.issues == []
+
+
+def test_validate_variable_missing_attrs_are_warnings():
+    da = _sst_da([280.0, 290.0])
+    r = validate_variable(da, "sst")
+    assert r.ok
+    codes = {i.code for i in r.warnings()}
+    assert "missing_standard_name" in codes
+    assert "missing_units" in codes
+
+
+def test_validate_variable_wrong_standard_name_is_error():
+    da = _sst_da(
+        [280.0, 290.0], attrs={"standard_name": "air_temperature", "units": "K"}
+    )
+    r = validate_variable(da, "sst")
+    assert not r.ok
+    codes = {i.code for i in r.errors()}
+    assert "wrong_standard_name" in codes
+
+
+def test_validate_variable_wrong_units_is_error():
+    da = _sst_da(
+        [280.0, 290.0],
+        attrs={"standard_name": "sea_surface_temperature", "units": "degC"},
+    )
+    r = validate_variable(da, "sst")
+    assert not r.ok
+    codes = {i.code for i in r.errors()}
+    assert "wrong_units" in codes
+
+
+def test_validate_variable_out_of_range_is_error():
+    da = _sst_da(
+        [50.0, 100.0],
+        attrs={"standard_name": "sea_surface_temperature", "units": "K"},
+    )
+    r = validate_variable(da, "sst")
+    assert not r.ok
+    codes = {i.code for i in r.errors()}
+    assert "out_of_range" in codes
+
+
+def test_validate_variable_ignores_range_when_disabled():
+    da = _sst_da(
+        [50.0, 100.0],
+        attrs={"standard_name": "sea_surface_temperature", "units": "K"},
+    )
+    r = validate_variable(da, "sst", check_range=False)
+    assert r.ok
+
+
+def test_validate_dataset_missing_variable():
+    ds = xr.Dataset({"sst": _sst_da([280.0], attrs={"units": "K"})})
+    r = validate_dataset(ds, ["sst", "t2m"], check_range=False)
+    codes = {(i.variable, i.code) for i in r.errors()}
+    assert ("t2m", "missing_variable") in codes
+
+
+def test_raise_if_errors_raises_only_on_errors():
+    da = _sst_da([280.0])  # missing attrs → warnings only
+    r = validate_variable(da, "sst")
+    r.raise_if_errors()  # should not raise
+
+    bad_attrs = {"standard_name": "sea_surface_temperature", "units": "K"}
+    bad = _sst_da([50.0], attrs=bad_attrs)
+    r = validate_variable(bad, "sst")
+    with pytest.raises(ValueError, match="Validation failed"):
+        r.raise_if_errors()
+
+
+def test_apply_cf_attrs_no_overwrite_by_default():
+    da = _sst_da([280.0], attrs={"units": "degC"})
+    out = apply_cf_attrs(da, "sst")
+    assert out.attrs["units"] == "degC"  # preserved
+    assert out.attrs["standard_name"] == "sea_surface_temperature"
+
+
+def test_apply_cf_attrs_overwrite():
+    da = _sst_da([280.0], attrs={"units": "degC"})
+    out = apply_cf_attrs(da, "sst", overwrite=True)
+    assert out.attrs["units"] == "K"
+
+
+def test_check_dtype_opt_in():
+    ok_attrs = {"units": "K", "standard_name": "sea_surface_temperature"}
+    da = _sst_da([280.0], attrs=ok_attrs)
+    var = Variable(name="sst_i32", units="K", dtype="int32")
+    r = validate_variable(da, var, check_dtype=True, check_range=False)
+    assert any(
+        i.code == "wrong_dtype" and i.severity is Severity.ERROR for i in r.issues
+    )

--- a/tests/types/test_variables.py
+++ b/tests/types/test_variables.py
@@ -1,0 +1,112 @@
+"""Variable registry + CF metadata basics."""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from xr_toolz.types import REGISTRY, SST, T2M, Variable, register, resolve
+
+
+def test_variable_is_frozen_and_hashable():
+    v1 = Variable(name="foo", units="m")
+    v2 = Variable(name="foo", units="m")
+    assert v1 == v2
+    assert hash(v1) == hash(v2)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        v1.name = "bar"  # type: ignore[misc]
+
+
+def test_variable_for_source_aliases():
+    assert SST.for_source("cmems") == "thetao"
+    assert SST.for_source("cds") == "sea_surface_temperature"
+    assert SST.for_source("unknown") == "sst"  # falls back to canonical name
+
+
+def test_variable_cf_attrs_round_trip():
+    attrs = SST.cf_attrs()
+    assert attrs["standard_name"] == "sea_surface_temperature"
+    assert attrs["units"] == "K"
+    assert attrs["long_name"].startswith("Sea surface")
+
+
+def test_resolve_returns_registry_entry_for_known_name():
+    assert resolve("sst") is SST
+    assert resolve("t2m") is T2M
+
+
+def test_resolve_returns_variable_unchanged():
+    v = Variable(name="x", units="m")
+    assert resolve(v) is v
+
+
+def test_resolve_raises_with_helpful_message():
+    with pytest.raises(KeyError, match="Unknown variable"):
+        resolve("not_a_real_var")
+
+
+def test_register_inserts_into_registry():
+    v = Variable(name="my_custom_var", units="kg", standard_name="custom_stuff")
+    try:
+        register(v)
+        assert resolve("my_custom_var") is v
+    finally:
+        del REGISTRY["my_custom_var"]
+
+
+def test_registry_covers_key_ocn_and_atm_vars():
+    for n in ["sst", "ssh", "sla", "uo", "vo", "so", "t2m", "u10", "v10", "msl"]:
+        assert n in REGISTRY
+
+
+def test_registry_covers_ocean_colour_and_bgc_vars():
+    for n in [
+        # Altimetry derivatives
+        "adt",
+        "ugos",
+        "vgos",
+        # Salinity companions
+        "sos",
+        "dens",
+        # Sea ice
+        "ice_conc",
+        # Ocean colour
+        "chl",
+        "kd490",
+        "zsd",
+        "spm",
+        "bbp443",
+        "pp",
+        # Remote-sensing reflectance wavelengths
+        "rrs412",
+        "rrs443",
+        "rrs490",
+        "rrs510",
+        "rrs555",
+        "rrs670",
+        # Biogeochemistry
+        "no3",
+        "po4",
+        "si",
+        "o2",
+        "phyc",
+        "zooc",
+        "ph",
+        "spco2",
+    ]:
+        assert n in REGISTRY, f"{n} missing from REGISTRY"
+
+
+def test_rrs_wavelengths_share_standard_name_and_units():
+    attrs = [resolve(f"rrs{wl}") for wl in (412, 443, 490, 510, 555, 670)]
+    assert len({v.standard_name for v in attrs}) == 1
+    assert len({v.units for v in attrs}) == 1
+    # But long_names and aliases differ (per-wavelength metadata).
+    assert len({v.long_name for v in attrs}) == len(attrs)
+
+
+def test_chl_has_cf_standard_name():
+    chl = resolve("chl")
+    assert chl.standard_name == "mass_concentration_of_chlorophyll_a_in_sea_water"
+    assert chl.for_source("cmems") == "CHL"


### PR DESCRIPTION
## Summary

Two new top-level packages wired into `xr_toolz`:

- **`xr_toolz.types`** — domain-agnostic typed primitives so every submodule (data, geo, ocn, atm) speaks one language:
  - `BBox` (with antimeridian handling + CMEMS/CDS/xarray selectors), `TimeRange` (UTC-normalized), `DepthRange`, `PressureLevels`, `Request`
  - CF-aware `Variable` with `standard_name`, `long_name`, `units`, `valid_range`, `dtype`, and per-source aliases
  - 40-variable curated `REGISTRY` covering physics, salinity, sea-ice, ocean colour (including per-wavelength Rrs412/443/490/510/555/670), and biogeochemistry
  - Validators (`validate_variable`, `validate_dataset`, `apply_cf_attrs`) that surface findings through a `ValidationReport` rather than exceptions
- **`xr_toolz.data`** — adapter layer built on those types:
  - `DataSource` ABC + `DatasetInfo` with a `DatasetKind` enum (`gridded` / `alongtrack` / `profiles` / `trajectory`) so downstream code can branch safely
  - `CMEMSSource` (lazy `copernicusmarine`) and `CDSSource` (lazy `cdsapi`), both with deterministic on-disk caching under `$XR_TOOLZ_CACHE`
  - Credential loading from env → `~/.cmems` / `~/.cdsapirc` (read-only)
  - Per-family CMEMS preset catalog split across `presets/{phy,ssh,sst,sss,oc,insitu,bgc}.py` — every `dataset_id` verified against the live Copernicus Marine catalog
  - Unified short-name `CATALOG` (`glorys12.daily`, `ostia.sst`, `multiobs.sss.daily`, `globcolour.chl.monthly`, `cora.ts`, `era5.single_levels`, ...)

## Coverage

- `types/_src/*`: 97–100% line coverage
- `data/_src/*`: 81–100%; remaining uncovered lines are the lazy-import `ImportError` guards that can't fire when the package is installed

## Test plan

- [x] `uv run pytest tests/` — 252 passing, including 114 tests for the new modules
- [x] `uv run --group lint ruff check .` — clean
- [x] `uv run --group lint ruff format --check .` — clean
- [x] `uv run --group typecheck ty check src/xr_toolz` — zero errors (pre-existing xarray Literal warnings unchanged)
- [ ] Smoke-test against the real Copernicus Marine service once `copernicusmarine` is installed in a local env
- [ ] Smoke-test against the real CDS with a small `t2m` request

🤖 Generated with [Claude Code](https://claude.com/claude-code)