### PR TITLE
docs(design): add D7-D10 architecture decisions

### DIFF
--- a/docs/design/api/components.md
+++ b/docs/design/api/components.md
@@ -3,14 +3,20 @@ status: draft
 version: 0.1.0
 ---
 
-!!! note "Imports in this page are from the original `geo_toolz` layout"
-    These design docs were adapted from the `geo_toolz` design study.
-    Code snippets use the original feature-based import paths
-    (`geo_toolz.<module>`). In `xr_toolz`, the domain-agnostic
-    operations live under `xr_toolz.geo.<module>`; physics-specific
-    operations live under `xr_toolz.ocn` / `xr_toolz.atm` /
-    `xr_toolz.rs`. See `xr_toolz/__init__.py` and
-    `xr_toolz/geo/__init__.py` for the current export surface.
+!!! note "These design docs cover the planned operator surface for `xr_toolz`"
+    Code snippets use class names directly. In the implementation, the
+    submodule layout is:
+
+    - **`xr_toolz.geo`** — domain-agnostic geoprocessing (CRS, validation,
+      subset, masks, regrid, discretize, detrend)
+    - **`xr_toolz.transforms`** — signal transforms / decompositions /
+      encoders (D8)
+    - **`xr_toolz.metrics`** — skill scores (D7)
+    - **`xr_toolz.kinematics`** — domain-specific physical quantities,
+      sub-organized by domain (D9)
+    - **`xr_toolz.viz`** — plotting operators (D10)
+
+    See `xr_toolz/__init__.py` for the current export surface.
 
 # Components — Layer 1 Operators
 
@@ -169,29 +175,89 @@ class LowpassFilter:
 
 ---
 
-## `encoders` — Coordinate Encodings
+## `transforms` — Signal Transforms, Decompositions, and Encoders
 
-Transform coordinates into feature representations useful for ML models and analysis. Covers spatial coordinate transforms and temporal encodings, including NeRF-style positional encodings.
+Mathematical transforms over data values and over coordinates. **All encoders, basis expansions, signal transforms, and statistical decompositions live here** — see [decisions.md §D8](../decisions.md) for why this is one module instead of split between `geo` and `transforms`.
+
+Organized by sub-category:
+
+### `transforms.fourier` — Fourier-domain transforms
+
+Wraps `xrft`. Layer 0 functions + Layer 1 Operator wrappers.
 
 ```python
-class LonLatToCartesian:
+# Layer 0
+def power_spectrum(da, dim, *, isotropic=False, **kwargs) -> xr.DataArray: ...
+def cross_spectrum(da_a, da_b, dim, **kwargs) -> xr.DataArray: ...
+def coherence(da_a, da_b, dim, **kwargs) -> xr.DataArray: ...
+def stft(da, dim, *, window_size, hop, **kwargs) -> xr.DataArray: ...
+def drop_negative_frequencies[T](da: T, dims, *, drop=True) -> T: ...
+
+# Layer 1
+class PowerSpectrum(Operator): ...
+class CrossSpectrum(Operator): ...
+class Coherence(Operator): ...
+class STFT(Operator): ...
+```
+
+### `transforms.dct` — Cosine / sine transforms
+
+Wraps `scipy.fft`. Layer 0: `dct`, `idct`, `dst`, `idst`. Layer 1: `DCT`, `DST`.
+
+### `transforms.wavelet` — Wavelet transforms
+
+Optional dep `PyWavelets`. Layer 0: `cwt`, `dwt`. Layer 1: `CWT` (`DWT` is dict-returning, kept function-only).
+
+### `transforms.decompose` — Statistical decompositions
+
+Thin presets over `XarrayEstimator` (sklearn-bridge). Stateful (need `.fit()` first) — they are intentionally **not** plain `Dataset → Dataset` operators. EOF uses `mode` axis name; PCA/ICA/NMF/KMeans use `component`.
+
+```python
+def pca(n_components, sample_dim, ...) -> XarrayEstimator: ...
+def eof(n_components, sample_dim, ...) -> XarrayEstimator: ...   # mode axis
+def ica(n_components, sample_dim, ...) -> XarrayEstimator: ...
+def nmf(n_components, sample_dim, ...) -> XarrayEstimator: ...
+def kmeans(n_clusters, sample_dim, ...) -> XarrayEstimator: ...
+```
+
+### `transforms.encoders` — Coordinate and basis encoders
+
+Transform coordinates or values into feature representations. Sub-organized by what they encode:
+
+```python
+# transforms/encoders/coord_space.py — spatial coordinate transforms
+class LonLatToCartesian(Operator):
     """Convert lon/lat coordinates to 3D Cartesian (x, y, z) on the unit sphere."""
     def __init__(self): ...
 
-class CyclicalTimeEncoding:
+class GeocentricToENU(Operator):
+    """Geocentric (ECEF) → local East-North-Up at a reference point."""
+    def __init__(self, ref_lon: float, ref_lat: float): ...
+
+# transforms/encoders/coord_time.py — temporal coordinate transforms
+class CyclicalTimeEncoding(Operator):
     """Add sin/cos cyclical features for temporal components."""
     def __init__(self, components: tuple = ("dayofyear", "hour")): ...
 
-class FourierFeatures:
-    """Add Fourier feature encodings to specified coordinate dimensions.
-    NeRF-style positional encoding: [sin(2πσ⁰x), cos(2πσ⁰x), ..., sin(2πσ^(L-1)x), cos(2πσ^(L-1)x)]"""
+class JulianDate(Operator):
+    """Continuous Julian / decimal-year encoding."""
+    def __init__(self): ...
+
+# transforms/encoders/basis.py — basis / feature expansions
+class FourierFeatures(Operator):
+    """NeRF-style positional encoding: [sin(2πσ⁰x), cos(2πσ⁰x), …, sin(2πσ^(L-1)x), cos(2πσ^(L-1)x)]."""
     def __init__(self, coords: list[str], num_freqs: int = 10, scale: float = 1.0): ...
 
-class RandomFourierFeatures:
-    """Random Fourier feature mapping (Rahimi & Recht 2007).
-    Approximates RBF kernels for downstream linear models."""
+class RandomFourierFeatures(Operator):
+    """Random Fourier features (Rahimi & Recht 2007). Approximates RBF kernels for downstream linear models."""
     def __init__(self, coords: list[str], num_features: int = 64, sigma: float = 1.0, seed: int = 0): ...
+
+class PolynomialFeatures(Operator):
+    """Polynomial basis expansion over selected coords/variables."""
+    def __init__(self, coords: list[str], degree: int = 2): ...
 ```
+
+All encoders are coordinate-aware *or* value-aware Operators with the standard `Dataset → Dataset` shape — they add new variables / coords carrying the encoded features. Stateless (no `fit` step required), so they slot into `Sequential` directly.
 
 ---
 
@@ -215,123 +281,223 @@ class PointsToGrid:
 
 ---
 
-## `extremes` — Extreme Value Analysis
+## `extremes` — *Deferred*
 
-Block maxima, peaks over threshold, and point process approaches for characterizing distributional tails.
+Extreme-value statistics (block maxima/minima, peaks over threshold, point process counts/stats) live in the standalone **xtremax** package (master_plan Layer 3). `xr_toolz` does not own the implementation.
 
-```python
-class BlockMaxima:
-    def __init__(self, block_size: int = 365, side: str = "center"): ...
+If a thin xarray wrapper / Operator surface is needed later, it would be added as `xr_toolz.extremes` (parallel to how `xr_toolz.assimilate` wraps filterX), but no work is planned in v0.x.
 
-class BlockMinima:
-    def __init__(self, block_size: int = 365, side: str = "center"): ...
-
-class PeakOverThreshold:
-    def __init__(self, quantile: float = 0.98, decluster_freq: int | None = None): ...
-
-class PointProcessCounts:
-    def __init__(self, threshold: float, block_size: int = 365): ...
-
-class PointProcessStats:
-    def __init__(self, threshold: float, block_size: int = 365, statistic: str = "mean"): ...
-```
-
----
-
-## `spectral` — Spectral Analysis
-
-Power spectral density and spectral transformations for space and time. Wraps `xrft`.
-
-```python
-class PSD:
-    """Power spectral density along specified dimensions."""
-    def __init__(self, variable: str, dims: list[str], scaling="density", detrend="linear"): ...
-
-class IsotropicPSD:
-    """Isotropic power spectral density."""
-    def __init__(self, variable: str, dims: list[str], scaling="density"): ...
-
-class CrossSpectrum:
-    """Cross-spectral density between two variables (multi-input)."""
-    def __init__(self, var_a: str, var_b: str, dims: list[str]): ...
-```
+Until then: use `xtremax` directly, or hand-author a `Lambda(...)` operator over an xtremax function for a one-off pipeline.
 
 ---
 
 ## `metrics` — Evaluation Metrics
 
-Pixel-level, spectral, and multiscale metrics. These are multi-input operators: `(prediction, reference) → Dataset | scalar`.
+Pixel-level, spectral, multiscale, and distributional skill scores. **Owned implementation, no `xskillscore` dependency** (see [decisions.md §D7](../decisions.md)).
+
+Two-layer module:
+
+- **Layer 0** — pure functions in `xr_toolz/metrics/_src/<family>.py`. Standard signature: `(prediction, reference, *, dim, **kwargs) → xr.DataArray | xr.Dataset | float`. Importable directly for use in scripts, notebooks, and inside other operators.
+- **Layer 1** — `Operator` wrappers around the Layer 0 functions. Multi-input: `__call__(prediction, reference) → result`. Each wrapper is one call into its Layer 0 function with config carried on the operator.
+
+Custom skill score: write a Layer 0 function, then either reuse the generic `MetricOp(fn, **config)` wrapper or hand-author an `Operator` subclass.
+
+### Layer 0 — pure functions
 
 ```python
-class RMSE:
+# xr_toolz/metrics/_src/pixel.py
+def rmse(prediction, reference, *, dim) -> xr.DataArray: ...
+def nrmse(prediction, reference, *, dim, normalize="std") -> xr.DataArray: ...
+def mae(prediction, reference, *, dim) -> xr.DataArray: ...
+def bias(prediction, reference, *, dim) -> xr.DataArray: ...
+def correlation(prediction, reference, *, dim) -> xr.DataArray: ...
+def murphy_score(prediction, reference, *, dim) -> xr.DataArray: ...
+def nash_sutcliffe(prediction, reference, *, dim) -> xr.DataArray: ...
+def crps(prediction, reference, *, dim) -> xr.DataArray: ...
+
+# xr_toolz/metrics/_src/spectral.py
+def psd_score(prediction, reference, *, dim, **kwargs) -> xr.Dataset: ...
+def resolved_scale(prediction, reference, *, dim, threshold=0.5, **kwargs) -> xr.DataArray: ...
+def coherence_skill(prediction, reference, *, dim, **kwargs) -> xr.DataArray: ...
+
+# xr_toolz/metrics/_src/multiscale.py
+def per_scale_rmse(prediction, reference, *, dim, scales) -> xr.DataArray: ...
+def wavelet_rmse(prediction, reference, *, dim, wavelet="db4", level=4) -> xr.DataArray: ...
+
+# xr_toolz/metrics/_src/distributional.py
+def ks_statistic(prediction, reference, *, dim) -> xr.DataArray: ...
+def wasserstein_1d(prediction, reference, *, dim) -> xr.DataArray: ...
+def energy_distance(prediction, reference, *, dim) -> xr.DataArray: ...
+
+# xr_toolz/metrics/_src/masked.py
+def masked_rmse(prediction, reference, *, dim, mask) -> xr.DataArray: ...
+# ... mask-aware variants of the others
+```
+
+### Layer 1 — Operator wrappers
+
+```python
+class RMSE(Operator):
     """Root mean squared error. Multi-input operator."""
     def __init__(self, variable: str, dims: list[str]): ...
     def __call__(self, prediction, reference) -> xr.DataArray: ...
 
-class NRMSE:
-    def __init__(self, variable: str, dims: list[str]): ...
-    def __call__(self, prediction, reference) -> xr.DataArray: ...
+class NRMSE(Operator): ...
+class MAE(Operator): ...
+class Bias(Operator): ...
+class Correlation(Operator): ...
+class MurphyScore(Operator): ...
+class NashSutcliffe(Operator): ...
+class CRPS(Operator): ...
 
-class MAE:
-    def __init__(self, variable: str, dims: list[str]): ...
-
-class Bias:
-    def __init__(self, variable: str, dims: list[str]): ...
-
-class Correlation:
-    def __init__(self, variable: str, dims: list[str]): ...
-
-class PSDScore:
+class PSDScore(Operator):
     """Spectral coherence-based score."""
-    def __init__(self, variable: str, dims: list[str]): ...
+    def __init__(self, variable: str, dims: list[str], **kwargs): ...
     def __call__(self, prediction, reference) -> xr.Dataset: ...
 
-class ResolvedScale:
+class ResolvedScale(Operator):
     """Minimum resolved spatial scale at a given PSD threshold."""
     def __init__(self, variable: str, dims: list[str], threshold: float = 0.5): ...
+
+class CoherenceSkill(Operator): ...
+class PerScaleRMSE(Operator): ...
+class WaveletRMSE(Operator): ...
+class KSStatistic(Operator): ...
+class Wasserstein1D(Operator): ...
+class EnergyDistance(Operator): ...
+
+class MetricOp(Operator):
+    """Generic wrapper: turns any Layer 0 metric function into an Operator."""
+    def __init__(self, fn, variable: str, dims: list[str], **kwargs): ...
+    def __call__(self, prediction, reference): ...
+```
+
+### Adding a custom skill score
+
+```python
+# 1. Write a Layer 0 function
+def my_score(prediction, reference, *, dim, alpha=1.0):
+    return ((prediction - reference) ** alpha).mean(dim=dim)
+
+# 2. Use directly, or wrap as an Operator
+op = MetricOp(my_score, variable="ssh", dims=["time"], alpha=2.0)
+op(pred, ref)
 ```
 
 ---
 
-## `kinematics` — Physical Quantities
+## `viz` — Plotting Operators
 
-Domain-specific physical transformations. Starting with remote sensing, methane, and oceanography. Uses `metpy` where available, with pure numpy/scipy fallbacks.
+First-class `Operator` subclasses that return `matplotlib.Figure` / `Axes`. **Documented exception to the `Dataset → Dataset` invariant** — see [decisions.md §D10](../decisions.md). They compose inside `Sequential` as the terminal step, and inside `Graph` as one of N output nodes (the motivating pattern: an evaluation graph that emits scores *and* figures from one symbolic computation).
+
+Sub-organized by what they plot:
+
+```
+xr_toolz/viz/_src/
+    maps.py         # PlotMap, PlotMapDiff, PlotMapPanel
+    series.py       # PlotTimeseries, PlotHovmoller, PlotProfile
+    spectral.py     # PlotSpectrum, PlotResolvedScale, PlotCoherence
+    eval.py         # PlotMetricsTable, QuicklookPanel
+```
+
+Two-layer pattern as elsewhere — pure plotting functions at Layer 0 + `Operator` wrappers at Layer 1.
 
 ```python
-# Oceanography
-class Streamfunction:
-    def __init__(self, variable="ssh", f0=None, g=None): ...
+# Layer 0
+def plot_map(da, *, ax=None, projection=None, cmap=None, **kwargs) -> matplotlib.axes.Axes: ...
+def plot_timeseries(da, *, ax=None, **kwargs) -> matplotlib.axes.Axes: ...
+def plot_spectrum(da, *, ax=None, log=True, **kwargs) -> matplotlib.axes.Axes: ...
 
-class GeostrophicVelocities:
-    def __init__(self, variable="ssh"): ...
+# Layer 1
+class PlotMap(Operator):
+    def __init__(self, variable: str, *, projection=None, cmap=None, figsize=(8, 6)): ...
+    def __call__(self, ds) -> matplotlib.figure.Figure: ...
 
-class RelativeVorticity:
-    def __init__(self, u_var="u", v_var="v"): ...
-
-class KineticEnergy:
-    def __init__(self, u_var="u", v_var="v"): ...
-
-class OkuboWeiss:
-    def __init__(self, u_var="u", v_var="v"): ...
-
-# Remote sensing
-class NormalizedDifference:
-    def __init__(self, var_a: str, var_b: str, name: str = "ndvi"): ...
-
-class RadianceToReflectance:
-    def __init__(self, solar_zenith_var: str, solar_irradiance: float): ...
-
-# Methane
-class ColumnAveragingKernel:
-    def __init__(self, pressure_var: str, kernel_var: str): ...
-
-# Atmospheric
-class WindSpeed:
-    def __init__(self, u_var="u10", v_var="v10"): ...
-
-class PotentialTemperature:
-    def __init__(self, temp_var: str, pressure_var: str): ...
+class PlotTimeseries(Operator): ...
+class PlotHovmoller(Operator): ...
+class PlotSpectrum(Operator): ...
+class PlotResolvedScale(Operator): ...
+class QuicklookPanel(Operator):
+    """Multi-panel quick diagnostic plot — map + timeseries + spectrum."""
+    def __init__(self, variable: str, *, dims=None): ...
 ```
+
+End-to-end pattern (the motivating use case):
+
+```python
+preprocess = Sequential([Validate(), Regrid(grid), RemoveClimatology(clim)])
+
+evaluate = Graph(
+    inputs={"pred": Input(), "ref": Input()},
+    outputs={
+        "rmse": RMSE("ssh", dims=["time"])(pred, ref),
+        "psd_score": PSDScore("ssh", dims=["lon", "lat"])(pred, ref),
+        "fig_map": PlotMap("ssh")(pred),
+        "fig_psd": PlotSpectrum("ssh", dims=["lon", "lat"])(pred),
+    },
+)
+
+results = evaluate(pred=preprocess(raw_pred), ref=preprocess(raw_ref))
+# results["rmse"] → xr.DataArray
+# results["fig_psd"] → matplotlib.Figure
+```
+
+`Sequential` validates that non-`Dataset` returns only appear at the final step; otherwise raises a clear error.
+
+---
+
+## `kinematics` — Domain-Specific Physical Quantities
+
+**Single home for derived physical-quantity operators across all geophysical domains** (atmosphere, ocean, ice, remote sensing). Replaces the earlier-considered split into `xr_toolz.atm/`, `xr_toolz.ocn/`, `xr_toolz.ice/`, `xr_toolz.rs/`. See [decisions.md §D9](../decisions.md).
+
+Sub-organized by domain in one-file-per-domain layout:
+
+```
+xr_toolz/kinematics/_src/
+    ocean.py        # Streamfunction, GeostrophicVelocities, RelativeVorticity,
+                    # KineticEnergy, OkuboWeiss, MixedLayerDepth, …
+    atmosphere.py   # WindSpeed, PotentialTemperature, BruntVaisala,
+                    # Vorticity, Divergence, …
+    ice.py          # SeaIceConcentration, IceAge, IceDrift, …
+    remote.py       # NormalizedDifference (NDVI/NDWI/…), RadianceToReflectance,
+                    # ColumnAveragingKernel, …
+```
+
+Each sub-file ships **Layer 0** pure functions and **Layer 1** Operator wrappers, mirroring the metrics pattern.
+
+```python
+# transforms/kinematics/_src/ocean.py
+def streamfunction(ds, *, variable="ssh", f0=None, g=None) -> xr.DataArray: ...
+def geostrophic_velocities(ds, *, variable="ssh") -> xr.Dataset: ...
+def relative_vorticity(ds, *, u_var="u", v_var="v") -> xr.DataArray: ...
+def kinetic_energy(ds, *, u_var="u", v_var="v") -> xr.DataArray: ...
+def okubo_weiss(ds, *, u_var="u", v_var="v") -> xr.DataArray: ...
+
+class Streamfunction(Operator): ...
+class GeostrophicVelocities(Operator): ...
+class RelativeVorticity(Operator): ...
+class KineticEnergy(Operator): ...
+class OkuboWeiss(Operator): ...
+
+# transforms/kinematics/_src/atmosphere.py
+def wind_speed(ds, *, u_var="u10", v_var="v10") -> xr.DataArray: ...
+def potential_temperature(ds, *, temp_var, pressure_var) -> xr.DataArray: ...
+
+class WindSpeed(Operator): ...
+class PotentialTemperature(Operator): ...
+
+# transforms/kinematics/_src/remote.py
+def normalized_difference(ds, *, var_a, var_b, name="ndvi") -> xr.DataArray: ...
+def radiance_to_reflectance(ds, *, solar_zenith_var, solar_irradiance) -> xr.DataArray: ...
+
+class NormalizedDifference(Operator): ...
+class RadianceToReflectance(Operator): ...
+```
+
+Uses `metpy` where available, with pure numpy/scipy fallbacks. No hard dependency on `metpy`.
+
+**Disambiguation rule when an operator could fit multiple domains:**
+The variable being *operated on* decides the home, not the variable being *produced*. `WindSpeed(u10, v10)` lives in `atmosphere.py` (atmospheric inputs) even when used in an ocean-forcing context.
 
 ---
 

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -3,14 +3,20 @@ status: draft
 version: 0.1.0
 ---
 
-!!! note "Imports in this page are from the original `geo_toolz` layout"
-    These design docs were adapted from the `geo_toolz` design study.
-    Code snippets use the original feature-based import paths
-    (`geo_toolz.<module>`). In `xr_toolz`, the domain-agnostic
-    operations live under `xr_toolz.geo.<module>`; physics-specific
-    operations live under `xr_toolz.ocn` / `xr_toolz.atm` /
-    `xr_toolz.rs`. See `xr_toolz/__init__.py` and
-    `xr_toolz/geo/__init__.py` for the current export surface.
+!!! note "These design docs cover the planned operator surface for `xr_toolz`"
+    Code snippets use class names directly. In the implementation, the
+    submodule layout is:
+
+    - **`xr_toolz.geo`** — domain-agnostic geoprocessing (CRS, validation,
+      subset, masks, regrid, discretize, detrend)
+    - **`xr_toolz.transforms`** — signal transforms / decompositions /
+      encoders (D8)
+    - **`xr_toolz.metrics`** — skill scores (D7)
+    - **`xr_toolz.kinematics`** — domain-specific physical quantities,
+      sub-organized by domain (D9)
+    - **`xr_toolz.viz`** — plotting operators (D10)
+
+    See `xr_toolz/__init__.py` for the current export surface.
 
 # Architecture
 
@@ -87,7 +93,8 @@ class Operator:
     Every operator is a callable. Single-input operators map
     Dataset → Dataset. Multi-input operators accept multiple
     positional arguments. Reductions may return scalars or
-    lower-dimensional Datasets.
+    lower-dimensional Datasets. Terminal viz operators may return
+    matplotlib Figure / Axes (see decisions.md §D10).
 
     Subclasses must implement `__call__`.
     """
@@ -132,14 +139,26 @@ class Sequential(Operator):
     Sequential is itself an Operator, so pipelines nest:
         preprocess = Sequential([ValidateCoords(), Regrid(grid)])
         full = Sequential([preprocess, Detrend(clim), Subset(region)])
+
+    Non-Dataset returns (e.g., a terminal viz Operator that returns
+    matplotlib.Figure — see decisions.md §D10) are allowed only as the
+    LAST step. A non-Dataset return from any earlier step is a runtime
+    error, since the next operator would receive an unexpected type.
     """
 
     def __init__(self, operators: list[Operator]):
         self.operators = operators
 
     def __call__(self, ds):
-        for op in self.operators:
+        for i, op in enumerate(self.operators):
             ds = op(ds)
+            is_last = i == len(self.operators) - 1
+            if not is_last and not isinstance(ds, (xr.Dataset, xr.DataArray)):
+                raise TypeError(
+                    f"Step [{i}] {op!r} returned {type(ds).__name__}; "
+                    f"non-Dataset returns are only allowed at the final step "
+                    f"of a Sequential (see decisions.md §D10)."
+                )
         return ds
 
     def get_config(self) -> dict:
@@ -157,6 +176,8 @@ class Sequential(Operator):
             lines.append(f"  [{i}] {op!r}")
         return "\n".join(lines)
 ```
+
+**Type rule (D10).** Most operators are `Dataset → Dataset`. Terminal viz operators (`PlotMap`, `PlotSpectrum`, …) return `matplotlib.Figure` / `Axes`. `Sequential` validates that any non-`Dataset` return appears only at the last step; otherwise it raises a clear `TypeError`. `Graph` already supports heterogeneous output types and needs no change — viz nodes slot in as one of N outputs.
 
 ## Stateful Operations: The Split-Object Pattern
 

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -115,3 +115,132 @@ version: 0.1.0
 - Multi-input operators (metrics taking prediction + reference) are first-class
 - Drop-in compatible with Sequential when graph has one input/output
 - Execution is eager and synchronous — no lazy evaluation
+
+---
+
+## D7: Metrics — own the implementation, two-layer (functions + Operator)
+
+**Status:** accepted (resolved 2026-04-25)
+
+**Context:** Should `xr_toolz.metrics` wrap `xskillscore`, depend on it optionally, or own the implementation?
+
+**Options:**
+- (A) Wrap xskillscore — small surface, inherits their tests, but no spectral / multiscale / masked-coverage variants and the API is function-style (no Operator)
+- (B) Optional internal delegation — own the Operator API, fall through to xskillscore where it matches
+- (C) Own it end-to-end as a two-layer module: pure-function skill scores at Layer 0, thin Operator wrappers at Layer 1
+
+**Decision:** Option C.
+
+- **Layer 0** — pure functions in `xr_toolz/metrics/_src/<family>.py` returning `xr.DataArray | xr.Dataset | float`. One file per family: `pixel.py` (RMSE, NRMSE, MAE, Bias, Correlation, Murphy, NSE, CRPS), `spectral.py` (PSDScore, ResolvedScale, Coherence-as-skill), `multiscale.py` (per-scale RMSE, wavelet-RMSE), `distributional.py` (KS, Wasserstein, energy distance), `masked.py` (mask-aware variants of the above).
+- **Layer 1** — Operator wrappers in `xr_toolz/metrics/operators.py` (`RMSE`, `PSDScore`, `ResolvedScale`, …). Each is a thin call into the Layer 0 function with config carried on the operator. Multi-input: `__call__(prediction, reference) → DataArray | Dataset | float`.
+- Custom user metrics: write a Layer 0 function with the standard signature, wrap once with `MetricOp(fn, **config)` (or a hand-authored Operator subclass).
+- **No xskillscore dependency.** Implementations are short and well-known; tests pin them against analytic ground truth and (offline) against xskillscore for the overlapping subset.
+
+**Consequences:**
+- Single coherent Operator surface across pixel / spectral / multiscale / distributional metrics.
+- Spectral and multiscale skill scores (the differentiator) sit naturally next to RMSE rather than in a parallel module.
+- Custom skill scores have a low-friction extension path (write a function, optionally wrap).
+- Test cost: ~10 pixel + ~5 spectral/multiscale + ~3 distributional implementations to author and verify, but each is small.
+- Removes `xskillscore` from the dependency tree (it was never required, but D7 makes the choice explicit).
+
+---
+
+## D8: Encoders live under `transforms`, organized by what they encode
+
+**Status:** accepted (resolved 2026-04-25)
+
+**Context:** Coordinate encoders (`LonLatToCartesian`, `CyclicalTime`) and basis / feature encoders (`FourierFeatures`, `RandomFourierFeatures`, `PolynomialFeatures`) overlap conceptually with both `geo` (coordinate-aware) and `transforms` (basis expansion). Where do they live?
+
+**Options:**
+- (A) Coord encoders in `geo.encoders`, basis encoders in `transforms.encoders` — split by what they encode
+- (B) Everything in `geo.encoders` — keeps `transforms` purely about signal transforms
+- (C) Everything in `transforms.encoders` — single home, sub-organized by category
+
+**Decision:** Option C. All encoders move under `xr_toolz.transforms.encoders`, sub-organized by category:
+
+```
+xr_toolz/transforms/encoders/
+    coord_space.py    # LonLatToCartesian, GeocentricToENU, …
+    coord_time.py     # CyclicalTimeEncoding, JulianDate, …
+    basis.py          # FourierFeatures, RandomFourierFeatures, PolynomialFeatures
+```
+
+Rationale:
+- One namespace to look in for "encode something into a feature representation".
+- Mathematically, `FourierFeatures` and `DCT` are siblings (basis expansions); putting them in different top-level modules hides that.
+- Sub-files (`coord_space`, `coord_time`, `basis`) preserve the conceptual split without forcing two parallel `encoders/` namespaces.
+
+**Consequences:**
+- `xr_toolz.geo._src/encoders.py` is removed; all encoder classes re-export from `transforms.encoders`.
+- `xr_toolz.transforms` becomes the single home for: fourier / dct / wavelet / decompose / encoders.
+- Existing imports from `xr_toolz.geo` need a one-time migration when this lands in code; design docs already reflect the new home.
+- Future encoder families (e.g., spherical harmonic basis, learned positional encodings) get a natural home — likely a new sub-file under `transforms.encoders/`.
+
+---
+
+## D9: Domain stubs collapse into one `kinematics` submodule, sub-organized by domain
+
+**Status:** accepted (resolved 2026-04-25)
+
+**Context:** `xr_toolz` currently has empty stubs at `xr_toolz/atm/`, `xr_toolz/ocn/`, `xr_toolz/ice/`, `xr_toolz/rs/`. Each was intended to host derived physical-quantity operators (`GeostrophicVelocities`, `WindSpeed`, `NormalizedDifference`, etc.). Should they fill out as four parallel domain-named submodules, or collapse into one home?
+
+**Options:**
+- (A) Fill them — keep `atm/`, `ocn/`, `ice/`, `rs/` as top-level submodules, each with its own `kinematics`, `derived_variables`, etc. inside
+- (B) Collapse into a single `xr_toolz.kinematics` submodule with one file per domain (`ocean.py`, `atmosphere.py`, `ice.py`, `remote.py`)
+
+**Decision:** Option B.
+
+```
+xr_toolz/kinematics/_src/
+    ocean.py
+    atmosphere.py
+    ice.py
+    remote.py
+```
+
+Each sub-file follows the metrics two-layer pattern: Layer 0 pure functions + Layer 1 Operator wrappers.
+
+Rationale:
+- Removes nine "where does X go?" questions (`WindSpeed`-over-ocean, methane retrieval, sea-ice forcing on the atmosphere, etc.) by collapsing them into one cross-domain home with a clear disambiguation rule (the variable being *operated on* decides the file, not the variable being *produced*).
+- Today's `atm/`, `ocn/`, `ice/`, `rs/` are empty namespaces — premature partitioning.
+- One module surface to document; one place to look.
+- A researcher who wants ocean physics imports `xr_toolz.kinematics.ocean.GeostrophicVelocities` — barely longer than `xr_toolz.ocn.GeostrophicVelocities` and the home is unambiguous.
+
+**Consequences:**
+- The `xr_toolz/atm/`, `xr_toolz/ocn/`, `xr_toolz/ice/`, `xr_toolz/rs/` packages are removed. Existing (currently minimal) code in `ocn/` migrates into `kinematics/_src/ocean.py`.
+- A new `xr_toolz.kinematics` top-level module is reserved.
+- Cross-domain operators that genuinely don't fit one file (rare) get a `kinematics/_src/shared.py`.
+- Future domain growth (e.g., a `methane.py` if methane-retrieval operators get plentiful) is a new file in the same module, not a new top-level submodule.
+
+---
+
+## D10: Viz operators are first-class `Operator`s that return `Figure` / `Axes`
+
+**Status:** accepted (resolved 2026-04-25)
+
+**Context:** Plotting (`PlotMap`, `PlotSpectrum`, `PlotTimeseries`, `QuicklookPanel`, etc.) produces `matplotlib.Figure` / `Axes`, not `xr.Dataset`. The base contract states single-input operators are `Dataset → Dataset`. How are viz operators integrated?
+
+**Options:**
+- (A) Viz are `Operator` subclasses that return `Figure` / `Axes`. Documented exception to `Dataset → Dataset`. Compose inside `Sequential` (as terminal nodes) and `Graph` (as one of N outputs)
+- (B) Separate `Plotter` protocol — viz lives outside the `Operator` system, called after a pipeline runs
+- (C) Mutating viz — `Operator` returns the Dataset unchanged with a side-effecting figure
+
+**Decision:** Option A.
+
+- `xr_toolz.viz` operators are `Operator` subclasses with `__call__(ds) → matplotlib.Figure | matplotlib.Axes`.
+- The `Operator` contract (architecture.md) is amended: terminal viz operators are an explicit exception to `Dataset → Dataset`.
+- They compose inside `Graph` as terminal output nodes — the motivating use case is end-to-end evaluation graphs that emit both scalar scores and figures from one symbolic computation: `Graph(inputs={"pred": …, "ref": …}, outputs={"rmse": rmse_node, "psd_score": psd_node, "psd_fig": plot_psd_node})`.
+- They compose inside `Sequential` only as the **last** step. A `Sequential` that emits a non-`Dataset` from a non-final step is a runtime error.
+
+Rationale:
+- Real end-to-end pattern: sequential preprocessing → graph that branches into both metrics and figures. Forcing viz into a parallel surface (Option B) means hand-wiring the figure side, defeating the symbolic-graph payoff.
+- Option C (mutating, attaching figures to `attrs`) is a memory hazard and surprising — rejected.
+- Option A's downside (the contract gets one exception) is small and well-localized to one module.
+
+**Consequences:**
+- `xr_toolz/viz/` is a new top-level submodule.
+- `Sequential` validates that any non-`Dataset` return appears only at the final step; otherwise raises a clear error.
+- `Graph` already supports heterogeneous output types — no change needed.
+- Documented operator-contract exception in [architecture.md §Operator](architecture.md): "Terminal viz operators may return `Figure` / `Axes`".
+- Plot operators carry their config (`figsize`, `cmap`, `projection`, …) so they're hydra-serializable like any other operator.
+


### PR DESCRIPTION
## Summary

Records four xr_toolz-internal design decisions that came out of a planning conversation around the next round of submodules. **Docs only — no code changes.**

- **D7** — `metrics`: own the implementation, two-layer (functions + Operator). No `xskillscore` dependency. Layer 0 pure functions in `metrics/_src/{pixel,spectral,multiscale,distributional,masked}.py`; Layer 1 Operator wrappers; generic `MetricOp(fn, …)` for one-off custom scores.
- **D8** — encoders home: all encoders move under `xr_toolz.transforms.encoders`, sub-organized into `coord_space.py`, `coord_time.py`, `basis.py`. The standalone `spectral` section is folded into `transforms.fourier`.
- **D9** — domain stubs collapse: `xr_toolz.atm/`, `xr_toolz.ocn/`, `xr_toolz.ice/`, `xr_toolz.rs/` become one `xr_toolz.kinematics/_src/{ocean,atmosphere,ice,remote}.py` with a clear "the variable being operated on decides the file" disambiguation rule.
- **D10** — viz operators are first-class `Operator`s that return `matplotlib.Figure` / `Axes`. Documented exception to `Dataset → Dataset`. `Sequential` enforces the rule "non-Dataset returns only at the final step".

### Files changed

- `docs/design/decisions.md` — appends D7–D10
- `docs/design/architecture.md` — Operator base-class docstring updated for the viz exception; `Sequential.__call__` example gains the type-rule check; new "Type rule (D10)" paragraph; header note refreshed to point at the new `kinematics` / `transforms` / `metrics` / `viz` layout (was pointing at the now-defunct `ocn` / `atm` / `rs` split)
- `docs/design/api/components.md` — rewrites: `transforms` (absorbs encoders + spectral, sub-organized by category), `metrics` (two-layer pattern with custom-score extension example), `kinematics` (one file per domain with disambiguation rule), new `viz` section with end-to-end Sequential→Graph example, `extremes` becomes a deferred pointer to xtremax. Header note refreshed.

### Out of scope

Implementation lands in follow-up PRs — this is the design-record commit.

## Test plan

- [x] `uv run mkdocs build --strict` — net-zero new warnings vs. `main` (3 pre-existing warnings remain: `CHANGELOG.md` nav reference, `index.md → CHANGELOG.md`, `architecture.md → ../xarray_sklearn/README.md`)
- [x] `uv run --group lint ruff check .` — clean
- [x] `uv run --group lint ruff format --check .` — clean
- [ ] Spot-check rendered pages on `mkdocs serve` (D7 / D8 / D9 / D10 sections in decisions.md, the new `transforms` / `metrics` / `kinematics` / `viz` sections in components.md, the Type-rule paragraph in architecture.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)