### PR TITLE
docs(design): add validation framework design docs

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -22,6 +22,11 @@ version: 0.1.0
     and as `xr_toolz.<domain>.<topic>` for the physics chapters in
     `kinematics`.
 
+!!! note "Validation expansion"
+    The validation additions extend the existing design docs. Existing
+    examples in primitives, components, models, and integration should
+    remain unchanged. New validation examples live in additional files.
+
 ## Structure
 
 ```
@@ -29,18 +34,24 @@ geo_toolz/
 ├── README.md              # This file
 ├── vision.md              # Motivation, user stories, design principles, identity
 ├── architecture.md        # Three-layer stack, Operator model, Graph API, inference, dependencies
+├── validation.md          # Validation philosophy: scale, data, physical, process, phenomena
 ├── boundaries.md          # Ownership, ecosystem, scope, testing strategy, roadmap
 ├── api/
 │   ├── README.md          # Submodule inventory, notation, import conventions
 │   ├── primitives.md      # Layer 0 — pure functions by submodule
 │   ├── components.md      # Layer 1 — Operator classes by submodule
-│   └── models.md          # Layer 2 — Graph API, ModelOp, inference
+│   ├── models.md          # Layer 2 — Graph API, ModelOp, inference
+│   └── validation.md      # Validation API map by scientific question
 ├── examples/
 │   ├── README.md          # Index and reading order
 │   ├── primitives.md      # Layer 0 — pure function pipelines, pipe syntax
 │   ├── components.md      # Layer 1 — Sequential, operator composition, Hydra
 │   ├── models.md          # Layer 2 — Graph API, inference, model comparison
-│   └── integration.md     # Layer 3 — sklearn, xrpatcher, xarray_sklearn, ekalmX
+│   ├── integration.md     # Layer 3 — sklearn, xrpatcher, xarray_sklearn, ekalmX
+│   ├── validation.md      # Field, spectral, lead-time, structural, process examples
+│   ├── lagrangian.md      # Particle and drifter-style transport diagnostics
+│   ├── budgets.md         # Heat/salt/volume/energy budget residual examples
+│   └── phenomena.md       # Event/object detection and verification examples
 └── decisions.md           # Design decisions with rationale
 ```
 
@@ -48,8 +59,9 @@ geo_toolz/
 
 1. **[vision.md](vision.md)** — understand the why
 2. **[architecture.md](architecture.md)** — understand the three-layer stack
-3. **[boundaries.md](boundaries.md)** — understand the scope
-4. **[api/README.md](api/README.md)** — scan the surface
-5. **[api/primitives.md](api/primitives.md)** → **[components.md](api/components.md)** → **[models.md](api/models.md)** — drill into detail
-6. **[examples/primitives.md](examples/primitives.md)** → **[components.md](examples/components.md)** → **[models.md](examples/models.md)** → **[integration.md](examples/integration.md)** — see it in action
-7. **[decisions.md](decisions.md)** — understand the tradeoffs
+3. **[validation.md](validation.md)** — understand the expanded validation philosophy
+4. **[boundaries.md](boundaries.md)** — understand the scope
+5. **[api/README.md](api/README.md)** — scan the surface
+6. **[api/primitives.md](api/primitives.md)** → **[components.md](api/components.md)** → **[models.md](api/models.md)** → **[validation.md](api/validation.md)** — drill into detail
+7. **[examples/primitives.md](examples/primitives.md)** → **[components.md](examples/components.md)** → **[models.md](examples/models.md)** → **[integration.md](examples/integration.md)** → **[validation.md](examples/validation.md)** — see it in action
+8. **[decisions.md](decisions.md)** — understand the tradeoffs

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -52,7 +52,8 @@ geo_toolz/
 │   ├── lagrangian.md      # Particle and drifter-style transport diagnostics
 │   ├── budgets.md         # Heat/salt/volume/energy budget residual examples
 │   └── phenomena.md       # Event/object detection and verification examples
-└── decisions.md           # Design decisions with rationale
+├── decisions.md           # Design decisions D1–D10 (existing tradeoffs)
+└── validation-decisions.md # Design decisions D11–D15 (validation framework)
 ```
 
 ## Reading Order
@@ -64,4 +65,5 @@ geo_toolz/
 5. **[api/README.md](api/README.md)** — scan the surface
 6. **[api/primitives.md](api/primitives.md)** → **[components.md](api/components.md)** → **[models.md](api/models.md)** → **[validation.md](api/validation.md)** — drill into detail
 7. **[examples/primitives.md](examples/primitives.md)** → **[components.md](examples/components.md)** → **[models.md](examples/models.md)** → **[integration.md](examples/integration.md)** → **[validation.md](examples/validation.md)** — see it in action
-8. **[decisions.md](decisions.md)** — understand the tradeoffs
+8. **[decisions.md](decisions.md)** — D1–D10 architectural tradeoffs
+9. **[validation-decisions.md](validation-decisions.md)** — D11–D15 validation framework decisions

--- a/docs/design/api/README.md
+++ b/docs/design/api/README.md
@@ -56,7 +56,7 @@ Each submodule provides Layer 0 pure functions and Layer 1 Operator wrappers. La
 | `lagrangian` | Particle and transport diagnostics | `advect_particles`, `pair_dispersion`, `residence_time`, `ftle` | `AdvectParticles`, `PairDispersion`, `FTLE` | v0.4 |
 | `budgets` | Control-volume and conservation diagnostics | `budget_residual`, `heat_budget_residual`, `salt_budget_residual` | `BudgetResidual`, `HeatBudgetResidual` | v0.4 |
 | `phenomena` | Object/event detection and matching | `detect_marine_heatwaves`, `detect_eddies`, `match_objects` | `DetectMarineHeatwaves`, `DetectEddies`, `MatchObjects` | v0.4 |
-| `metrics.object` | Event/object verification scores | `contingency_table`, `pod`, `far`, `csi`, `iou` | `POD`, `FAR`, `CSI`, `IoU` | v0.4 |
+| `metrics.object` | Event/object verification scores | `contingency_table`, `pod`, `far`, `csi`, `iou` | `ProbabilityOfDetection`, `FalseAlarmRatio`, `CriticalSuccessIndex`, `IntersectionOverUnion` | v0.4 |
 
 **Status key:** `v0.1` = Foundation | `v0.2` = Analysis + Inference | `v0.3` = Domain Operators + expanded metrics | `v0.4+` = Validation expansion
 

--- a/docs/design/api/README.md
+++ b/docs/design/api/README.md
@@ -49,8 +49,16 @@ Each submodule provides Layer 0 pure functions and Layer 1 Operator wrappers. La
 | `kinematics` | Physical quantities | `streamfunction`, `geostrophic_velocity`, ... | `Streamfunction`, `GeostrophicVelocity`, ... | v0.3 |
 | `crs` | CRS transforms | `assign_crs`, `reproject`, ... | `AssignCRS`, `Reproject` | v0.3 |
 | `sklearn` | sklearn interop | `to_2d`, `from_2d` | `SklearnOp` | v0.3 |
+| `metrics.structural` | Structural/geometric skill metrics | `ssim`, `centroid_displacement`, `phase_shift_error` | `SSIM`, `CentroidDisplacement`, `PhaseShiftError` | v0.3 |
+| `metrics.forecast` | Lead-time and forecast-horizon diagnostics | `skill_by_lead_time`, `rmse_by_lead`, `acc_by_lead` | `SkillByLeadTime`, `RMSEByLead` | v0.3 |
+| `metrics.probabilistic` | Ensemble and probabilistic forecast verification | `crps`, `spread_skill_ratio`, `rank_histogram`, `ensemble_coverage` | `CRPS`, `SpreadSkillRatio`, `RankHistogram` | v0.3 |
+| `metrics.physical` | Physical consistency scores | `geostrophic_balance_error`, `divergence_error`, `vorticity_error` | `GeostrophicBalanceError`, `DivergenceError` | v0.3 |
+| `lagrangian` | Particle and transport diagnostics | `advect_particles`, `pair_dispersion`, `residence_time`, `ftle` | `AdvectParticles`, `PairDispersion`, `FTLE` | v0.4 |
+| `budgets` | Control-volume and conservation diagnostics | `budget_residual`, `heat_budget_residual`, `salt_budget_residual` | `BudgetResidual`, `HeatBudgetResidual` | v0.4 |
+| `phenomena` | Object/event detection and matching | `detect_marine_heatwaves`, `detect_eddies`, `match_objects` | `DetectMarineHeatwaves`, `DetectEddies`, `MatchObjects` | v0.4 |
+| `metrics.object` | Event/object verification scores | `contingency_table`, `pod`, `far`, `csi`, `iou` | `POD`, `FAR`, `CSI`, `IoU` | v0.4 |
 
-**Status key:** `v0.1` = Foundation | `v0.2` = Analysis + Inference | `v0.3` = Domain Operators | `v0.4+` = Expansion
+**Status key:** `v0.1` = Foundation | `v0.2` = Analysis + Inference | `v0.3` = Domain Operators + expanded metrics | `v0.4+` = Validation expansion
 
 ---
 
@@ -83,6 +91,13 @@ from geo_toolz.regrid import Regrid
 from geo_toolz.detrend import CalculateClimatology, RemoveClimatology
 from geo_toolz.metrics import RMSE, PSDScore
 
+# Expanded validation operators
+from geo_toolz.metrics.forecast import RMSEByLead
+from geo_toolz.metrics.structural import SSIM
+from geo_toolz.lagrangian import AdvectParticles
+from geo_toolz.budgets import HeatBudgetResidual
+from geo_toolz.phenomena import DetectMarineHeatwaves
+
 # Inference
 from geo_toolz.inference import ModelOp, SklearnModelOp, JaxModelOp
 
@@ -99,6 +114,7 @@ from geo_toolz._src.detrend.climatology import calculate_climatology, remove_cli
 | [primitives.md](primitives.md) | Layer 0 — pure functions by submodule (validation, subset, regrid, detrend, ...) |
 | [components.md](components.md) | Layer 1 — Operator classes by submodule, Operator base class |
 | [models.md](models.md) | Layer 2 — Graph API (Node, Input, Graph), ModelOp, inference wrappers |
+| [validation.md](validation.md) | Validation API map by scientific question and metric family |
 
 ---
 

--- a/docs/design/api/validation.md
+++ b/docs/design/api/validation.md
@@ -1,0 +1,256 @@
+---
+status: draft
+version: 0.2.0
+---
+
+# Validation API Map
+
+This page maps scientific validation questions to the proposed `xr_toolz` API surface. It complements [`primitives.md`](primitives.md), [`components.md`](components.md), and the top-level [`validation.md`](../validation.md) design note.
+
+---
+
+## User Story
+
+As a user, I want one place to understand which validation tool to use for which scientific question, so that I can compose appropriate diagnostics without searching through every submodule.
+
+## Motivation
+
+Validation is broader than scalar metrics. A complete geoscience ML evaluation may need pointwise error, spectral fidelity, structural similarity, ensemble calibration, physical balances, conservation budgets, Lagrangian transport, and event verification.
+
+---
+
+## Which Diagnostic Should I Use?
+
+| Scientific question | Module | Operators / functions |
+|---|---|---|
+| Are grid values accurate? | `xr_toolz.metrics.pixel` | `RMSE`, `MAE`, `Bias`, `Correlation`, `NashSutcliffe` |
+| Are scales resolved? | `xr_toolz.metrics.spectral`, `xr_toolz.metrics.multiscale` | `PSDScore`, `ResolvedScale`, `CoherenceSkill`, `PerScaleRMSE`, `WaveletRMSE` |
+| Does skill depend on forecast horizon? | `xr_toolz.metrics.forecast` | `SkillByLeadTime`, `RMSEByLead`, `AnomalyCorrelationByLead`, `SpectralSkillByLead` |
+| Does skill vary by region or regime? | `xr_toolz.metrics.scale`, `xr_toolz.geo.masks` | `EvaluateByRegion`, `FrequencyBandSkill`, `BandLimitedRMSE`, `AddRegionMask` |
+| Is an ensemble calibrated? | `xr_toolz.metrics.probabilistic` | `CRPS`, `SpreadSkillRatio`, `RankHistogram`, `EnsembleCoverage`, `ReliabilityCurve` |
+| Are structures displaced or blurred? | `xr_toolz.metrics.structural` | `SSIM`, `GradientDifference`, `PhaseShiftError`, `CentroidDisplacement` |
+| Are physical balances respected? | `xr_toolz.metrics.physical`, `xr_toolz.kinematics` | `GeostrophicBalanceError`, `DivergenceError`, `VorticityError`, `KineticEnergyError` |
+| Are budgets closed? | `xr_toolz.budgets` | `ControlVolumeIntegral`, `BoundaryFlux`, `HeatBudgetResidual`, `SaltBudgetResidual`, `VolumeBudgetResidual`, `KineticEnergyBudgetResidual` |
+| Is material transport realistic? | `xr_toolz.lagrangian`, `xr_toolz.metrics.lagrangian` | `AdvectParticles`, `PairDispersion`, `ResidenceTime`, `ConnectivityMatrix`, `FTLE`, `EndpointError` |
+| Are events captured? | `xr_toolz.phenomena`, `xr_toolz.metrics.object` | `DetectMarineHeatwaves`, `DetectEddies`, `DetectFronts`, `MatchObjects`, `POD`, `FAR`, `CSI`, `IoU` |
+| Do diagnostics need plots? | `xr_toolz.viz.validation` | `ScaleSkillPanel`, `SpectralSkillPanel`, `LeadTimeSkillPanel`, `ProcessBudgetPanel`, `EventVerificationPanel` |
+
+---
+
+## Recommended Validation Families
+
+### 1. Baseline field scores
+
+#### User Story
+
+As an ML researcher, I want standard pointwise scores as a baseline, so that new diagnostics can be compared against familiar scalar metrics.
+
+#### Motivation
+
+RMSE, MAE, bias, correlation, and NSE remain useful, but they should be treated as baseline diagnostics rather than sufficient validation.
+
+#### Demo API
+
+```python
+from xr_toolz.metrics import RMSE, MAE, Bias, Correlation, NashSutcliffe
+```
+
+#### Demo Example Usage
+
+```python
+rmse = RMSE(variable="ssh", dims=("time", "lat", "lon"))(ds_pred, ds_ref)
+bias = Bias(variable="ssh", dims=("time", "lat", "lon"))(ds_pred, ds_ref)
+```
+
+---
+
+### 2. Scale-aware validation
+
+#### User Story
+
+As a forecasting researcher, I want to evaluate by lead time, spatial scale, temporal scale, and region, so that aggregate scores do not hide scale-dependent failures.
+
+#### Motivation
+
+A model may have good global RMSE while underrepresenting high-wavenumber variance, failing in coastal regimes, or degrading rapidly with forecast horizon.
+
+#### Demo API
+
+```python
+from xr_toolz.metrics.forecast import SkillByLeadTime, RMSEByLead, AnomalyCorrelationByLead
+from xr_toolz.metrics.scale import EvaluateByRegion, FrequencyBandSkill
+from xr_toolz.metrics.spectral import PSDScore, ResolvedScale
+```
+
+#### Demo Example Usage
+
+```python
+lead_rmse = RMSEByLead(variable="ssh", dims=("lat", "lon"), lead_dim="lead_time")(forecast, reference)
+regional_skill = EvaluateByRegion(metric=RMSE(variable="ssh", dims=("time",)), regions=region_masks)(forecast, reference)
+```
+
+---
+
+### 3. Probabilistic validation
+
+#### User Story
+
+As a probabilistic modeler, I want to evaluate calibration, sharpness, spread, and coverage, so that ensemble forecasts are judged as probability distributions rather than deterministic means.
+
+#### Motivation
+
+Chaotic geophysical systems require uncertainty-aware evaluation. CRPS, rank histograms, reliability curves, and coverage scores reveal underdispersion, overdispersion, and calibration errors.
+
+#### Demo API
+
+```python
+from xr_toolz.metrics.probabilistic import CRPS, SpreadSkillRatio, RankHistogram, EnsembleCoverage, ReliabilityCurve
+```
+
+#### Demo Example Usage
+
+```python
+crps = CRPS(variable="ssh", ensemble_dim="member", dims=("time", "lat", "lon"))(ensemble, reference)
+coverage = EnsembleCoverage(variable="ssh", q=(0.05, 0.95), ensemble_dim="member")(ensemble, reference)
+```
+
+---
+
+### 4. Structural validation
+
+#### User Story
+
+As an ocean ML researcher, I want structural and displacement-aware metrics, so that coherent but shifted eddies, fronts, or plumes are not treated the same as missing features.
+
+#### Motivation
+
+Pointwise metrics have a double-penalty problem for displaced coherent structures. Structural metrics diagnose geometry, phase, and morphology.
+
+#### Demo API
+
+```python
+from xr_toolz.metrics.structural import SSIM, GradientDifference, PhaseShiftError, CentroidDisplacement
+```
+
+#### Demo Example Usage
+
+```python
+ssim = SSIM(variable="ssh", dims=("lat", "lon"))(ds_pred, ds_ref)
+phase = PhaseShiftError(variable="ssh", dims=("lat", "lon"))(ds_pred, ds_ref)
+```
+
+---
+
+### 5. Physical and process validation
+
+#### User Story
+
+As a physical scientist, I want to evaluate geophysical balances, density structure, and conservation budgets, so that model skill reflects physical consistency.
+
+#### Motivation
+
+Good short-range errors do not guarantee physically plausible dynamics. Balance residuals, density checks, and control-volume budgets diagnose whether predictions obey the structure of the underlying system.
+
+#### Demo API
+
+```python
+from xr_toolz.metrics.physical import GeostrophicBalanceError, DivergenceError, DensityInversionFraction
+from xr_toolz.budgets import HeatBudgetResidual, SaltBudgetResidual, VolumeBudgetResidual, ControlVolumeIntegral
+```
+
+#### Demo Example Usage
+
+```python
+geo = GeostrophicBalanceError(ssh_var="ssh", u_var="u", v_var="v")(ds_pred)
+heat = HeatBudgetResidual(temp_var="theta", u_var="u", v_var="v", surface_flux_var="qnet")(ds_pred)
+```
+
+---
+
+### 6. Lagrangian validation
+
+#### User Story
+
+As a transport researcher, I want to advect particles through predicted and reference velocity fields, so that I can compare trajectories, dispersion, residence times, and connectivity.
+
+#### Motivation
+
+Eulerian field agreement does not guarantee material transport fidelity. Lagrangian diagnostics reveal errors that accumulate along parcel pathways.
+
+#### Demo API
+
+```python
+from xr_toolz.lagrangian import SeedParticles, AdvectParticles, PairDispersion, ResidenceTime, ConnectivityMatrix, FTLE
+from xr_toolz.metrics.lagrangian import EndpointError, TrajectoryRMSE, DispersionError
+```
+
+#### Demo Example Usage
+
+```python
+particles = SeedParticles(strategy="grid", spacing=0.25, region=med_mask)(ds_ref)
+traj_pred = AdvectParticles(u_var="u", v_var="v", dt="1h", steps=240)(ds_pred, particles)
+traj_ref = AdvectParticles(u_var="u", v_var="v", dt="1h", steps=240)(ds_ref, particles)
+endpoint = EndpointError()(traj_pred, traj_ref)
+```
+
+---
+
+### 7. Phenomena-based validation
+
+#### User Story
+
+As an applied scientist, I want to detect and verify events such as marine heatwaves, eddies, fronts, and upwelling events, so that model evaluation reflects scientifically meaningful phenomena.
+
+#### Motivation
+
+Event verification checks whether the model represents discrete structures in space and time, not only whether the continuous field has low average error.
+
+#### Demo API
+
+```python
+from xr_toolz.phenomena import EventDefinition, DetectMarineHeatwaves, DetectEddies, DetectFronts, MatchObjects
+from xr_toolz.metrics.object import ProbabilityOfDetection, FalseAlarmRatio, CriticalSuccessIndex, IntersectionOverUnion
+```
+
+#### Demo Example Usage
+
+```python
+events_pred = DetectMarineHeatwaves(sst_var="sst", climatology=sst_clim, percentile=90, min_duration=5)(ds_pred)
+events_ref = DetectMarineHeatwaves(sst_var="sst", climatology=sst_clim, percentile=90, min_duration=5)(ds_ref)
+matches = MatchObjects(method="iou", threshold=0.2)(events_pred, events_ref)
+
+csi = CriticalSuccessIndex()(matches)
+iou = IntersectionOverUnion()(matches)
+```
+
+---
+
+## End-to-End Validation Graph
+
+```python
+from xr_toolz.core import Graph, Input
+from xr_toolz.metrics import RMSE, PSDScore
+from xr_toolz.metrics.forecast import RMSEByLead
+from xr_toolz.metrics.structural import SSIM
+from xr_toolz.budgets import HeatBudgetResidual
+
+pred = Input("prediction")
+ref = Input("reference")
+
+rmse = RMSE(variable="ssh", dims=("time", "lat", "lon"))(pred, ref)
+psd = PSDScore(variable="ssh", dims=("lat", "lon"))(pred, ref)
+lead = RMSEByLead(variable="ssh", dims=("lat", "lon"), lead_dim="lead_time")(pred, ref)
+structure = SSIM(variable="ssh", dims=("lat", "lon"))(pred, ref)
+heat_budget = HeatBudgetResidual(temp_var="theta", u_var="u", v_var="v")(pred)
+
+validation = Graph(
+    inputs={"prediction": pred, "reference": ref},
+    outputs={
+        "rmse": rmse,
+        "psd": psd,
+        "lead_rmse": lead,
+        "ssim": structure,
+        "heat_budget": heat_budget,
+    },
+)
+```

--- a/docs/design/api/validation.md
+++ b/docs/design/api/validation.md
@@ -3,6 +3,14 @@ status: draft
 version: 0.2.0
 ---
 
+!!! note "Module paths shown are proposed design targets"
+    The submodules referenced on this page (`xr_toolz.metrics.*`,
+    `xr_toolz.budgets`, `xr_toolz.phenomena`, `xr_toolz.lagrangian`,
+    `xr_toolz.viz.validation`, …) are **proposed** layouts and **are not part of
+    the current export surface**. Today, most domain-agnostic functionality
+    still lives under `xr_toolz.geo.*`. Treat the imports below as design-target
+    aliases; once the proposed modules ship, the snippets become copy/paste-ready.
+
 # Validation API Map
 
 This page maps scientific validation questions to the proposed `xr_toolz` API surface. It complements [`primitives.md`](primitives.md), [`components.md`](components.md), and the top-level [`validation.md`](../validation.md) design note.
@@ -26,13 +34,13 @@ Validation is broader than scalar metrics. A complete geoscience ML evaluation m
 | Are grid values accurate? | `xr_toolz.metrics.pixel` | `RMSE`, `MAE`, `Bias`, `Correlation`, `NashSutcliffe` |
 | Are scales resolved? | `xr_toolz.metrics.spectral`, `xr_toolz.metrics.multiscale` | `PSDScore`, `ResolvedScale`, `CoherenceSkill`, `PerScaleRMSE`, `WaveletRMSE` |
 | Does skill depend on forecast horizon? | `xr_toolz.metrics.forecast` | `SkillByLeadTime`, `RMSEByLead`, `AnomalyCorrelationByLead`, `SpectralSkillByLead` |
-| Does skill vary by region or regime? | `xr_toolz.metrics.scale`, `xr_toolz.geo.masks` | `EvaluateByRegion`, `FrequencyBandSkill`, `BandLimitedRMSE`, `AddRegionMask` |
+| Does skill vary by region or regime? | `xr_toolz.metrics.multiscale`, `xr_toolz.metrics.spectral`, `xr_toolz.geo.masks` | `EvaluateByRegion`, `FrequencyBandSkill`, `BandLimitedRMSE`, `AddRegionMask` |
 | Is an ensemble calibrated? | `xr_toolz.metrics.probabilistic` | `CRPS`, `SpreadSkillRatio`, `RankHistogram`, `EnsembleCoverage`, `ReliabilityCurve` |
 | Are structures displaced or blurred? | `xr_toolz.metrics.structural` | `SSIM`, `GradientDifference`, `PhaseShiftError`, `CentroidDisplacement` |
 | Are physical balances respected? | `xr_toolz.metrics.physical`, `xr_toolz.kinematics` | `GeostrophicBalanceError`, `DivergenceError`, `VorticityError`, `KineticEnergyError` |
 | Are budgets closed? | `xr_toolz.budgets` | `ControlVolumeIntegral`, `BoundaryFlux`, `HeatBudgetResidual`, `SaltBudgetResidual`, `VolumeBudgetResidual`, `KineticEnergyBudgetResidual` |
 | Is material transport realistic? | `xr_toolz.lagrangian`, `xr_toolz.metrics.lagrangian` | `AdvectParticles`, `PairDispersion`, `ResidenceTime`, `ConnectivityMatrix`, `FTLE`, `EndpointError` |
-| Are events captured? | `xr_toolz.phenomena`, `xr_toolz.metrics.object` | `DetectMarineHeatwaves`, `DetectEddies`, `DetectFronts`, `MatchObjects`, `POD`, `FAR`, `CSI`, `IoU` |
+| Are events captured? | `xr_toolz.phenomena`, `xr_toolz.metrics.object` | `DetectMarineHeatwaves`, `DetectEddies`, `DetectFronts`, `MatchObjects`, `ProbabilityOfDetection`, `FalseAlarmRatio`, `CriticalSuccessIndex`, `IntersectionOverUnion` |
 | Do diagnostics need plots? | `xr_toolz.viz.validation` | `ScaleSkillPanel`, `SpectralSkillPanel`, `LeadTimeSkillPanel`, `ProcessBudgetPanel`, `EventVerificationPanel` |
 
 ---
@@ -78,7 +86,8 @@ A model may have good global RMSE while underrepresenting high-wavenumber varian
 
 ```python
 from xr_toolz.metrics.forecast import SkillByLeadTime, RMSEByLead, AnomalyCorrelationByLead
-from xr_toolz.metrics.scale import EvaluateByRegion, FrequencyBandSkill
+from xr_toolz.metrics.multiscale import EvaluateByRegion
+from xr_toolz.metrics.spectral import FrequencyBandSkill
 from xr_toolz.metrics.spectral import PSDScore, ResolvedScale
 ```
 

--- a/docs/design/examples/README.md
+++ b/docs/design/examples/README.md
@@ -28,7 +28,11 @@ examples/
 ├── primitives.md          # Layer 0 — pure functions, pipe syntax, toolz composition
 ├── components.md          # Layer 1 — Sequential, operator composition, Hydra, stateful ops
 ├── models.md              # Layer 2 — Graph API, inference, model comparison
-└── integration.md         # Layer 3 — sklearn, xrpatcher, xarray_sklearn, ekalmX
+├── integration.md         # Layer 3 — sklearn, xrpatcher, xarray_sklearn, ekalmX
+├── validation.md          # Expanded validation graphs and skill diagnostics
+├── lagrangian.md          # Particle, trajectory, dispersion, and connectivity examples
+├── budgets.md             # Conservation and control-volume budget examples
+└── phenomena.md           # Event/object detection and verification examples
 ```
 
 ## Reading Order
@@ -37,3 +41,14 @@ examples/
 2. **[components.md](components.md)** — L1: Sequential pipelines and operator patterns
 3. **[models.md](models.md)** — L2: Graph API, ModelOp, model comparison
 4. **[integration.md](integration.md)** — L3: sklearn, xrpatcher, xarray_sklearn, ecosystem
+5. **[validation.md](validation.md)** — validation graphs and field/spectral/structural/process diagnostics
+6. **[lagrangian.md](lagrangian.md)** — material transport and trajectory diagnostics
+7. **[budgets.md](budgets.md)** — heat, salt, volume, and kinetic-energy budgets
+8. **[phenomena.md](phenomena.md)** — marine heatwave, eddy, and generic event verification
+
+## Validation Examples
+
+- **[validation.md](validation.md)** — end-to-end validation examples with pixel, spectral, lead-time, structural, probabilistic, regional, and process scores.
+- **[lagrangian.md](lagrangian.md)** — particle advection, endpoint error, pair dispersion, residence time, connectivity, and FTLE-style diagnostics.
+- **[budgets.md](budgets.md)** — control-volume heat, salt, volume, and kinetic-energy budget residual examples.
+- **[phenomena.md](phenomena.md)** — marine heatwave, eddy, generic event, and event-graph verification examples.

--- a/docs/design/examples/budgets.md
+++ b/docs/design/examples/budgets.md
@@ -3,6 +3,14 @@ status: draft
 version: 0.2.0
 ---
 
+!!! note "Module paths shown are proposed design targets"
+    The snippets below import from `xr_toolz.budgets`, `xr_toolz.metrics.*`, and other
+    submodules that **do not exist in the current export surface** — the current
+    domain-agnostic functionality still lives under `xr_toolz.geo.*`. Treat these
+    imports as design-target aliases; once the modules ship the snippets become
+    copy/paste-ready, but until then map each `xr_toolz.<topic>` path to its
+    equivalent under today's `xr_toolz.geo.<topic>`.
+
 # Budget Validation Examples
 
 Budget validation checks whether predicted fields satisfy finite-volume conservation constraints. These diagnostics are especially useful for long autoregressive rollouts, coupled fields, and physically interpretable ML models.

--- a/docs/design/examples/budgets.md
+++ b/docs/design/examples/budgets.md
@@ -1,0 +1,139 @@
+---
+status: draft
+version: 0.2.0
+---
+
+# Budget Validation Examples
+
+Budget validation checks whether predicted fields satisfy finite-volume conservation constraints. These diagnostics are especially useful for long autoregressive rollouts, coupled fields, and physically interpretable ML models.
+
+---
+
+## Example 1: Heat Budget Residual
+
+### User Story
+
+As a physical oceanographer, I want to know whether predicted temperature evolution is consistent with advection and surface heat fluxes, so that short-term field skill does not hide long-term heat drift.
+
+### Motivation
+
+A model can have good pointwise temperature skill while violating heat conservation. Budget residuals expose whether errors accumulate as physically meaningful drift.
+
+### Demo API
+
+```python
+from xr_toolz.budgets import HeatBudgetResidual, ControlVolumeIntegral
+```
+
+### Demo Example Usage
+
+```python
+heat_residual = HeatBudgetResidual(
+    temp_var="theta",
+    u_var="u",
+    v_var="v",
+    surface_flux_var="qnet",
+)(ds_pred)
+
+regional_drift = ControlVolumeIntegral(
+    variable="heat_budget_residual",
+    volume_metrics=grid_metrics,
+    region=med_mask,
+)(heat_residual.to_dataset(name="heat_budget_residual"))
+```
+
+---
+
+## Example 2: Salt Budget Residual
+
+### User Story
+
+As an ocean model evaluator, I want to check whether predicted salinity changes are consistent with transport and surface freshwater forcing, so that spurious water-mass modification is detected.
+
+### Motivation
+
+Salt budgets diagnose water-mass consistency and can reveal unphysical mixing or drift that is not captured by a single salinity RMSE.
+
+### Demo API
+
+```python
+from xr_toolz.budgets import SaltBudgetResidual, ControlVolumeIntegral
+```
+
+### Demo Example Usage
+
+```python
+salt_residual = SaltBudgetResidual(
+    salt_var="so",
+    u_var="u",
+    v_var="v",
+    surface_flux_var="fwf",
+)(ds_pred)
+
+salt_drift = ControlVolumeIntegral(
+    variable="salt_budget_residual",
+    volume_metrics=grid_metrics,
+    region=basin_mask,
+)(salt_residual.to_dataset(name="salt_budget_residual"))
+```
+
+---
+
+## Example 3: Volume Continuity Residual
+
+### User Story
+
+As a model developer, I want to check volume continuity, so that predicted velocity fields do not imply unphysical sources or sinks of water.
+
+### Motivation
+
+Continuity residuals diagnose mass/volume conservation and are a useful complement to velocity RMSE, especially for learned velocity fields.
+
+### Demo API
+
+```python
+from xr_toolz.budgets import VolumeBudgetResidual
+```
+
+### Demo Example Usage
+
+```python
+volume_residual = VolumeBudgetResidual(
+    u_var="u",
+    v_var="v",
+    w_var="w",
+)(ds_pred)
+```
+
+---
+
+## Example 4: Kinetic Energy Budget Residual
+
+### User Story
+
+As a dynamical oceanographer, I want to evaluate kinetic-energy production and dissipation consistency, so that model forecasts do not preserve low RMSE by introducing nonphysical energetics.
+
+### Motivation
+
+Energy diagnostics help determine whether the model reproduces realistic energy pathways, not merely visually plausible velocity snapshots.
+
+### Demo API
+
+```python
+from xr_toolz.budgets import KineticEnergyBudgetResidual
+from xr_toolz.viz.validation import ProcessBudgetPanel
+```
+
+### Demo Example Usage
+
+```python
+ke_residual = KineticEnergyBudgetResidual(
+    u_var="u",
+    v_var="v",
+    forcing_vars=["wind_stress_x", "wind_stress_y"],
+)(ds_pred)
+
+fig = ProcessBudgetPanel(budget_var="ke_budget_residual")(
+    ke_residual.to_dataset(name="ke_budget_residual")
+)
+```

--- a/docs/design/examples/lagrangian.md
+++ b/docs/design/examples/lagrangian.md
@@ -1,0 +1,131 @@
+---
+status: draft
+version: 0.2.0
+---
+
+# Lagrangian Validation Examples
+
+Lagrangian validation evaluates the material transport implied by predicted velocity fields. These examples complement Eulerian field metrics by focusing on trajectories, dispersion, residence times, and regional connectivity.
+
+---
+
+## Example 1: Particle Advection and Endpoint Error
+
+### User Story
+
+As a transport researcher, I want to compare particle trajectories under predicted and reference velocity fields, so that I can quantify accumulated pathway error.
+
+### Motivation
+
+Small Eulerian velocity errors can integrate into large Lagrangian trajectory errors. Endpoint error and trajectory RMSE provide direct diagnostics of transport realism.
+
+### Demo API
+
+```python
+from xr_toolz.lagrangian import SeedParticles, AdvectParticles
+from xr_toolz.metrics.lagrangian import EndpointError, TrajectoryRMSE
+```
+
+### Demo Example Usage
+
+```python
+particles = SeedParticles(strategy="grid", spacing=0.25, region=med_mask)(ds_ref)
+
+traj_pred = AdvectParticles(u_var="u", v_var="v", dt="1h", steps=240)(ds_pred, particles)
+traj_ref = AdvectParticles(u_var="u", v_var="v", dt="1h", steps=240)(ds_ref, particles)
+
+endpoint = EndpointError()(traj_pred, traj_ref)
+trajectory_rmse = TrajectoryRMSE(dims=("particle", "time"))(traj_pred, traj_ref)
+```
+
+---
+
+## Example 2: Pair Dispersion
+
+### User Story
+
+As a Lagrangian oceanographer, I want to compare pair dispersion statistics, so that I can evaluate whether the model reproduces scale-dependent spreading and mixing.
+
+### Motivation
+
+Pair dispersion measures how particle separations grow through time. It is sensitive to mesoscale and submesoscale transport errors that may be hidden in Eulerian RMSE.
+
+### Demo API
+
+```python
+from xr_toolz.lagrangian import PairDispersion
+from xr_toolz.metrics.lagrangian import DispersionError
+```
+
+### Demo Example Usage
+
+```python
+pair_pred = PairDispersion()(traj_pred)
+pair_ref = PairDispersion()(traj_ref)
+
+dispersion_error = DispersionError()(pair_pred, pair_ref)
+```
+
+---
+
+## Example 3: Residence Time and Connectivity
+
+### User Story
+
+As a regional oceanographer, I want to compare residence times and connectivity matrices, so that I can evaluate whether a model reproduces exchange pathways between basins or coastal regions.
+
+### Motivation
+
+Transport applications often care about where water parcels go and how long they remain in a region. These diagnostics are especially relevant for pollutant transport, biogeochemistry, marine ecology, and regional ocean circulation.
+
+### Demo API
+
+```python
+from xr_toolz.lagrangian import ResidenceTime, ConnectivityMatrix
+from xr_toolz.metrics.lagrangian import ResidenceTimeError, ConnectivityError
+```
+
+### Demo Example Usage
+
+```python
+residence_pred = ResidenceTime(regions=basin_masks)(traj_pred)
+residence_ref = ResidenceTime(regions=basin_masks)(traj_ref)
+residence_error = ResidenceTimeError()(residence_pred, residence_ref)
+
+connectivity_pred = ConnectivityMatrix(source_regions=basin_masks, target_regions=basin_masks)(traj_pred)
+connectivity_ref = ConnectivityMatrix(source_regions=basin_masks, target_regions=basin_masks)(traj_ref)
+connectivity_error = ConnectivityError()(connectivity_pred, connectivity_ref)
+```
+
+---
+
+## Example 4: FTLE and Transport Barriers
+
+### User Story
+
+As a dynamical-systems researcher, I want to compute FTLE-like diagnostics from predicted velocity fields, so that I can compare stretching, mixing, and transport-barrier structure.
+
+### Motivation
+
+Finite-time stretching diagnostics reveal coherent transport geometry. They can identify dynamically meaningful structures that are not obvious from fixed-grid error fields.
+
+### Demo API
+
+```python
+from xr_toolz.lagrangian import SeedParticles, FTLE
+from xr_toolz.metrics import RMSE
+```
+
+### Demo Example Usage
+
+```python
+particles = SeedParticles(strategy="grid", spacing=0.1, region=domain_mask)(ds_ref)
+
+ftle_pred = FTLE(integration_time="30D", u_var="u", v_var="v")(ds_pred, particles)
+ftle_ref = FTLE(integration_time="30D", u_var="u", v_var="v")(ds_ref, particles)
+
+ftle_error = RMSE(variable="ftle", dims=("lat", "lon"))(
+    ftle_pred.to_dataset(name="ftle"),
+    ftle_ref.to_dataset(name="ftle"),
+)
+```

--- a/docs/design/examples/lagrangian.md
+++ b/docs/design/examples/lagrangian.md
@@ -3,6 +3,13 @@ status: draft
 version: 0.2.0
 ---
 
+!!! note "Module paths shown are proposed design targets"
+    The snippets below import from `xr_toolz.lagrangian`, `xr_toolz.metrics.*`, and
+    other submodules that **do not exist in the current export surface** — the
+    current domain-agnostic functionality still lives under `xr_toolz.geo.*`.
+    Treat these imports as design-target aliases; until the modules ship, map each
+    `xr_toolz.<topic>` path to its equivalent under today's `xr_toolz.geo.<topic>`.
+
 # Lagrangian Validation Examples
 
 Lagrangian validation evaluates the material transport implied by predicted velocity fields. These examples complement Eulerian field metrics by focusing on trajectories, dispersion, residence times, and regional connectivity.

--- a/docs/design/examples/phenomena.md
+++ b/docs/design/examples/phenomena.md
@@ -3,6 +3,13 @@ status: draft
 version: 0.2.0
 ---
 
+!!! note "Module paths shown are proposed design targets"
+    The snippets below import from `xr_toolz.phenomena`, `xr_toolz.metrics.object`,
+    and other submodules that **do not exist in the current export surface** — the
+    current domain-agnostic functionality still lives under `xr_toolz.geo.*`.
+    Treat these imports as design-target aliases; until the modules ship, map each
+    `xr_toolz.<topic>` path to its equivalent under today's `xr_toolz.geo.<topic>`.
+
 # Phenomena-Based Validation Examples
 
 Phenomena-based validation treats verification as event detection and characterization. It complements field metrics by asking whether predictions reproduce meaningful finite-amplitude ocean features.

--- a/docs/design/examples/phenomena.md
+++ b/docs/design/examples/phenomena.md
@@ -1,0 +1,188 @@
+---
+status: draft
+version: 0.2.0
+---
+
+# Phenomena-Based Validation Examples
+
+Phenomena-based validation treats verification as event detection and characterization. It complements field metrics by asking whether predictions reproduce meaningful finite-amplitude ocean features.
+
+---
+
+## Example 1: Marine Heatwave Verification
+
+### User Story
+
+As a marine heatwave researcher, I want to detect MHWs in predicted and reference SST fields and compare detection skill, duration, intensity, and spatial overlap.
+
+### Motivation
+
+A model can produce low SST RMSE while missing the timing, persistence, or spatial extent of extreme warm events. Event verification makes these errors explicit.
+
+### Demo API
+
+```python
+from xr_toolz.phenomena import DetectMarineHeatwaves, MatchObjects
+from xr_toolz.metrics.object import ProbabilityOfDetection, FalseAlarmRatio, CriticalSuccessIndex, IntersectionOverUnion, DurationError, IntensityBias
+```
+
+### Demo Example Usage
+
+```python
+events_pred = DetectMarineHeatwaves(
+    sst_var="sst",
+    climatology=sst_climatology,
+    percentile=90,
+    min_duration=5,
+)(ds_pred)
+
+events_ref = DetectMarineHeatwaves(
+    sst_var="sst",
+    climatology=sst_climatology,
+    percentile=90,
+    min_duration=5,
+)(ds_ref)
+
+matches = MatchObjects(method="iou", threshold=0.2)(events_pred, events_ref)
+
+pod = ProbabilityOfDetection()(matches)
+far = FalseAlarmRatio()(matches)
+csi = CriticalSuccessIndex()(matches)
+iou = IntersectionOverUnion()(matches)
+duration = DurationError()(matches)
+intensity = IntensityBias(variable="sst")(matches)
+```
+
+---
+
+## Example 2: Eddy Verification
+
+### User Story
+
+As an ocean dynamics researcher, I want to detect mesoscale eddies in predicted and reference SSH fields, so that I can evaluate whether the model captures eddy occurrence, size, amplitude, and trajectory.
+
+### Motivation
+
+Eddies are coherent, finite-amplitude structures. A model can achieve favorable average SSH skill while smoothing eddies, displacing them, or shortening their lifetimes.
+
+### Demo API
+
+```python
+from xr_toolz.phenomena import DetectEddies, MatchObjects, ObjectProperties
+from xr_toolz.metrics.object import CriticalSuccessIndex, IntersectionOverUnion, CentroidDistance, IntensityBias
+```
+
+### Demo Example Usage
+
+```python
+eddies_pred = DetectEddies(
+    ssh_var="ssha",
+    method="closed_contour",
+    min_radius=25_000,
+    min_lifetime="7D",
+)(ds_pred)
+
+eddies_ref = DetectEddies(
+    ssh_var="ssha",
+    method="closed_contour",
+    min_radius=25_000,
+    min_lifetime="7D",
+)(ds_ref)
+
+matches = MatchObjects(method="iou", threshold=0.1)(eddies_pred, eddies_ref)
+props_pred = ObjectProperties(variables=["ssha"])(eddies_pred, ds_pred)
+
+scores = {
+    "csi": CriticalSuccessIndex()(matches),
+    "iou": IntersectionOverUnion()(matches),
+    "centroid_error": CentroidDistance(dims=("lat", "lon"))(matches),
+    "amplitude_bias": IntensityBias(variable="ssha")(matches),
+}
+```
+
+---
+
+## Example 3: Generic EventDefinition
+
+### User Story
+
+As a method developer, I want event definitions to be reusable objects, so that prediction and reference fields are thresholded consistently.
+
+### Motivation
+
+Before scoring events, the phenomenon must be defined objectively: threshold, baseline, minimum duration, minimum area, and connectivity. Making that definition explicit reduces ambiguity.
+
+### Demo API
+
+```python
+from xr_toolz.phenomena import EventDefinition, DetectAnomalyObjects, MatchObjects
+from xr_toolz.metrics.object import ProbabilityOfDetection, FalseAlarmRatio, CriticalSuccessIndex
+```
+
+### Demo Example Usage
+
+```python
+upwelling_def = EventDefinition(
+    variable="sst",
+    threshold="climatology_p10",
+    baseline=sst_climatology,
+    min_duration=3,
+    min_area=10_000_000,
+    connectivity=8,
+    anomaly=True,
+)
+
+upwelling_pred = DetectAnomalyObjects(upwelling_def)(ds_pred)
+upwelling_ref = DetectAnomalyObjects(upwelling_def)(ds_ref)
+
+matches = MatchObjects(method="iou", threshold=0.2)(upwelling_pred, upwelling_ref)
+
+scores = {
+    "pod": ProbabilityOfDetection()(matches),
+    "far": FalseAlarmRatio()(matches),
+    "csi": CriticalSuccessIndex()(matches),
+}
+```
+
+---
+
+## Example 4: Event Verification Graph
+
+### User Story
+
+As an applied scientist, I want one graph that detects events, matches them, computes skill scores, and produces a diagnostic panel.
+
+### Motivation
+
+Event verification has multiple dependent steps. The Graph API keeps detection, matching, scoring, and visualization reproducible.
+
+### Demo API
+
+```python
+from xr_toolz.core import Graph, Input
+from xr_toolz.phenomena import DetectMarineHeatwaves, MatchObjects
+from xr_toolz.metrics.object import ProbabilityOfDetection, FalseAlarmRatio, CriticalSuccessIndex
+from xr_toolz.viz.validation import EventVerificationPanel
+```
+
+### Demo Example Usage
+
+```python
+pred = Input("prediction")
+ref = Input("reference")
+
+pred_events = DetectMarineHeatwaves(sst_var="sst", climatology=sst_clim, percentile=90, min_duration=5)(pred)
+ref_events = DetectMarineHeatwaves(sst_var="sst", climatology=sst_clim, percentile=90, min_duration=5)(ref)
+
+matches = MatchObjects(method="iou", threshold=0.2)(pred_events, ref_events)
+
+pod = ProbabilityOfDetection()(matches)
+far = FalseAlarmRatio()(matches)
+csi = CriticalSuccessIndex()(matches)
+panel = EventVerificationPanel()(matches)
+
+event_graph = Graph(
+    inputs={"prediction": pred, "reference": ref},
+    outputs={"pod": pod, "far": far, "csi": csi, "panel": panel},
+)
+```

--- a/docs/design/examples/validation.md
+++ b/docs/design/examples/validation.md
@@ -3,6 +3,16 @@ status: draft
 version: 0.2.0
 ---
 
+!!! note "Module paths shown are proposed design targets"
+    The snippets below import from `xr_toolz.metrics.*`, `xr_toolz.budgets`,
+    `xr_toolz.phenomena`, and `xr_toolz.lagrangian` — submodules that **do not
+    exist in the current export surface**. Today, validators such as
+    `ValidateCoords` live under `xr_toolz.geo.operators` (not
+    `xr_toolz.geo.validation`), and metric primitives live under
+    `xr_toolz.geo.metrics`. Treat the imports below as design-target aliases;
+    once the modules ship, the snippets will be copy/paste-ready against the
+    proposed layout.
+
 # Validation Examples
 
 This page shows how the proposed validation framework composes field, spectral, lead-time, structural, process, Lagrangian, and phenomena-based diagnostics without removing any existing examples.
@@ -23,7 +33,7 @@ A model can perform well in global RMSE while losing small-scale variance or deg
 
 ```python
 from xr_toolz.core import Graph, Input
-from xr_toolz.geo.validation import ValidateCoords
+from xr_toolz.geo.operators import ValidateCoords  # current export path
 from xr_toolz.metrics import RMSE, PSDScore
 from xr_toolz.metrics.forecast import RMSEByLead
 ```

--- a/docs/design/examples/validation.md
+++ b/docs/design/examples/validation.md
@@ -1,0 +1,190 @@
+---
+status: draft
+version: 0.2.0
+---
+
+# Validation Examples
+
+This page shows how the proposed validation framework composes field, spectral, lead-time, structural, process, Lagrangian, and phenomena-based diagnostics without removing any existing examples.
+
+---
+
+## Example 1: Field + Spectral + Lead-Time Skill
+
+### User Story
+
+As an ML forecasting researcher, I want to evaluate a forecast with RMSE, spectral skill, and lead-time skill in one graph, so that I can diagnose both average error and scale-dependent degradation.
+
+### Motivation
+
+A model can perform well in global RMSE while losing small-scale variance or degrading rapidly with forecast horizon. These diagnostics should be computed together so that validation reports are internally consistent.
+
+### Demo API
+
+```python
+from xr_toolz.core import Graph, Input
+from xr_toolz.geo.validation import ValidateCoords
+from xr_toolz.metrics import RMSE, PSDScore
+from xr_toolz.metrics.forecast import RMSEByLead
+```
+
+### Demo Example Usage
+
+```python
+pred = Input("prediction")
+ref = Input("reference")
+
+pred_clean = ValidateCoords()(pred)
+ref_clean = ValidateCoords()(ref)
+
+rmse = RMSE(variable="ssh", dims=("time", "lat", "lon"))(pred_clean, ref_clean)
+psd = PSDScore(variable="ssh", dims=("lat", "lon"))(pred_clean, ref_clean)
+lead = RMSEByLead(variable="ssh", dims=("lat", "lon"), lead_dim="lead_time")(pred_clean, ref_clean)
+
+validation_graph = Graph(
+    inputs={"prediction": pred, "reference": ref},
+    outputs={"rmse": rmse, "psd": psd, "lead_rmse": lead},
+)
+
+scores = validation_graph(prediction=ds_pred, reference=ds_ref)
+```
+
+---
+
+## Example 2: Structural Skill for a Displaced Eddy
+
+### User Story
+
+As an ocean ML researcher, I want to evaluate whether a predicted eddy is structurally correct even when it is slightly displaced, so that the validation does not reduce every spatial phase error to a double-penalized RMSE.
+
+### Motivation
+
+Pointwise scores penalize a displaced feature twice: once where the observed object is missed and once where the predicted object appears. Structural metrics help separate amplitude error from displacement, morphology, and phase error.
+
+### Demo API
+
+```python
+from xr_toolz.metrics import RMSE
+from xr_toolz.metrics.structural import SSIM, PhaseShiftError, GradientDifference
+```
+
+### Demo Example Usage
+
+```python
+rmse = RMSE(variable="ssh", dims=("lat", "lon"))(ds_pred, ds_ref)
+ssim = SSIM(variable="ssh", dims=("lat", "lon"))(ds_pred, ds_ref)
+phase = PhaseShiftError(variable="ssh", dims=("lat", "lon"))(ds_pred, ds_ref)
+gradient = GradientDifference(variable="ssh", dims=("lat", "lon"))(ds_pred, ds_ref)
+
+summary = {
+    "pointwise_error": rmse,
+    "structure": ssim,
+    "phase_shift": phase,
+    "gradient_error": gradient,
+}
+```
+
+---
+
+## Example 3: Regional and Regime-Aware Skill
+
+### User Story
+
+As a regional oceanographer, I want to compare model skill across coastal, open-ocean, eddy-rich, and frontal regimes, so that strong global performance does not hide regional failure modes.
+
+### Motivation
+
+Geophysical skill is often regime-dependent. Coastal regions, boundary currents, bathymetric gradients, and eddy-rich regions may have very different error behavior from open-ocean interiors.
+
+### Demo API
+
+```python
+from xr_toolz.geo.masks import AddRegionMask
+from xr_toolz.metrics import RMSE
+from xr_toolz.metrics.scale import EvaluateByRegion
+```
+
+### Demo Example Usage
+
+```python
+metric = RMSE(variable="ssh", dims=("time",))
+regional_skill = EvaluateByRegion(
+    metric=metric,
+    regions={
+        "coastal": coastal_mask,
+        "open_ocean": open_ocean_mask,
+        "eddy_rich": eddy_rich_mask,
+        "fronts": front_mask,
+    },
+)(ds_pred, ds_ref)
+```
+
+---
+
+## Example 4: Probabilistic Ensemble Validation
+
+### User Story
+
+As a probabilistic forecasting researcher, I want to evaluate ensemble calibration and sharpness, so that a stochastic model is not judged only by the error of its ensemble mean.
+
+### Motivation
+
+For chaotic geophysical systems, a useful ensemble should be both calibrated and sharp. CRPS, spread-skill ratio, rank histograms, and coverage diagnostics expose underdispersion, overdispersion, and biased uncertainty.
+
+### Demo API
+
+```python
+from xr_toolz.metrics.probabilistic import CRPS, SpreadSkillRatio, RankHistogram, EnsembleCoverage
+```
+
+### Demo Example Usage
+
+```python
+crps = CRPS(variable="ssh", ensemble_dim="member", dims=("time", "lat", "lon"))(ensemble_pred, ds_ref)
+spread_skill = SpreadSkillRatio(variable="ssh", ensemble_dim="member", dims=("time", "lat", "lon"))(ensemble_pred, ds_ref)
+ranks = RankHistogram(variable="ssh", ensemble_dim="member")(ensemble_pred, ds_ref)
+coverage = EnsembleCoverage(variable="ssh", q=(0.05, 0.95), ensemble_dim="member")(ensemble_pred, ds_ref)
+```
+
+---
+
+## Example 5: Process-Based Validation Graph
+
+### User Story
+
+As a physical oceanographer, I want to evaluate field skill and physical consistency in the same graph, so that I can detect models that score well statistically but violate balances or budgets.
+
+### Motivation
+
+Conventional error scores do not guarantee dynamical consistency. Balance residuals and budget checks expose physically implausible behavior, especially in long autoregressive rollouts.
+
+### Demo API
+
+```python
+from xr_toolz.core import Graph, Input
+from xr_toolz.metrics import RMSE
+from xr_toolz.metrics.physical import GeostrophicBalanceError, DivergenceError
+from xr_toolz.budgets import HeatBudgetResidual
+```
+
+### Demo Example Usage
+
+```python
+pred = Input("prediction")
+ref = Input("reference")
+
+rmse = RMSE(variable="ssh", dims=("time", "lat", "lon"))(pred, ref)
+geostrophic = GeostrophicBalanceError(ssh_var="ssh", u_var="u", v_var="v")(pred)
+divergence = DivergenceError(u_var="u", v_var="v", dims=("lat", "lon"))(pred)
+heat = HeatBudgetResidual(temp_var="theta", u_var="u", v_var="v", surface_flux_var="qnet")(pred)
+
+process_graph = Graph(
+    inputs={"prediction": pred, "reference": ref},
+    outputs={
+        "rmse": rmse,
+        "geostrophic_balance": geostrophic,
+        "divergence": divergence,
+        "heat_budget": heat,
+    },
+)
+```

--- a/docs/design/validation-decisions.md
+++ b/docs/design/validation-decisions.md
@@ -183,7 +183,7 @@ Detecting an event and scoring an event forecast are different tasks. Marine hea
 
 ### Decision
 
-Put event definitions, detection, labeling, matching, and properties in `xr_toolz.phenomena`. Put scores such as POD, FAR, CSI, IoU, duration error, and intensity bias in `xr_toolz.metrics.object`.
+Put event definitions, detection, labeling, matching, and properties in `xr_toolz.phenomena`. Put scores such as `ProbabilityOfDetection` (POD), `FalseAlarmRatio` (FAR), `CriticalSuccessIndex` (CSI), `IntersectionOverUnion` (IoU), duration error, and intensity bias in `xr_toolz.metrics.object`.
 
 ### Consequences
 

--- a/docs/design/validation-decisions.md
+++ b/docs/design/validation-decisions.md
@@ -1,0 +1,281 @@
+---
+status: draft
+version: 0.2.0
+---
+
+# Validation Design Decisions
+
+This companion decision log records proposed validation-specific decisions. It extends [`decisions.md`](decisions.md) without modifying the accepted D1–D10 decisions.
+
+---
+
+## D11: Validation is organized by scientific diagnostic family
+
+**Status:** proposed
+
+### Context
+
+Existing metrics cover pixel, spectral, multiscale, and distributional scores. Ocean and geoscience ML validation also requires structural, forecast, probabilistic, physical, Lagrangian, process, and phenomena-based diagnostics.
+
+### Decision
+
+Add a validation taxonomy with five conceptual families:
+
+1. Scales of evaluation
+2. Data representation
+3. Physical representation
+4. Process evaluation
+5. Phenomena-based evaluation
+
+Implementation is split across `metrics`, `lagrangian`, `budgets`, `phenomena`, and `viz`.
+
+### Consequences
+
+- `metrics` remains the home for scalar and array-valued skill scores.
+- `lagrangian` owns particle and transport diagnostics.
+- `budgets` owns conservation and control-volume residuals.
+- `phenomena` owns event definitions, detection, labeling, matching, and properties.
+- `viz` owns diagnostic panels.
+
+### User Story
+
+As a geoscience ML researcher, I want validation tools organized by scientific diagnostic question, so that I can choose the right metric family without reducing evaluation to a single global score.
+
+### Motivation
+
+A validation framework should reveal whether a model reproduces scales, uncertainty, structures, transport, processes, budgets, and events. These concepts are broader than pointwise error and should be discoverable in the API.
+
+### Demo API
+
+```python
+from xr_toolz.metrics import RMSE, PSDScore
+from xr_toolz.metrics.structural import SSIM
+from xr_toolz.metrics.forecast import RMSEByLead
+from xr_toolz.budgets import HeatBudgetResidual
+from xr_toolz.lagrangian import AdvectParticles
+from xr_toolz.phenomena import DetectMarineHeatwaves
+```
+
+### Demo Example Usage
+
+```python
+scores = {
+    "rmse": RMSE(variable="ssh", dims=("time", "lat", "lon"))(ds_pred, ds_ref),
+    "psd": PSDScore(variable="ssh", dims=("lat", "lon"))(ds_pred, ds_ref),
+    "ssim": SSIM(variable="ssh", dims=("lat", "lon"))(ds_pred, ds_ref),
+    "lead_rmse": RMSEByLead(variable="ssh", dims=("lat", "lon"))(ds_pred, ds_ref),
+    "heat_budget": HeatBudgetResidual(temp_var="theta", u_var="u", v_var="v")(ds_pred),
+}
+```
+
+---
+
+## D12: Lagrangian diagnostics live outside `metrics`
+
+**Status:** proposed
+
+### Context
+
+Particle advection, trajectories, FTLE-like diagnostics, residence time, and connectivity are not just scalar metrics. They create intermediate trajectory datasets that can be reused across many analyses.
+
+### Decision
+
+Create `xr_toolz.lagrangian` as a first-class module. Scalar comparisons of trajectory outputs can live in `xr_toolz.metrics.lagrangian`, but trajectory generation and transport diagnostics live in `xr_toolz.lagrangian`.
+
+### Consequences
+
+- Users can compute trajectories once and reuse them across endpoint error, pair dispersion, residence time, and connectivity metrics.
+- Lagrangian tools remain composable `Operator`s.
+- Future optional acceleration can be added without changing the validation API.
+
+### User Story
+
+As a Lagrangian transport researcher, I want to create reusable particle trajectories from model velocity fields, so that I can evaluate transport pathways with several downstream diagnostics.
+
+### Motivation
+
+Eulerian field agreement does not guarantee correct material transport. Trajectory generation is a first-class transformation, not merely a metric implementation detail.
+
+### Demo API
+
+```python
+from xr_toolz.lagrangian import SeedParticles, AdvectParticles, PairDispersion, ResidenceTime, ConnectivityMatrix, FTLE
+from xr_toolz.metrics.lagrangian import EndpointError, TrajectoryRMSE, ConnectivityError
+```
+
+### Demo Example Usage
+
+```python
+particles = SeedParticles(strategy="grid", spacing=0.25, region=med_mask)(ds_ref)
+traj_pred = AdvectParticles(u_var="u", v_var="v", dt="1h", steps=240)(ds_pred, particles)
+traj_ref = AdvectParticles(u_var="u", v_var="v", dt="1h", steps=240)(ds_ref, particles)
+endpoint = EndpointError()(traj_pred, traj_ref)
+```
+
+---
+
+## D13: Conservation diagnostics live in `budgets`
+
+**Status:** proposed
+
+### Context
+
+Budget residuals require tendencies, fluxes, control-volume integration, grid metrics, and optional source/sink terms. These are broader than simple field metrics.
+
+### Decision
+
+Create `xr_toolz.budgets` for generic and domain-specific budget residuals.
+
+### Consequences
+
+- Physical-process checks are reusable across ocean, atmosphere, tracers, and methane workflows.
+- Budget residual outputs can be passed to `metrics`, `viz`, or `Graph` workflows.
+- Grid metrics and control-volume definitions remain explicit instead of hidden in a metric implementation.
+
+### User Story
+
+As a physical scientist, I want to evaluate conservation residuals over finite volumes, so that long rollouts can be checked for physically meaningful drift.
+
+### Motivation
+
+A model can have good short-term RMSE while violating heat, salt, volume, tracer, or energy conservation. Budget checks identify where and how the prediction becomes dynamically inconsistent.
+
+### Demo API
+
+```python
+from xr_toolz.budgets import (
+    ControlVolumeIntegral,
+    BoundaryFlux,
+    BudgetResidual,
+    HeatBudgetResidual,
+    SaltBudgetResidual,
+    VolumeBudgetResidual,
+    KineticEnergyBudgetResidual,
+)
+```
+
+### Demo Example Usage
+
+```python
+heat_residual = HeatBudgetResidual(
+    temp_var="theta",
+    u_var="u",
+    v_var="v",
+    surface_flux_var="qnet",
+)(ds_pred)
+
+regional_heat_drift = ControlVolumeIntegral(
+    variable="heat_budget_residual",
+    volume_metrics=grid_metrics,
+    region=med_mask,
+)(heat_residual.to_dataset(name="heat_budget_residual"))
+```
+
+---
+
+## D14: Phenomena detection and object verification are separate
+
+**Status:** proposed
+
+### Context
+
+Detecting an event and scoring an event forecast are different tasks. Marine heatwaves, eddies, fronts, plumes, and storms require event definitions; verification requires matching and scoring.
+
+### Decision
+
+Put event definitions, detection, labeling, matching, and properties in `xr_toolz.phenomena`. Put scores such as POD, FAR, CSI, IoU, duration error, and intensity bias in `xr_toolz.metrics.object`.
+
+### Consequences
+
+- The same detected events can be visualized, filtered, matched, or scored.
+- Object metrics stay small and composable.
+- Event definitions become reusable objects applied consistently to predictions and references.
+
+### User Story
+
+As an applied ocean scientist, I want to define, detect, match, and score events as separate steps, so that event verification is reproducible and scientifically interpretable.
+
+### Motivation
+
+Field-level scores can be good while important finite-amplitude events are missed, delayed, displaced, or weakened. Object-based verification evaluates the phenomena themselves.
+
+### Demo API
+
+```python
+from xr_toolz.phenomena import EventDefinition, DetectMarineHeatwaves, DetectEddies, MatchObjects, ObjectProperties
+from xr_toolz.metrics.object import ProbabilityOfDetection, FalseAlarmRatio, CriticalSuccessIndex, IntersectionOverUnion
+```
+
+### Demo Example Usage
+
+```python
+events_pred = DetectMarineHeatwaves(
+    sst_var="sst",
+    climatology=sst_clim,
+    percentile=90,
+    min_duration=5,
+)(ds_pred)
+
+events_ref = DetectMarineHeatwaves(
+    sst_var="sst",
+    climatology=sst_clim,
+    percentile=90,
+    min_duration=5,
+)(ds_ref)
+
+matches = MatchObjects(method="iou", threshold=0.2)(events_pred, events_ref)
+
+scores = {
+    "pod": ProbabilityOfDetection()(matches),
+    "far": FalseAlarmRatio()(matches),
+    "csi": CriticalSuccessIndex()(matches),
+    "iou": IntersectionOverUnion()(matches),
+}
+```
+
+---
+
+## D15: Validation plots are terminal visualization operators
+
+**Status:** proposed
+
+### Context
+
+Validation reports often require diagnostic panels rather than raw score arrays alone. Existing D10 already accepts viz operators as terminal `Operator`s returning `Figure` / `Axes`.
+
+### Decision
+
+Add validation-specific plot operators under `xr_toolz.viz.validation`.
+
+### Consequences
+
+- Validation graphs can emit both scores and figures.
+- Diagnostic panels remain composable terminal outputs.
+- Plotting does not mutate datasets or hide figures in attrs.
+
+### User Story
+
+As a researcher, I want one validation graph to return metrics and publication-ready diagnostic panels, so that scoring and visualization are reproducible together.
+
+### Motivation
+
+Scale skill, spectral skill, process budgets, Lagrangian trajectories, and event verification are easier to inspect with standardized panels.
+
+### Demo API
+
+```python
+from xr_toolz.viz.validation import (
+    ScaleSkillPanel,
+    SpectralSkillPanel,
+    LeadTimeSkillPanel,
+    ProcessBudgetPanel,
+    EulerianLagrangianPanel,
+    EventVerificationPanel,
+)
+```
+
+### Demo Example Usage
+
+```python
+fig = SpectralSkillPanel(variable="ssh", dims=("lat", "lon"))(psd_scores)
+```

--- a/docs/design/validation.md
+++ b/docs/design/validation.md
@@ -3,6 +3,14 @@ status: draft
 version: 0.2.0
 ---
 
+!!! note "Module paths shown are proposed design targets"
+    Throughout this page, paths such as `xr_toolz.metrics.*`, `xr_toolz.budgets`,
+    and `xr_toolz.phenomena` refer to **proposed** subpackages and **are not part
+    of the current export surface**. Most domain-agnostic functionality today
+    still lives under `xr_toolz.geo` (for example `xr_toolz.geo.operators`,
+    `xr_toolz.geo.metrics`). Treat the snippets below as architectural direction;
+    once the proposed modules ship, the imports become copy/paste-ready.
+
 # Validation Framework
 
 `xr_toolz` validation should be broader than a list of scalar metrics. The design goal is to make evaluation workflows diagnose whether geoscience ML models reproduce values, scales, uncertainty, geometry, transport, physical processes, budgets, and identifiable events.
@@ -68,7 +76,8 @@ class BandLimitedRMSE(Operator): ...
 from xr_toolz.core import Graph, Input
 from xr_toolz.metrics import RMSE
 from xr_toolz.metrics.forecast import SkillByLeadTime
-from xr_toolz.metrics.scale import EvaluateByRegion, FrequencyBandSkill
+from xr_toolz.metrics.multiscale import EvaluateByRegion
+from xr_toolz.metrics.spectral import FrequencyBandSkill
 
 pred = Input("prediction")
 ref = Input("reference")

--- a/docs/design/validation.md
+++ b/docs/design/validation.md
@@ -1,0 +1,480 @@
+---
+status: draft
+version: 0.2.0
+---
+
+# Validation Framework
+
+`xr_toolz` validation should be broader than a list of scalar metrics. The design goal is to make evaluation workflows diagnose whether geoscience ML models reproduce values, scales, uncertainty, geometry, transport, physical processes, budgets, and identifiable events.
+
+This page extends the existing `preprocess -> infer -> evaluate` vision with five complementary validation views:
+
+1. Scales of evaluation
+2. Data representation
+3. Physical representation
+4. Process evaluation
+5. Phenomena-based evaluation
+
+The additions follow the existing three-layer design:
+
+- **Layer 0**: pure functions over `xarray` objects
+- **Layer 1**: thin `Operator` wrappers
+- **Layer 2**: `Graph` workflows combining prediction, reference, masks, climatology, grid metrics, and auxiliary data
+
+---
+
+## 1. Scales of Evaluation
+
+### User Story
+
+As an ocean ML researcher, I want to evaluate model skill by region, lead time, spatial scale, temporal scale, and spectral band, so that good aggregate RMSE does not hide failures at mesoscale, submesoscale, coastal, or long-lead regimes.
+
+### Motivation
+
+Oceanic and atmospheric variability are intrinsically multiscale. A global scalar score can be dominated by large-amplitude, large-scale variability while smoothing high-frequency structure. Validation should therefore support decomposition by spatial domain, temporal scale, forecast horizon, and frequency band.
+
+### Design
+
+Scale-aware validation should live primarily in `xr_toolz.metrics.forecast`, `xr_toolz.metrics.multiscale`, and `xr_toolz.metrics.spectral`, with masking and region utilities supplied by `xr_toolz.geo.masks` and `xr_toolz.geo.subset`.
+
+Common partitions include:
+
+- geographic regions and named masks
+- coastal, open-ocean, eddy-rich, frontal, or bathymetry-defined regimes
+- forecast lead time
+- temporal bands such as sub-daily, synoptic, seasonal, and interannual
+- spatial bands such as basin scale, mesoscale, and submesoscale
+- Fourier or wavelet frequency bands
+
+### Demo API
+
+```python
+# Layer 0 functions
+def skill_by_lead_time(prediction, reference, *, metric_fn, lead_dim="lead_time") -> xr.DataArray: ...
+def evaluate_by_region(prediction, reference, *, metric_fn, regions) -> xr.Dataset: ...
+def evaluate_by_frequency_band(prediction, reference, *, variable, bands, dims) -> xr.Dataset: ...
+def band_limited_rmse(prediction, reference, *, variable, bands, dims) -> xr.Dataset: ...
+
+# Layer 1 operators
+class SkillByLeadTime(Operator): ...
+class EvaluateByRegion(Operator): ...
+class FrequencyBandSkill(Operator): ...
+class BandLimitedRMSE(Operator): ...
+```
+
+### Demo Example Usage
+
+```python
+from xr_toolz.core import Graph, Input
+from xr_toolz.metrics import RMSE
+from xr_toolz.metrics.forecast import SkillByLeadTime
+from xr_toolz.metrics.scale import EvaluateByRegion, FrequencyBandSkill
+
+pred = Input("prediction")
+ref = Input("reference")
+
+rmse = RMSE(variable="ssh", dims=("lat", "lon"))
+lead_rmse = SkillByLeadTime(metric=rmse, lead_dim="lead_time")(pred, ref)
+regional_rmse = EvaluateByRegion(metric=rmse, regions=region_masks)(pred, ref)
+band_skill = FrequencyBandSkill(variable="ssh", dims=("lat", "lon"), bands=spatial_bands)(pred, ref)
+
+graph = Graph(
+    inputs={"prediction": pred, "reference": ref},
+    outputs={
+        "lead_rmse": lead_rmse,
+        "regional_rmse": regional_rmse,
+        "band_skill": band_skill,
+    },
+)
+```
+
+### Notes / Open Questions
+
+- Should `EvaluateByRegion` accept `regionmask.Regions`, an integer mask, or a dict of boolean masks? Prefer all three through normalization to an internal labeled mask.
+- Should frequency bands be specified in physical units, grid indices, or wavelengths? Prefer named bands plus explicit coordinate metadata when available.
+
+---
+
+## 2. Data Representation
+
+### User Story
+
+As a geoscience ML researcher, I want to compare predictions using pointwise, probabilistic, spectral, and structural metrics, so that displaced but physically coherent features are not treated the same as completely wrong predictions.
+
+### Motivation
+
+The representation used for validation determines which errors are penalized. Pointwise L1/L2 metrics are useful baselines, but they suffer from double penalties when coherent structures are displaced. Probabilistic metrics are needed for ensemble or stochastic predictions. Spectral metrics reveal loss of scale-dependent variance. Structural metrics diagnose geometry, phase, and morphology.
+
+### Design
+
+Data-representation metrics should be organized by metric family:
+
+```text
+xr_toolz.metrics.pixel
+xr_toolz.metrics.probabilistic
+xr_toolz.metrics.spectral
+xr_toolz.metrics.multiscale
+xr_toolz.metrics.structural
+xr_toolz.metrics.distributional
+xr_toolz.metrics.masked
+```
+
+Pointwise metrics remain first-class but should be documented as baseline diagnostics rather than sufficient validation.
+
+### Demo API
+
+```python
+# Structural metrics
+def ssim(prediction, reference, *, variable, dims, window=None) -> xr.DataArray: ...
+def gradient_difference(prediction, reference, *, variable, dims) -> xr.DataArray: ...
+def phase_shift_error(prediction, reference, *, variable, dims) -> xr.Dataset: ...
+def centroid_displacement(objects_pred, objects_ref, *, dims=("lat", "lon")) -> xr.Dataset: ...
+
+# Probabilistic metrics
+def spread_skill_ratio(ensemble, reference, *, variable, ensemble_dim="member", dims=None) -> xr.DataArray: ...
+def rank_histogram(ensemble, reference, *, variable, ensemble_dim="member") -> xr.Dataset: ...
+def ensemble_coverage(ensemble, reference, *, variable, q=(0.05, 0.95), ensemble_dim="member") -> xr.DataArray: ...
+def reliability_curve(probability, event, *, probability_bins=None) -> xr.Dataset: ...
+
+# Layer 1 operators
+class SSIM(Operator): ...
+class GradientDifference(Operator): ...
+class PhaseShiftError(Operator): ...
+class SpreadSkillRatio(Operator): ...
+class RankHistogram(Operator): ...
+class EnsembleCoverage(Operator): ...
+class ReliabilityCurve(Operator): ...
+```
+
+### Demo Example Usage
+
+```python
+from xr_toolz.metrics.structural import SSIM, PhaseShiftError
+from xr_toolz.metrics.probabilistic import SpreadSkillRatio, RankHistogram
+
+structure = SSIM(variable="ssh", dims=("lat", "lon"))(ds_pred, ds_ref)
+phase = PhaseShiftError(variable="ssh", dims=("lat", "lon"))(ds_pred, ds_ref)
+spread_skill = SpreadSkillRatio(variable="ssh", ensemble_dim="member")(ensemble_pred, ds_ref)
+ranks = RankHistogram(variable="ssh", ensemble_dim="member")(ensemble_pred, ds_ref)
+```
+
+### Notes / Open Questions
+
+- `SSIM` may require optional `scikit-image`; if unavailable, provide a documented fallback or raise an informative optional-dependency error.
+- `phase_shift_error` should support both periodic and non-periodic spatial dimensions.
+- Ensemble metrics should define expected input shape and metadata conventions for `member` dimensions.
+
+---
+
+## 3. Physical Representation
+
+### User Story
+
+As an oceanographer, I want to evaluate both Eulerian fields and Lagrangian transport, so that a model that looks good on a grid is not accepted if it produces unrealistic trajectories, mixing, residence times, or connectivity.
+
+### Motivation
+
+Most gridded model validation is Eulerian: predicted and reference fields are compared at fixed coordinates. This is necessary but not sufficient for transport. Small phase or gradient errors in a velocity field can integrate into large trajectory divergence, incorrect residence times, or biased regional exchange.
+
+### Design
+
+Eulerian diagnostics should remain in `xr_toolz.metrics` and `xr_toolz.kinematics`. Lagrangian diagnostics should be a first-class module because particle advection creates reusable trajectory datasets, not only scalar scores.
+
+```text
+xr_toolz.lagrangian          # trajectory generation and transport diagnostics
+xr_toolz.metrics.lagrangian  # scalar comparisons of trajectories/statistics
+```
+
+### Demo API
+
+```python
+# Layer 0 functions
+def seed_particles(ds, *, lon=None, lat=None, strategy="grid", spacing=None, region=None) -> xr.Dataset: ...
+def sample_velocity(ds, particles, *, u_var="u", v_var="v", method="linear") -> xr.Dataset: ...
+def advect_particles(ds, particles, *, u_var="u", v_var="v", dt="1h", steps=None, method="rk4") -> xr.Dataset: ...
+def pair_dispersion(trajectories, *, pairs=None) -> xr.DataArray: ...
+def residence_time(trajectories, *, regions) -> xr.Dataset: ...
+def connectivity_matrix(trajectories, *, source_regions, target_regions) -> xr.DataArray: ...
+def ftle(ds, particles, *, integration_time, u_var="u", v_var="v") -> xr.DataArray: ...
+
+# Layer 1 operators
+class SeedParticles(Operator): ...
+class AdvectParticles(Operator): ...
+class PairDispersion(Operator): ...
+class ResidenceTime(Operator): ...
+class ConnectivityMatrix(Operator): ...
+class FTLE(Operator): ...
+
+# Metrics over trajectory outputs
+class TrajectoryRMSE(Operator): ...
+class EndpointError(Operator): ...
+class DispersionError(Operator): ...
+class ResidenceTimeError(Operator): ...
+class ConnectivityError(Operator): ...
+```
+
+### Demo Example Usage
+
+```python
+from xr_toolz.lagrangian import SeedParticles, AdvectParticles, PairDispersion
+from xr_toolz.metrics.lagrangian import EndpointError
+
+particles = SeedParticles(strategy="grid", spacing=0.25, region=med_mask)(ds_ref)
+
+traj_pred = AdvectParticles(u_var="u", v_var="v", dt="1h", steps=240)(ds_pred, particles)
+traj_ref = AdvectParticles(u_var="u", v_var="v", dt="1h", steps=240)(ds_ref, particles)
+
+endpoint_error = EndpointError()(traj_pred, traj_ref)
+pair_dispersion_bias = PairDispersion()(traj_pred) - PairDispersion()(traj_ref)
+```
+
+### Notes / Open Questions
+
+- Particle integration should initially use numpy/scipy/xarray, with optional acceleration later.
+- The trajectory schema should be documented carefully: recommended dimensions are `particle` and `time`, with variables such as `lon`, `lat`, and optional sampled fields.
+- Drifter comparison should accept observed trajectory datasets using the same schema.
+
+---
+
+## 4. Process Evaluation
+
+### User Story
+
+As a physical oceanographer, I want to check balances, budgets, density structure, and material invariants, so that model skill reflects physical consistency rather than only statistical agreement.
+
+### Motivation
+
+A model can achieve favorable short-range error scores while violating conservation laws, static stability, geostrophic balance, or material transport constraints. Process-based validation helps distinguish physically plausible skill from learned correlations.
+
+### Design
+
+Process evaluation spans multiple modules:
+
+```text
+xr_toolz.kinematics        # derived quantities: vorticity, divergence, density, MLD, N2, KE
+xr_toolz.metrics.physical  # balance and physical-consistency scores
+xr_toolz.budgets           # control-volume budgets and residuals
+xr_toolz.lagrangian        # material-frame diagnostics
+```
+
+### Demo API
+
+```python
+# Physical metrics
+def geostrophic_balance_error(ds, *, ssh_var="ssh", u_var="u", v_var="v") -> xr.Dataset: ...
+def divergence_error(ds, *, u_var="u", v_var="v", dims=("lat", "lon")) -> xr.DataArray: ...
+def density_inversion_fraction(ds, *, density_var="rho", depth_dim="depth") -> xr.DataArray: ...
+def pv_conservation_error(trajectories, *, pv_var="pv") -> xr.DataArray: ...
+
+# Budgets
+def control_volume_integral(ds, *, variable, volume_metrics, region=None, dims=("z", "lat", "lon")) -> xr.DataArray: ...
+def boundary_flux(ds, *, variable, velocity_vars, face_metrics, region=None) -> xr.Dataset: ...
+def budget_residual(tendency, flux_divergence, *, source=None, sink=None) -> xr.DataArray: ...
+def heat_budget_residual(ds, *, temp_var="theta", u_var="u", v_var="v", w_var=None, surface_flux_var=None) -> xr.DataArray: ...
+def salt_budget_residual(ds, *, salt_var="so", u_var="u", v_var="v", w_var=None, surface_flux_var=None) -> xr.DataArray: ...
+def volume_budget_residual(ds, *, u_var="u", v_var="v", w_var=None) -> xr.DataArray: ...
+def kinetic_energy_budget_residual(ds, *, u_var="u", v_var="v", forcing_vars=None) -> xr.DataArray: ...
+
+# Layer 1 operators
+class GeostrophicBalanceError(Operator): ...
+class DivergenceError(Operator): ...
+class DensityInversionFraction(Operator): ...
+class ControlVolumeIntegral(Operator): ...
+class HeatBudgetResidual(Operator): ...
+class SaltBudgetResidual(Operator): ...
+class VolumeBudgetResidual(Operator): ...
+class KineticEnergyBudgetResidual(Operator): ...
+```
+
+### Demo Example Usage
+
+```python
+from xr_toolz.metrics.physical import GeostrophicBalanceError, DivergenceError
+from xr_toolz.budgets import HeatBudgetResidual, ControlVolumeIntegral
+
+geo_residual = GeostrophicBalanceError(ssh_var="ssh", u_var="u", v_var="v")(ds_pred)
+div_residual = DivergenceError(u_var="u", v_var="v", dims=("lat", "lon"))(ds_pred)
+
+heat_residual = HeatBudgetResidual(
+    temp_var="theta",
+    u_var="u",
+    v_var="v",
+    surface_flux_var="qnet",
+)(ds_pred)
+
+regional_heat_drift = ControlVolumeIntegral(
+    variable="heat_budget_residual",
+    volume_metrics=grid_metrics,
+    region=med_mask,
+)(heat_residual.to_dataset(name="heat_budget_residual"))
+```
+
+### Notes / Open Questions
+
+- Density and equation-of-state calculations should use `gsw` / TEOS-10 as an optional dependency when available.
+- Derivative-based diagnostics should document filtering/coarse-graining choices because gradients amplify small-scale artifacts.
+- Budget operators should make grid metrics explicit rather than guessing cell areas and volumes when possible.
+
+---
+
+## 5. Phenomena-Based Evaluation
+
+### User Story
+
+As an applied scientist, I want to evaluate specific events such as eddies, fronts, marine heatwaves, upwelling events, storms, or plumes, so that the model is judged by its ability to reproduce scientifically meaningful phenomena.
+
+### Motivation
+
+Many geoscience applications depend on identifiable finite-amplitude phenomena rather than continuous fields alone. A model may have low grid-level error while smoothing, displacing, delaying, weakening, or missing events. Object-based verification evaluates detection, spatial overlap, timing, intensity, duration, and lifecycle properties.
+
+### Design
+
+Separate event detection from event scoring:
+
+```text
+xr_toolz.phenomena       # event definitions, detection, labeling, matching, properties
+xr_toolz.metrics.object  # contingency scores and object-property errors
+xr_toolz.viz.validation  # event verification panels
+```
+
+### Demo API
+
+```python
+@dataclass
+class EventDefinition:
+    variable: str
+    threshold: float | str
+    baseline: xr.Dataset | None = None
+    min_duration: int | None = None
+    min_area: float | None = None
+    connectivity: int = 8
+    anomaly: bool = True
+
+# Detection
+def detect_anomaly_objects(ds, definition: EventDefinition) -> xr.Dataset: ...
+def detect_marine_heatwaves(ds, *, sst_var="sst", climatology=None, percentile=90, min_duration=5) -> xr.Dataset: ...
+def detect_eddies(ds, *, ssh_var="ssh", method="closed_contour", min_radius=None, min_lifetime=None) -> xr.Dataset: ...
+def detect_fronts(ds, *, variable, gradient_threshold=None, min_length=None) -> xr.Dataset: ...
+def label_objects(mask, *, dims=("lat", "lon"), connectivity=8) -> xr.Dataset: ...
+def match_objects(objects_pred, objects_ref, *, method="iou", threshold=0.1) -> xr.Dataset: ...
+def object_properties(objects, ds=None, *, variables=None) -> xr.Dataset: ...
+
+# Object metrics
+def contingency_table(matches) -> xr.Dataset: ...
+def probability_of_detection(matches) -> xr.DataArray: ...
+def false_alarm_ratio(matches) -> xr.DataArray: ...
+def critical_success_index(matches) -> xr.DataArray: ...
+def intersection_over_union(objects_pred, objects_ref) -> xr.DataArray: ...
+def duration_error(matches) -> xr.DataArray: ...
+def intensity_bias(matches, *, variable) -> xr.DataArray: ...
+def centroid_distance(matches, *, dims=("lat", "lon")) -> xr.DataArray: ...
+```
+
+### Demo Example Usage
+
+```python
+from xr_toolz.phenomena import DetectMarineHeatwaves, MatchObjects
+from xr_toolz.metrics.object import ProbabilityOfDetection, FalseAlarmRatio, CriticalSuccessIndex, IntersectionOverUnion
+
+events_pred = DetectMarineHeatwaves(
+    sst_var="sst",
+    climatology=sst_climatology,
+    percentile=90,
+    min_duration=5,
+)(ds_pred)
+
+events_ref = DetectMarineHeatwaves(
+    sst_var="sst",
+    climatology=sst_climatology,
+    percentile=90,
+    min_duration=5,
+)(ds_ref)
+
+matches = MatchObjects(method="iou", threshold=0.2)(events_pred, events_ref)
+
+scores = {
+    "pod": ProbabilityOfDetection()(matches),
+    "far": FalseAlarmRatio()(matches),
+    "csi": CriticalSuccessIndex()(matches),
+    "iou": IntersectionOverUnion()(matches),
+}
+```
+
+### Notes / Open Questions
+
+- `xr_toolz.extremes` remains deferred to `xtremax`; `phenomena` is broader because it covers object/event definitions, detection, matching, and verification.
+- Event definitions should be explicit and reusable so that prediction and reference fields are thresholded consistently.
+- Object outputs should remain xarray-native and preserve event IDs, time bounds, geometry summaries, and matched-pair metadata.
+
+---
+
+## Validation Graph Pattern
+
+### User Story
+
+As an applied ML researcher, I want one graph to preprocess predictions and references, compute multiple diagnostics, and return both scores and figures.
+
+### Motivation
+
+Validation usually requires more than one score. A model run may need RMSE, spectral skill, lead-time skill, structural diagnostics, budget residuals, trajectory diagnostics, and event verification. The existing Graph API is the natural way to wire these multi-input and multi-output workflows.
+
+### Demo API
+
+```python
+from xr_toolz.core import Graph, Input
+from xr_toolz.metrics import RMSE, PSDScore
+from xr_toolz.metrics.forecast import RMSEByLead
+from xr_toolz.metrics.structural import SSIM
+from xr_toolz.viz.validation import SpectralSkillPanel
+
+pred = Input("prediction")
+ref = Input("reference")
+
+rmse = RMSE(variable="ssh", dims=("time", "lat", "lon"))(pred, ref)
+psd = PSDScore(variable="ssh", dims=("lat", "lon"))(pred, ref)
+lead = RMSEByLead(variable="ssh", dims=("lat", "lon"), lead_dim="lead_time")(pred, ref)
+ssim = SSIM(variable="ssh", dims=("lat", "lon"))(pred, ref)
+fig = SpectralSkillPanel(variable="ssh", dims=("lat", "lon"))(psd)
+
+validation_graph = Graph(
+    inputs={"prediction": pred, "reference": ref},
+    outputs={
+        "rmse": rmse,
+        "psd_score": psd,
+        "lead_rmse": lead,
+        "ssim": ssim,
+        "spectral_panel": fig,
+    },
+)
+```
+
+### Demo Example Usage
+
+```python
+results = validation_graph(prediction=ds_pred, reference=ds_ref)
+
+results["rmse"]
+results["psd_score"]
+results["lead_rmse"]
+results["ssim"]
+results["spectral_panel"]
+```
+
+---
+
+## Recommended Module Additions
+
+```text
+xr_toolz.metrics.structural
+xr_toolz.metrics.forecast
+xr_toolz.metrics.probabilistic
+xr_toolz.metrics.physical
+xr_toolz.metrics.lagrangian
+xr_toolz.metrics.object
+xr_toolz.lagrangian
+xr_toolz.budgets
+xr_toolz.phenomena
+xr_toolz.viz.validation
+```
+
+These additions should extend the existing API surface without removing the current examples or decisions.

--- a/docs/design/vision.md
+++ b/docs/design/vision.md
@@ -28,7 +28,7 @@ The library covers the full applied-ML lifecycle on geospatial data:
 
 1. **Preprocess** — turn messy, heterogeneous Earth observation data into structured, analysis-ready datasets.
 2. **Infer** — run any trained model (sklearn, JAX/Equinox, PyTorch, NumPyro, plain callable) over those datasets and get xarray output back.
-3. **Evaluate** — score predictions against references with pixel-level, spectral, and multiscale metrics.
+3. **Evaluate** — score predictions against references with pointwise, probabilistic, spectral, multiscale, structural, physical, process-based, Lagrangian, and phenomena-based diagnostics.
 
 Every stage uses the same operator abstraction, so they compose into a single pipeline.
 
@@ -43,6 +43,14 @@ Every stage uses the same operator abstraction, so they compose into a single pi
 **Climate scientist** — "I want to compute anomalies, regrid to a common grid, and run spectral analysis on model output vs observations. I don't want to install xesmf or deal with ESMF compilation."
 
 **Student / newcomer** — "I want `Sequential([ValidateCoords(), Regrid(grid), RemoveClimatology(clim)])(ds)` and have it just work. I shouldn't need to learn about CRS, irregular grids, or NaN handling up front."
+
+**Ocean ML validation researcher** — "I have an ML forecast of SSH, SST, velocity, and tracers. I want to evaluate it by lead time, spatial scale, spectral band, physical regime, and phenomenon type, not only by global RMSE."
+
+**Physical oceanographer** — "I want to know whether a prediction conserves heat, salt, mass, and kinetic energy budgets over a control volume, even if its short-range pixel error looks good."
+
+**Lagrangian transport researcher** — "I want to advect particles through predicted velocity fields and compare dispersion, residence time, and connectivity against reference simulations or drifter data."
+
+**Extreme-event analyst** — "I want to detect marine heatwaves, eddies, fronts, and other ocean events in both prediction and reference fields, then compare detection skill, geometry, duration, and intensity."
 
 ---
 
@@ -68,6 +76,7 @@ Every stage uses the same operator abstraction, so they compose into a single pi
 - A pipeline abstraction (Sequential for linear, Graph for DAGs)
 - An inference wrapper (ModelOp) that turns any model into an Operator
 - An evaluation toolkit (pixel-level, spectral, multiscale metrics)
+- A validation framework for geoscience ML models, including field-based, spectral, process-based, Lagrangian, and object/event-based diagnostics
 - The xarray bookkeeping layer for the broader ecosystem (ekalmX, pyrox_gp, somax)
 
 ### What geo_toolz is NOT
@@ -97,6 +106,8 @@ Every stage uses the same operator abstraction, so they compose into a single pi
 | torchvision transforms | Composable callable transforms with `__call__` |
 | xesmf | Regridding concepts (but pure scipy, no ESMF dependency) |
 | xskillscore | Verification metrics (consumed as dependency) |
+| object-based weather verification | Event detection, matching, and property-based verification |
+| Lagrangian ocean diagnostics | Particle, residence-time, connectivity, and transport-barrier evaluation |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds a docs-only validation framework expansion for `xr_toolz`, based on the proposed ocean/geoscience ML validation taxonomy.

### Added

- `docs/design/validation.md`
  - Five-part validation framework:
    - scales of evaluation
    - data representation
    - physical representation
    - process evaluation
    - phenomena-based evaluation
  - Each section includes user story, motivation, design notes, demo API, example usage, and open questions.

- `docs/design/api/validation.md`
  - Validation API map by scientific question.
  - Suggested modules and operators for pointwise, spectral, forecast, probabilistic, structural, physical, Lagrangian, budget, and object/event verification.

- `docs/design/validation-decisions.md`
  - Proposed decisions D11–D15:
    - validation taxonomy by scientific diagnostic family
    - Lagrangian diagnostics outside `metrics`
    - conservation diagnostics in `budgets`
    - phenomena detection separated from object metrics
    - validation plots as terminal visualization operators

- New example docs:
  - `docs/design/examples/validation.md`
  - `docs/design/examples/lagrangian.md`
  - `docs/design/examples/budgets.md`
  - `docs/design/examples/phenomena.md`

### Updated

- `docs/design/README.md`
  - Links the new validation design docs and examples.
- `docs/design/vision.md`
  - Expands evaluation scope beyond pixel/spectral/multiscale metrics.
  - Adds validation-focused user stories.
- `docs/design/api/README.md`
  - Adds the proposed validation modules to the API inventory.
- `docs/design/examples/README.md`
  - Adds the new validation example pages to the reading order.

## Notes

- This PR intentionally does not remove existing examples.
- This is documentation-only; no runtime code is changed.
- The new API names are proposed design targets, not implemented code yet.

## Testing

- Not run; docs-only changes.