### PR TITLE
docs: wire all notebooks into mkdocs nav under Tutorials

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,6 +59,21 @@ nav:
           - Components: design/examples/components.md
           - Models: design/examples/models.md
           - Integration: design/examples/integration.md
+  - Tutorials:
+      - Core:
+          - Operators & Pipelines: notebooks/operators_pipeline_demo.ipynb
+      - Data — CMEMS:
+          - SST Products: notebooks/cmems_sst_products.ipynb
+          - SSS Products: notebooks/cmems_sss_products.ipynb
+          - SSH Products: notebooks/cmems_ssh_products.ipynb
+          - Ocean Colour: notebooks/cmems_oc_products.ipynb
+      - Data — CDS In-situ:
+          - Surface Land: notebooks/cds_insitu_land_demo.ipynb
+          - Surface Marine: notebooks/cds_insitu_marine_demo.ipynb
+      - Data — AEMET:
+          - Smoke Demo: notebooks/aemet_smoke.ipynb
+          - Comunidad Valenciana: notebooks/aemet_valencia.ipynb
+          - National Climatology: notebooks/aemet_national.ipynb
   - API Reference: api/reference.md
   - Contributing: contributing.md
   - Changelog: CHANGELOG.md


### PR DESCRIPTION
## Summary
- Adds a **Tutorials** top-level nav section to `mkdocs.yml`, grouping all 10 notebooks by theme:
  - **Core** — Operators & Pipelines (keras-style tour)
  - **Data — CMEMS** — SST / SSS / SSH / Ocean Colour product walkthroughs
  - **Data — CDS In-situ** — surface-land and surface-marine demos
  - **Data — AEMET** — smoke, Comunidad Valenciana, national climatology
- `example_demo.ipynb` is intentionally excluded (pypackage template boilerplate with a wrong Colab URL pointing at the template repo, not `xr_toolz`).

## Notes
- `mkdocs build` succeeds cleanly. Three strict-mode warnings (`CHANGELOG.md` missing, broken cross-repo link in `architecture.md`, `index.md` dead link) are pre-existing and unchanged.
- All notebooks are pre-executed; `mkdocs-jupyter` renders them with `execute: false`.

## Test plan
- [ ] `uv run --group docs mkdocs build` — runs without new warnings.
- [ ] `uv run --group docs mkdocs serve` — Tutorials section visible in top nav; all 10 notebooks render with figures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)