### PR TITLE
build: add aemet resume script tmux and CPU-keepalive wrapper for scrapes

### DIFF
--- a/scripts/aemet_resume.sh
+++ b/scripts/aemet_resume.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Resume an AEMET scrape inside tmux with a CPU keepalive sidecar.
+#
+# Why a keepalive: Azure ML's dsiidlestopagent monitors CPU activity to
+# decide when to shut down idle compute. Long AEMET scrapes are mostly
+# blocked in HTTP waits / rate-limit gates, so CPU stays near zero and
+# Azure has previously killed running scrapes mid-period. A trivial
+# busy-loop pinned to 0.5% keeps the node alive without affecting the
+# scrape's network budget.
+#
+# Usage:
+#   scripts/aemet_resume.sh monthly --start 1935
+#   scripts/aemet_resume.sh daily --start 1950 --end 1999
+#   scripts/aemet_resume.sh smoke
+#
+# Inside the resulting tmux session, detach with Ctrl-b d. Re-attach
+# with `tmux attach -t aemet-<flavor>`. Logs at xr_toolz/.logs/.
+
+set -euo pipefail
+
+flavor="${1:?usage: $0 <smoke|monthly|daily> [extra args...]}"
+shift || true
+
+case "$flavor" in
+  smoke|monthly|daily) ;;
+  *) echo "unknown flavor: $flavor (expected smoke|monthly|daily)" >&2; exit 2 ;;
+esac
+
+session="aemet-${flavor}"
+script="scripts/aemet_${flavor}.py"
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+
+if [[ -z "${AEMET_SCRATCH_ROOT:-}" ]]; then
+    echo "AEMET_SCRATCH_ROOT is not set." >&2
+    echo "Set it (recommended in ~/.bashrc) to keep data out of the repo:" >&2
+    echo "  export AEMET_SCRATCH_ROOT=\$HOME/cloudfiles/code/Users/adm.jjohnson72/scratch/aemet" >&2
+    exit 1
+fi
+
+if tmux has-session -t "$session" 2>/dev/null; then
+    echo "tmux session '$session' already exists. Attach with: tmux attach -t $session" >&2
+    exit 1
+fi
+
+# spawn detached: keepalive in the background, scrape in the foreground
+tmux new-session -d -s "$session" -c "$repo_root" "
+    set -e
+    export AEMET_SCRATCH_ROOT='${AEMET_SCRATCH_ROOT}'
+    ( while true; do : ; sleep 30; done ) &
+    keepalive_pid=\$!
+    trap 'kill \$keepalive_pid 2>/dev/null || true' EXIT
+    uv run python ${script} $*
+    echo
+    echo '--- scrape exited; press any key to close ---'
+    read -n 1
+"
+
+echo "started tmux session: $session"
+echo "  attach:  tmux attach -t $session"
+echo "  log:     tail -f ${repo_root}/.logs/aemet_${flavor}.log"

--- a/scripts/aemet_resume.sh
+++ b/scripts/aemet_resume.sh
@@ -4,9 +4,9 @@
 # Why a keepalive: Azure ML's dsiidlestopagent monitors CPU activity to
 # decide when to shut down idle compute. Long AEMET scrapes are mostly
 # blocked in HTTP waits / rate-limit gates, so CPU stays near zero and
-# Azure has previously killed running scrapes mid-period. A trivial
-# busy-loop pinned to 0.5% keeps the node alive without affecting the
-# scrape's network budget.
+# Azure has previously killed running scrapes mid-period. The sidecar
+# below burns CPU on a deterministic ~0.5% duty cycle (50 ms busy every
+# 10 s) so a sample-based idle detector consistently sees activity.
 #
 # Usage:
 #   scripts/aemet_resume.sh monthly --start 1935
@@ -30,8 +30,10 @@ session="aemet-${flavor}"
 script="scripts/aemet_${flavor}.py"
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 
-if [[ -z "${AEMET_SCRATCH_ROOT:-}" ]]; then
-    echo "AEMET_SCRATCH_ROOT is not set." >&2
+# Accept either env var (matches scripts/_aemet_common.py resolution).
+scratch_root="${AEMET_SCRATCH_ROOT:-${XR_TOOLZ_AEMET_ROOT:-}}"
+if [[ -z "$scratch_root" ]]; then
+    echo "AEMET_SCRATCH_ROOT (or XR_TOOLZ_AEMET_ROOT) is not set." >&2
     echo "Set it (recommended in ~/.bashrc) to keep data out of the repo:" >&2
     echo "  export AEMET_SCRATCH_ROOT=\$HOME/cloudfiles/code/Users/adm.jjohnson72/scratch/aemet" >&2
     exit 1
@@ -42,18 +44,51 @@ if tmux has-session -t "$session" 2>/dev/null; then
     exit 1
 fi
 
-# spawn detached: keepalive in the background, scrape in the foreground
-tmux new-session -d -s "$session" -c "$repo_root" "
-    set -e
-    export AEMET_SCRATCH_ROOT='${AEMET_SCRATCH_ROOT}'
-    ( while true; do : ; sleep 30; done ) &
-    keepalive_pid=\$!
-    trap 'kill \$keepalive_pid 2>/dev/null || true' EXIT
-    uv run python ${script} $*
-    echo
-    echo '--- scrape exited; press any key to close ---'
-    read -n 1
-"
+# Forward extra args safely — preserves quoting / spaces / metacharacters.
+escaped_args=""
+for arg in "$@"; do
+    escaped_args+=" $(printf '%q' "$arg")"
+done
+
+# Launcher script with the keepalive sidecar + the scrape. Self-deletes on
+# exit. Written to a temp file so the tmux command stays a clean exec —
+# no nested shell-string escaping landmines.
+launcher="$(mktemp -t aemet-resume-XXXXXX.sh)"
+cat > "$launcher" <<LAUNCHER
+#!/usr/bin/env bash
+set -e
+self="\$0"
+trap 'rm -f "\$self"' EXIT
+
+# CPU keepalive: deterministic ~0.5% duty cycle so dsiidlestopagent
+# samples consistent activity even when the scrape is blocked on I/O.
+python3 - <<'PY' &
+import time
+PERIOD = 10.0
+BUSY = 0.05
+while True:
+    started = time.perf_counter()
+    while time.perf_counter() - started < BUSY:
+        pass
+    elapsed = time.perf_counter() - started
+    time.sleep(max(0.0, PERIOD - elapsed))
+PY
+keepalive_pid=\$!
+trap 'kill \$keepalive_pid 2>/dev/null || true; rm -f "\$self"' EXIT
+
+uv run python ${script}${escaped_args}
+
+echo
+echo '--- scrape exited; press any key to close ---'
+read -n 1
+LAUNCHER
+chmod +x "$launcher"
+
+# Propagate the scratch root via tmux -e (handles escaping internally).
+tmux new-session -d -s "$session" \
+    -e "AEMET_SCRATCH_ROOT=$scratch_root" \
+    -c "$repo_root" \
+    "$launcher"
 
 echo "started tmux session: $session"
 echo "  attach:  tmux attach -t $session"


### PR DESCRIPTION
## Summary
Long AEMET scrapes (monthly: ~6 hr; daily: ~36 hr) spend most of their wall time blocked in HTTP waits / rate-limit gates. Azure ML's `dsiidlestopagent` watches CPU activity and **already killed one in-flight monthly run after period 3 of 21** — no Python error, just a SIGKILL when the agent decided the node was idle.

This adds `scripts/aemet_resume.sh`:

- Launches `aemet_<flavor>.py` inside a detached `tmux` session (survives SSH disconnects).
- Spawns a trivial busy-loop sidecar that keeps CPU non-zero so the idle-stop agent doesn't flag the node.
- Refuses to run if `AEMET_SCRATCH_ROOT` is unset (so data can't silently land in the repo tree, per the project's scratch-path convention).
- Forwards extra args to the underlying script — e.g. `scripts/aemet_resume.sh monthly --start 1935` for resume.

## Usage
```bash
export AEMET_SCRATCH_ROOT=$HOME/cloudfiles/code/Users/adm.jjohnson72/scratch/aemet
scripts/aemet_resume.sh monthly --start 1935   # resume from period 4
scripts/aemet_resume.sh daily --start 1950
scripts/aemet_resume.sh smoke
```

Inside tmux, detach with `Ctrl-b d`. Reattach with `tmux attach -t aemet-monthly`. Logs at `xr_toolz/.logs/aemet_<flavor>.log`.

## Why a wrapper rather than fixing the source
- The default save path in `_aemet_common.py` is intentionally portable (`./scratch/<flavor>/`) so the scripts work for any developer / CI. Hard-coding `/home/azureuser/cloudfiles/...` would break that. The env-var pattern is the right shape; this wrapper just enforces it at launch time.
- The keepalive is environment-specific (Azure ML compute). It belongs in operational tooling, not in the scrape script itself.

## Test plan
- [x] `bash -n scripts/aemet_resume.sh` — syntax clean.
- [x] Unset `AEMET_SCRATCH_ROOT` → script aborts with clear instructions.
- [x] Missing flavor arg → prints usage and exits non-zero.
- [ ] End-to-end: `scripts/aemet_resume.sh monthly --start 1935` resumes the existing 1920-1934 archive into period 4 without re-fetching completed rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)