### PR TITLE
refactor(metrics): stand up xr_toolz.metrics taxonomy (F1.1)

### DIFF
--- a/src/xr_toolz/geo/__init__.py
+++ b/src/xr_toolz/geo/__init__.py
@@ -3,14 +3,22 @@
 This submodule hosts everything that applies across Earth-science
 domains: coordinate validation, spatial/temporal subsetting, masks,
 regridding-adjacent (interpolation), detrending, encoders, spectral
-analysis, pixel + spectral metrics, extremes, binning, and CRS
-utilities.
+analysis, extremes, binning, and CRS utilities.
 
 The public API is re-exported from :mod:`xr_toolz.geo._src`. For direct
 access to a specific Layer-0 module, import e.g.
 ``xr_toolz.geo._src.detrend``. Layer-1 ``Operator`` wrappers live in
 :mod:`xr_toolz.geo.operators`.
+
+Evaluation metrics (``mse``, ``rmse``, …, ``psd_score``, ``find_intercept_1D``)
+moved to :mod:`xr_toolz.metrics`. They remain importable from this
+module for one release with a :class:`DeprecationWarning`.
 """
+
+from __future__ import annotations
+
+import warnings
+from typing import Any
 
 from xr_toolz.geo._src.crs import (
     assign_crs,
@@ -73,19 +81,6 @@ from xr_toolz.geo._src.masks import (
     add_ocean_mask,
     apply_mask,
 )
-from xr_toolz.geo._src.metrics import (
-    bias,
-    correlation,
-    find_intercept_1D,
-    mae,
-    mse,
-    nrmse,
-    psd_error,
-    psd_score,
-    r2_score,
-    resolved_scale,
-    rmse,
-)
 from xr_toolz.geo._src.subset import (
     select_variables,
     subset_bbox,
@@ -99,6 +94,39 @@ from xr_toolz.geo._src.validation import (
 )
 
 
+# Names moved to xr_toolz.metrics — kept importable for one release with
+# a deprecation warning fired only on actual access (PEP 562).
+_DEPRECATED_METRICS = {
+    "bias": "xr_toolz.metrics._src.pixel",
+    "correlation": "xr_toolz.metrics._src.pixel",
+    "mae": "xr_toolz.metrics._src.pixel",
+    "mse": "xr_toolz.metrics._src.pixel",
+    "nrmse": "xr_toolz.metrics._src.pixel",
+    "r2_score": "xr_toolz.metrics._src.pixel",
+    "rmse": "xr_toolz.metrics._src.pixel",
+    "find_intercept_1D": "xr_toolz.metrics._src.spectral",
+    "psd_error": "xr_toolz.metrics._src.spectral",
+    "psd_score": "xr_toolz.metrics._src.spectral",
+    "resolved_scale": "xr_toolz.metrics._src.spectral",
+}
+
+
+def __getattr__(name: str) -> Any:
+    if name in _DEPRECATED_METRICS:
+        from importlib import import_module
+
+        warnings.warn(
+            f"xr_toolz.geo.{name} is deprecated; "
+            f"import from xr_toolz.metrics instead. "
+            f"This re-export will be removed in the next minor release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        module = import_module(_DEPRECATED_METRICS[name])
+        return getattr(module, name)
+    raise AttributeError(f"module 'xr_toolz.geo' has no attribute {name!r}")
+
+
 __all__ = [
     "Grid",
     "Period",
@@ -109,7 +137,6 @@ __all__ = [
     "add_ocean_mask",
     "apply_mask",
     "assign_crs",
-    "bias",
     "bin_2d",
     "block_maxima",
     "block_minima",
@@ -120,14 +147,12 @@ __all__ = [
     "calculate_climatology_season",
     "calculate_climatology_smoothed",
     "coarsen",
-    "correlation",
     "cyclical_encode",
     "encode_time_cyclical",
     "encode_time_ordinal",
     "fillnan_rbf",
     "fillnan_spatial",
     "fillnan_temporal",
-    "find_intercept_1D",
     "fourier_features",
     "get_crs",
     "histogram_2d",
@@ -136,26 +161,18 @@ __all__ = [
     "lon_180_to_360",
     "lon_360_to_180",
     "lonlat_to_xy",
-    "mae",
-    "mse",
-    "nrmse",
     "points_to_grid",
     "positional_encoding",
     "pot_exceedances",
     "pot_threshold",
     "pp_counts",
     "pp_stats",
-    "psd_error",
-    "psd_score",
-    "r2_score",
     "random_fourier_features",
     "refine",
     "remove_climatology",
     "rename_coords",
     "reproject",
     "resample_time",
-    "resolved_scale",
-    "rmse",
     "select_variables",
     "subset_bbox",
     "subset_time",

--- a/src/xr_toolz/geo/_src/metrics.py
+++ b/src/xr_toolz/geo/_src/metrics.py
@@ -1,49 +1,46 @@
 """Deprecated — moved to :mod:`xr_toolz.metrics`.
 
 This module re-exports the pixel and spectral metrics from their new
-home for one release, with a :class:`DeprecationWarning` on import.
-Schedule removal in the next minor release.
+home (:mod:`xr_toolz.metrics.pixel` and :mod:`xr_toolz.metrics.spectral`)
+for one release. The re-export is lazy via :pep:`562`: importing this
+module is silent, but accessing a moved name emits a
+:class:`DeprecationWarning`. Schedule removal in the next minor release.
 """
 
 from __future__ import annotations
 
 import warnings
+from typing import Any
 
 
-warnings.warn(
-    "xr_toolz.geo._src.metrics is deprecated; import from "
-    "xr_toolz.metrics (pixel + spectral submodules) instead.",
-    DeprecationWarning,
-    stacklevel=2,
-)
-
-from xr_toolz.metrics._src.pixel import (
-    bias,
-    correlation,
-    mae,
-    mse,
-    nrmse,
-    r2_score,
-    rmse,
-)
-from xr_toolz.metrics._src.spectral import (
-    find_intercept_1D,
-    psd_error,
-    psd_score,
-    resolved_scale,
-)
+_DEPRECATED_NAMES = {
+    "bias": "xr_toolz.metrics.pixel",
+    "correlation": "xr_toolz.metrics.pixel",
+    "mae": "xr_toolz.metrics.pixel",
+    "mse": "xr_toolz.metrics.pixel",
+    "nrmse": "xr_toolz.metrics.pixel",
+    "r2_score": "xr_toolz.metrics.pixel",
+    "rmse": "xr_toolz.metrics.pixel",
+    "find_intercept_1D": "xr_toolz.metrics.spectral",
+    "psd_error": "xr_toolz.metrics.spectral",
+    "psd_score": "xr_toolz.metrics.spectral",
+    "resolved_scale": "xr_toolz.metrics.spectral",
+}
 
 
-__all__ = [
-    "bias",
-    "correlation",
-    "find_intercept_1D",
-    "mae",
-    "mse",
-    "nrmse",
-    "psd_error",
-    "psd_score",
-    "r2_score",
-    "resolved_scale",
-    "rmse",
-]
+def __getattr__(name: str) -> Any:
+    if name in _DEPRECATED_NAMES:
+        from importlib import import_module
+
+        target = _DEPRECATED_NAMES[name]
+        warnings.warn(
+            f"xr_toolz.geo._src.metrics.{name} is deprecated; "
+            f"import from {target} instead. "
+            f"This re-export will be removed in the next minor release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return getattr(import_module(target), name)
+    raise AttributeError(
+        f"module 'xr_toolz.geo._src.metrics' has no attribute {name!r}"
+    )

--- a/src/xr_toolz/geo/_src/metrics.py
+++ b/src/xr_toolz/geo/_src/metrics.py
@@ -1,270 +1,49 @@
-"""Pixel-level and spectral evaluation metrics.
+"""Deprecated — moved to :mod:`xr_toolz.metrics`.
 
-Pixel metrics take ``ds_pred`` (prediction) and ``ds_ref`` (reference)
-Datasets, a variable name, and a list of reduction dimensions; they
-return a :class:`xr.DataArray` with the remaining dimensions.
-
-Spectral metrics (``psd_*_score``) compare the PSD of the prediction
-against the PSD of the reference and return a normalized score plus
-helpers to locate the resolved-scale crossover.
-
-Convention: positive ``bias`` means the prediction is larger than the
-reference. Correlation is Pearson's ``r``.
+This module re-exports the pixel and spectral metrics from their new
+home for one release, with a :class:`DeprecationWarning` on import.
+Schedule removal in the next minor release.
 """
 
 from __future__ import annotations
 
 import warnings
-from collections.abc import Sequence
-from typing import Any
 
-import numpy as np
-import xarray as xr
-from scipy.interpolate import interp1d
 
-from xr_toolz.transforms._src.fourier import (
-    drop_negative_frequencies,
-    power_spectrum,
+warnings.warn(
+    "xr_toolz.geo._src.metrics is deprecated; import from "
+    "xr_toolz.metrics (pixel + spectral submodules) instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+from xr_toolz.metrics._src.pixel import (
+    bias,
+    correlation,
+    mae,
+    mse,
+    nrmse,
+    r2_score,
+    rmse,
+)
+from xr_toolz.metrics._src.spectral import (
+    find_intercept_1D,
+    psd_error,
+    psd_score,
+    resolved_scale,
 )
 
 
-Dims = str | Sequence[str]
-
-
-def mse(
-    ds_pred: xr.Dataset,
-    ds_ref: xr.Dataset,
-    variable: str,
-    dims: Dims,
-) -> xr.DataArray:
-    """Mean squared error reduced over ``dims``."""
-    diff = ds_pred[variable] - ds_ref[variable]
-    return (diff**2).mean(dim=dims)
-
-
-def rmse(
-    ds_pred: xr.Dataset,
-    ds_ref: xr.Dataset,
-    variable: str,
-    dims: Dims,
-) -> xr.DataArray:
-    """Root mean squared error reduced over ``dims``."""
-    return mse(ds_pred, ds_ref, variable, dims) ** 0.5
-
-
-def nrmse(
-    ds_pred: xr.Dataset,
-    ds_ref: xr.Dataset,
-    variable: str,
-    dims: Dims,
-) -> xr.DataArray:
-    """Normalized RMSE: ``1 - RMSE / sqrt(<ref^2>)``.
-
-    Returns a score in ``(-inf, 1]`` where 1 means a perfect match and 0
-    means the prediction is as wrong as a zero prediction.
-    """
-    err = rmse(ds_pred, ds_ref, variable, dims)
-    scale = (ds_ref[variable] ** 2).mean(dim=dims) ** 0.5
-    return 1.0 - err / scale
-
-
-def mae(
-    ds_pred: xr.Dataset,
-    ds_ref: xr.Dataset,
-    variable: str,
-    dims: Dims,
-) -> xr.DataArray:
-    """Mean absolute error reduced over ``dims``."""
-    return abs(ds_pred[variable] - ds_ref[variable]).mean(dim=dims)
-
-
-def bias(
-    ds_pred: xr.Dataset,
-    ds_ref: xr.Dataset,
-    variable: str,
-    dims: Dims,
-) -> xr.DataArray:
-    """Mean bias ``<pred - ref>`` reduced over ``dims``."""
-    return (ds_pred[variable] - ds_ref[variable]).mean(dim=dims)
-
-
-def correlation(
-    ds_pred: xr.Dataset,
-    ds_ref: xr.Dataset,
-    variable: str,
-    dims: Dims,
-) -> xr.DataArray:
-    """Pearson correlation between prediction and reference over ``dims``."""
-    return xr.corr(ds_pred[variable], ds_ref[variable], dim=dims)
-
-
-def r2_score(
-    ds_pred: xr.Dataset,
-    ds_ref: xr.Dataset,
-    variable: str,
-    dims: Dims,
-) -> xr.DataArray:
-    """Coefficient of determination: ``1 - SS_res / SS_tot``."""
-    ref = ds_ref[variable]
-    ss_res = ((ref - ds_pred[variable]) ** 2).sum(dim=dims)
-    ss_tot = ((ref - ref.mean(dim=dims)) ** 2).sum(dim=dims)
-    return 1.0 - ss_res / ss_tot
-
-
-# ---------- spectral scores -----------------------------------------------
-
-
-def psd_error(
-    ds_pred: xr.Dataset,
-    ds_ref: xr.Dataset,
-    variable: str,
-    psd_dims: Sequence[str],
-    avg_dims: Sequence[str] | None = None,
-    isotropic: bool = False,
-    **kwargs: Any,
-) -> xr.Dataset:
-    """PSD of the prediction error ``pred - ref``.
-
-    Args:
-        ds_pred: Prediction dataset.
-        ds_ref: Reference dataset.
-        variable: Variable to score.
-        psd_dims: Dimensions over which to take the PSD.
-        avg_dims: Optional dims to conditionally average out after the
-            PSD (e.g. average over ``lat`` after computing the lon/time
-            spectrum).
-        isotropic: If ``True``, use the isotropic power spectrum.
-        **kwargs: Forwarded to the underlying PSD function.
-
-    Returns:
-        Dataset with a single ``"error"`` variable containing the
-        PSD of the error.
-    """
-    diff = (ds_pred[variable] - ds_ref[variable]).rename("error")
-    err = power_spectrum(diff, dim=list(psd_dims), isotropic=isotropic, **kwargs)
-    err_ds = err.rename("error").to_dataset()
-    if avg_dims is not None:
-        err_ds = drop_negative_frequencies(err_ds, dims=avg_dims, drop=True)
-    return err_ds
-
-
-def psd_score(
-    ds_pred: xr.Dataset,
-    ds_ref: xr.Dataset,
-    variable: str,
-    psd_dims: Sequence[str],
-    avg_dims: Sequence[str] | None = None,
-    isotropic: bool = False,
-    **kwargs: Any,
-) -> xr.Dataset:
-    """Normalized PSD score ``1 - PSD(err) / PSD(ref)``.
-
-    A score of ``1`` means the error has no power at that scale; ``0``
-    means the error has as much power as the reference signal.
-
-    Args:
-        ds_pred: Prediction dataset.
-        ds_ref: Reference dataset.
-        variable: Variable to score.
-        psd_dims: Dimensions over which to take the PSD.
-        avg_dims: Optional conditional-average dims applied after PSD.
-        isotropic: If ``True``, use the isotropic power spectrum.
-        **kwargs: Forwarded to the underlying PSD function.
-
-    Returns:
-        Dataset with a single ``"score"`` variable.
-    """
-    err = psd_error(
-        ds_pred, ds_ref, variable, psd_dims, avg_dims, isotropic=isotropic, **kwargs
-    )
-    ref_psd = power_spectrum(
-        ds_ref[variable], dim=list(psd_dims), isotropic=isotropic, **kwargs
-    )
-    ref_ds = ref_psd.rename(variable).to_dataset()
-    if avg_dims is not None:
-        ref_ds = drop_negative_frequencies(ref_ds, dims=avg_dims, drop=True)
-    score = 1.0 - err["error"] / ref_ds[variable]
-    return score.to_dataset(name="score")
-
-
-def resolved_scale(
-    score: xr.DataArray | xr.Dataset,
-    frequency: str,
-    level: float = 0.5,
-) -> float:
-    """Wavelength (``1 / frequency``) at which a PSD score crosses ``level``.
-
-    Args:
-        score: DataArray of PSD-score values along ``frequency``, or a
-            Dataset containing a ``"score"`` variable.
-        frequency: Name of the frequency coordinate.
-        level: Score threshold (default 0.5 — the commonly-used
-            "resolved scale" threshold).
-
-    Returns:
-        Scalar wavelength at which the score first crosses ``level``.
-    """
-    score_da = score["score"] if isinstance(score, xr.Dataset) else score
-    freqs = np.asarray(score_da[frequency].values)
-    vals = np.asarray(score_da.values)
-    positive = freqs > 0
-    freqs = freqs[positive]
-    vals = vals[positive]
-    wavelengths = 1.0 / freqs
-    return find_intercept_1D(x=wavelengths, y=vals, level=level)
-
-
-# ---------- interpolation helpers -----------------------------------------
-
-
-def find_intercept_1D(
-    x: np.ndarray,
-    y: np.ndarray,
-    level: float = 0.5,
-    kind: str = "slinear",
-    **kwargs: Any,
-) -> float:
-    """Invert a 1-D monotone-ish curve at ``y = level`` and return ``x``.
-
-    Uses :class:`scipy.interpolate.interp1d` on ``(y, x)``. Duplicate
-    ``y`` values (common for plateaued PSD scores) are collapsed to
-    their first occurrence in the sorted order before interpolating,
-    because ``interp1d`` requires a strictly monotone x-axis.
-    Extrapolates silently when ``level`` falls outside the range of the
-    deduplicated ``y``.
-    """
-    y_arr = np.asarray(y, dtype=float)
-    x_arr = np.asarray(x, dtype=float)
-    order = np.argsort(y_arr)
-    y_sorted = y_arr[order]
-    x_sorted = x_arr[order]
-
-    # Collapse runs of duplicate y to the first-seen x so interp1d has
-    # a strictly increasing x-axis. `np.unique` returns the first index
-    # of each unique value; we sort those indices to preserve order.
-    _, first_idx = np.unique(y_sorted, return_index=True)
-    first_idx.sort()
-    y_unique = y_sorted[first_idx]
-    x_unique = x_sorted[first_idx]
-
-    if y_unique.size < 2:
-        # Can't interpolate a single point; return it unconditionally.
-        return float(x_unique.item()) if x_unique.size else float("nan")
-
-    f = interp1d(
-        y_unique,
-        x_unique,
-        fill_value=kwargs.pop("fill_value", "extrapolate"),
-        kind=kind,
-        **kwargs,
-    )
-    try:
-        return float(np.asarray(f(level)).item())
-    except ValueError:
-        warnings.warn(
-            f"level={level} outside range of y — returning edge value.",
-            stacklevel=2,
-        )
-        y_min, y_max = float(y_unique.min()), float(y_unique.max())
-        edge = y_min if level < y_min else y_max
-        return float(np.asarray(f(edge)).item())
+__all__ = [
+    "bias",
+    "correlation",
+    "find_intercept_1D",
+    "mae",
+    "mse",
+    "nrmse",
+    "psd_error",
+    "psd_score",
+    "r2_score",
+    "resolved_scale",
+    "rmse",
+]

--- a/src/xr_toolz/geo/operators.py
+++ b/src/xr_toolz/geo/operators.py
@@ -5,10 +5,15 @@ Each class is a thin adapter: store configuration, implement
 from :class:`xr_toolz.core.Operator`, so they compose with
 :class:`~xr_toolz.core.Sequential`, the ``|`` pipe, and the functional
 :class:`~xr_toolz.core.Graph` API.
+
+Metric operators (``MSE``, ``RMSE``, …, ``PSDScore``) moved to
+:mod:`xr_toolz.metrics.operators`. They remain importable from this
+module for one release with a :class:`DeprecationWarning`.
 """
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Sequence
 from typing import Any
 
@@ -17,7 +22,6 @@ from xr_toolz.geo._src import (
     detrend as _detrend,
     interpolate as _interpolate,
     masks as _masks,
-    metrics as _metrics,
     subset as _subset,
     validation as _validation,
 )
@@ -289,112 +293,52 @@ class ResampleTime(Operator):
         return {"freq": self.freq, "method": self.method, "time": self.time}
 
 
-# ---------- pixel metrics (multi-input) -----------------------------------
+# ---------- deprecated metric ops -----------------------------------------
+
+# Moved to xr_toolz.metrics.operators. Re-export lazily for one release
+# so existing user imports continue to work with a deprecation warning.
+_DEPRECATED_METRIC_OPS = {
+    "MSE",
+    "RMSE",
+    "NRMSE",
+    "MAE",
+    "Bias",
+    "Correlation",
+    "R2Score",
+    "_PixelMetricOp",
+    "PSDScore",
+}
 
 
-class _PixelMetricOp(Operator):
-    """Base class for two-input pixel metrics."""
+def __getattr__(name: str) -> Any:
+    if name in _DEPRECATED_METRIC_OPS:
+        from importlib import import_module
 
-    _fn: Any = None
-
-    def __init__(self, variable: str, dims: str | Sequence[str]):
-        self.variable = variable
-        self.dims = dims if isinstance(dims, str) else list(dims)
-
-    def _apply(self, ds_pred, ds_ref):
-        return self.__class__._fn(ds_pred, ds_ref, self.variable, self.dims)
-
-    def get_config(self) -> dict[str, Any]:
-        return {
-            "variable": self.variable,
-            "dims": self.dims if isinstance(self.dims, str) else list(self.dims),
-        }
-
-
-class MSE(_PixelMetricOp):
-    _fn = staticmethod(_metrics.mse)
-
-
-class RMSE(_PixelMetricOp):
-    _fn = staticmethod(_metrics.rmse)
-
-
-class NRMSE(_PixelMetricOp):
-    _fn = staticmethod(_metrics.nrmse)
-
-
-class MAE(_PixelMetricOp):
-    _fn = staticmethod(_metrics.mae)
-
-
-class Bias(_PixelMetricOp):
-    _fn = staticmethod(_metrics.bias)
-
-
-class Correlation(_PixelMetricOp):
-    _fn = staticmethod(_metrics.correlation)
-
-
-class R2Score(_PixelMetricOp):
-    _fn = staticmethod(_metrics.r2_score)
-
-
-class PSDScore(Operator):
-    """Two-input PSD score operator."""
-
-    def __init__(
-        self,
-        variable: str,
-        psd_dims: Sequence[str],
-        avg_dims: Sequence[str] | None = None,
-        isotropic: bool = False,
-        **kwargs: Any,
-    ):
-        self.variable = variable
-        self.psd_dims = list(psd_dims)
-        self.avg_dims = None if avg_dims is None else list(avg_dims)
-        self.isotropic = isotropic
-        self.kwargs = dict(kwargs)
-
-    def _apply(self, ds_pred, ds_ref):
-        return _metrics.psd_score(
-            ds_pred,
-            ds_ref,
-            self.variable,
-            self.psd_dims,
-            avg_dims=self.avg_dims,
-            isotropic=self.isotropic,
-            **self.kwargs,
+        warnings.warn(
+            f"xr_toolz.geo.operators.{name} is deprecated; "
+            f"import from xr_toolz.metrics.operators instead. "
+            f"This re-export will be removed in the next minor release.",
+            DeprecationWarning,
+            stacklevel=2,
         )
-
-    def get_config(self) -> dict[str, Any]:
-        return {
-            "variable": self.variable,
-            "psd_dims": list(self.psd_dims),
-            "avg_dims": None if self.avg_dims is None else list(self.avg_dims),
-            "isotropic": self.isotropic,
-            **self.kwargs,
-        }
+        if name == "PSDScore":
+            module = import_module("xr_toolz.metrics._src.spectral")
+        else:
+            module = import_module("xr_toolz.metrics._src.pixel")
+        return getattr(module, name)
+    raise AttributeError(f"module 'xr_toolz.geo.operators' has no attribute {name!r}")
 
 
 __all__ = [
-    "MAE",
-    "MSE",
-    "NRMSE",
-    "RMSE",
     "AddClimatology",
     "AddCountryMask",
     "AddLandMask",
     "AddOceanMask",
     "ApplyMask",
-    "Bias",
     "CalculateClimatology",
     "CalculateClimatologySmoothed",
-    "Correlation",
     "FillNaNSpatial",
     "FillNaNTemporal",
-    "PSDScore",
-    "R2Score",
     "RemoveClimatology",
     "RenameCoords",
     "ResampleTime",

--- a/src/xr_toolz/geo/operators.py
+++ b/src/xr_toolz/geo/operators.py
@@ -305,7 +305,6 @@ _DEPRECATED_METRIC_OPS = {
     "Bias",
     "Correlation",
     "R2Score",
-    "_PixelMetricOp",
     "PSDScore",
 }
 

--- a/src/xr_toolz/metrics/__init__.py
+++ b/src/xr_toolz/metrics/__init__.py
@@ -1,0 +1,63 @@
+"""Evaluation metrics — pixel, spectral, and (forthcoming) view-specific.
+
+Submodules group metrics by *scientific diagnostic family*:
+
+- :mod:`xr_toolz.metrics._src.pixel` — pointwise (mse, rmse, …)
+- :mod:`xr_toolz.metrics._src.spectral` — PSD-based scores
+- :mod:`xr_toolz.metrics._src.multiscale`, :mod:`forecast` — V1
+- :mod:`xr_toolz.metrics._src.structural`, :mod:`probabilistic`,
+  :mod:`distributional`, :mod:`masked` — V2
+- :mod:`xr_toolz.metrics._src.lagrangian` — V3
+- :mod:`xr_toolz.metrics._src.physical` — V4
+- :mod:`xr_toolz.metrics._src.object` — V5
+
+Layer-1 ``Operator`` wrappers are re-exported flat from this package
+and from :mod:`xr_toolz.metrics.operators`.
+"""
+
+from xr_toolz.metrics._src.pixel import (
+    MAE,
+    MSE,
+    NRMSE,
+    RMSE,
+    Bias,
+    Correlation,
+    R2Score,
+    bias,
+    correlation,
+    mae,
+    mse,
+    nrmse,
+    r2_score,
+    rmse,
+)
+from xr_toolz.metrics._src.spectral import (
+    PSDScore,
+    find_intercept_1D,
+    psd_error,
+    psd_score,
+    resolved_scale,
+)
+
+
+__all__ = [
+    "MAE",
+    "MSE",
+    "NRMSE",
+    "RMSE",
+    "Bias",
+    "Correlation",
+    "PSDScore",
+    "R2Score",
+    "bias",
+    "correlation",
+    "find_intercept_1D",
+    "mae",
+    "mse",
+    "nrmse",
+    "psd_error",
+    "psd_score",
+    "r2_score",
+    "resolved_scale",
+    "rmse",
+]

--- a/src/xr_toolz/metrics/_src/distributional.py
+++ b/src/xr_toolz/metrics/_src/distributional.py
@@ -1,0 +1,6 @@
+"""Stub: lands with view V2 (Epic).
+
+This module is intentionally empty. It will be populated by the V2
+view epic and is shipped now so downstream PRs can import its path
+without depending on a package layout change.
+"""

--- a/src/xr_toolz/metrics/_src/forecast.py
+++ b/src/xr_toolz/metrics/_src/forecast.py
@@ -1,0 +1,6 @@
+"""Stub: lands with view V1 (Epic).
+
+This module is intentionally empty. It will be populated by the V1
+view epic and is shipped now so downstream PRs can import its path
+without depending on a package layout change.
+"""

--- a/src/xr_toolz/metrics/_src/lagrangian.py
+++ b/src/xr_toolz/metrics/_src/lagrangian.py
@@ -1,0 +1,6 @@
+"""Stub: lands with view V3 (Epic).
+
+This module is intentionally empty. It will be populated by the V3
+view epic and is shipped now so downstream PRs can import its path
+without depending on a package layout change.
+"""

--- a/src/xr_toolz/metrics/_src/masked.py
+++ b/src/xr_toolz/metrics/_src/masked.py
@@ -1,0 +1,6 @@
+"""Stub: lands with view V2 (Epic).
+
+This module is intentionally empty. It will be populated by the V2
+view epic and is shipped now so downstream PRs can import its path
+without depending on a package layout change.
+"""

--- a/src/xr_toolz/metrics/_src/multiscale.py
+++ b/src/xr_toolz/metrics/_src/multiscale.py
@@ -1,0 +1,6 @@
+"""Stub: lands with view V1 (Epic).
+
+This module is intentionally empty. It will be populated by the V1
+view epic and is shipped now so downstream PRs can import its path
+without depending on a package layout change.
+"""

--- a/src/xr_toolz/metrics/_src/object.py
+++ b/src/xr_toolz/metrics/_src/object.py
@@ -1,0 +1,6 @@
+"""Stub: lands with view V5 (Epic).
+
+This module is intentionally empty. It will be populated by the V5
+view epic and is shipped now so downstream PRs can import its path
+without depending on a package layout change.
+"""

--- a/src/xr_toolz/metrics/_src/physical.py
+++ b/src/xr_toolz/metrics/_src/physical.py
@@ -1,0 +1,6 @@
+"""Stub: lands with view V4 (Epic).
+
+This module is intentionally empty. It will be populated by the V4
+view epic and is shipped now so downstream PRs can import its path
+without depending on a package layout change.
+"""

--- a/src/xr_toolz/metrics/_src/pixel.py
+++ b/src/xr_toolz/metrics/_src/pixel.py
@@ -1,0 +1,172 @@
+"""Pixel-level (pointwise) evaluation metrics.
+
+Layer-0 functions take ``ds_pred`` (prediction) and ``ds_ref`` (reference)
+Datasets, a variable name, and a list of reduction dimensions; they
+return a :class:`xr.DataArray` with the remaining dimensions.
+
+Convention: positive ``bias`` means the prediction is larger than the
+reference. Correlation is Pearson's ``r``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+import xarray as xr
+
+from xr_toolz.core import Operator
+
+
+Dims = str | Sequence[str]
+
+
+# ---------- Layer-0 (xarray) ----------------------------------------------
+
+
+def mse(
+    ds_pred: xr.Dataset,
+    ds_ref: xr.Dataset,
+    variable: str,
+    dims: Dims,
+) -> xr.DataArray:
+    """Mean squared error reduced over ``dims``."""
+    diff = ds_pred[variable] - ds_ref[variable]
+    return (diff**2).mean(dim=dims)
+
+
+def rmse(
+    ds_pred: xr.Dataset,
+    ds_ref: xr.Dataset,
+    variable: str,
+    dims: Dims,
+) -> xr.DataArray:
+    """Root mean squared error reduced over ``dims``."""
+    return mse(ds_pred, ds_ref, variable, dims) ** 0.5
+
+
+def nrmse(
+    ds_pred: xr.Dataset,
+    ds_ref: xr.Dataset,
+    variable: str,
+    dims: Dims,
+) -> xr.DataArray:
+    """Normalized RMSE: ``1 - RMSE / sqrt(<ref^2>)``.
+
+    Returns a score in ``(-inf, 1]`` where 1 means a perfect match and 0
+    means the prediction is as wrong as a zero prediction.
+    """
+    err = rmse(ds_pred, ds_ref, variable, dims)
+    scale = (ds_ref[variable] ** 2).mean(dim=dims) ** 0.5
+    return 1.0 - err / scale
+
+
+def mae(
+    ds_pred: xr.Dataset,
+    ds_ref: xr.Dataset,
+    variable: str,
+    dims: Dims,
+) -> xr.DataArray:
+    """Mean absolute error reduced over ``dims``."""
+    return abs(ds_pred[variable] - ds_ref[variable]).mean(dim=dims)
+
+
+def bias(
+    ds_pred: xr.Dataset,
+    ds_ref: xr.Dataset,
+    variable: str,
+    dims: Dims,
+) -> xr.DataArray:
+    """Mean bias ``<pred - ref>`` reduced over ``dims``."""
+    return (ds_pred[variable] - ds_ref[variable]).mean(dim=dims)
+
+
+def correlation(
+    ds_pred: xr.Dataset,
+    ds_ref: xr.Dataset,
+    variable: str,
+    dims: Dims,
+) -> xr.DataArray:
+    """Pearson correlation between prediction and reference over ``dims``."""
+    return xr.corr(ds_pred[variable], ds_ref[variable], dim=dims)
+
+
+def r2_score(
+    ds_pred: xr.Dataset,
+    ds_ref: xr.Dataset,
+    variable: str,
+    dims: Dims,
+) -> xr.DataArray:
+    """Coefficient of determination: ``1 - SS_res / SS_tot``."""
+    ref = ds_ref[variable]
+    ss_res = ((ref - ds_pred[variable]) ** 2).sum(dim=dims)
+    ss_tot = ((ref - ref.mean(dim=dims)) ** 2).sum(dim=dims)
+    return 1.0 - ss_res / ss_tot
+
+
+# ---------- Layer-1 (Operator wrappers) -----------------------------------
+
+
+class _PixelMetricOp(Operator):
+    """Base class for two-input pixel metrics."""
+
+    _fn: Any = None
+
+    def __init__(self, variable: str, dims: str | Sequence[str]):
+        self.variable = variable
+        self.dims = dims if isinstance(dims, str) else list(dims)
+
+    def _apply(self, ds_pred, ds_ref):
+        return self.__class__._fn(ds_pred, ds_ref, self.variable, self.dims)
+
+    def get_config(self) -> dict[str, Any]:
+        return {
+            "variable": self.variable,
+            "dims": self.dims if isinstance(self.dims, str) else list(self.dims),
+        }
+
+
+class MSE(_PixelMetricOp):
+    _fn = staticmethod(mse)
+
+
+class RMSE(_PixelMetricOp):
+    _fn = staticmethod(rmse)
+
+
+class NRMSE(_PixelMetricOp):
+    _fn = staticmethod(nrmse)
+
+
+class MAE(_PixelMetricOp):
+    _fn = staticmethod(mae)
+
+
+class Bias(_PixelMetricOp):
+    _fn = staticmethod(bias)
+
+
+class Correlation(_PixelMetricOp):
+    _fn = staticmethod(correlation)
+
+
+class R2Score(_PixelMetricOp):
+    _fn = staticmethod(r2_score)
+
+
+__all__ = [
+    "MAE",
+    "MSE",
+    "NRMSE",
+    "RMSE",
+    "Bias",
+    "Correlation",
+    "R2Score",
+    "bias",
+    "correlation",
+    "mae",
+    "mse",
+    "nrmse",
+    "r2_score",
+    "rmse",
+]

--- a/src/xr_toolz/metrics/_src/probabilistic.py
+++ b/src/xr_toolz/metrics/_src/probabilistic.py
@@ -1,0 +1,6 @@
+"""Stub: lands with view V2 (Epic).
+
+This module is intentionally empty. It will be populated by the V2
+view epic and is shipped now so downstream PRs can import its path
+without depending on a package layout change.
+"""

--- a/src/xr_toolz/metrics/_src/spectral.py
+++ b/src/xr_toolz/metrics/_src/spectral.py
@@ -1,0 +1,224 @@
+"""Spectral evaluation metrics.
+
+Spectral metrics (``psd_*``) compare the PSD of the prediction against
+the PSD of the reference and return a normalized score plus helpers to
+locate the resolved-scale crossover.
+"""
+
+from __future__ import annotations
+
+import warnings
+from collections.abc import Sequence
+from typing import Any
+
+import numpy as np
+import xarray as xr
+from scipy.interpolate import interp1d
+
+from xr_toolz.core import Operator
+from xr_toolz.transforms._src.fourier import (
+    drop_negative_frequencies,
+    power_spectrum,
+)
+
+
+# ---------- Layer-0 (xarray) ----------------------------------------------
+
+
+def psd_error(
+    ds_pred: xr.Dataset,
+    ds_ref: xr.Dataset,
+    variable: str,
+    psd_dims: Sequence[str],
+    avg_dims: Sequence[str] | None = None,
+    isotropic: bool = False,
+    **kwargs: Any,
+) -> xr.Dataset:
+    """PSD of the prediction error ``pred - ref``.
+
+    Args:
+        ds_pred: Prediction dataset.
+        ds_ref: Reference dataset.
+        variable: Variable to score.
+        psd_dims: Dimensions over which to take the PSD.
+        avg_dims: Optional dims to conditionally average out after the
+            PSD (e.g. average over ``lat`` after computing the lon/time
+            spectrum).
+        isotropic: If ``True``, use the isotropic power spectrum.
+        **kwargs: Forwarded to the underlying PSD function.
+
+    Returns:
+        Dataset with a single ``"error"`` variable containing the
+        PSD of the error.
+    """
+    diff = (ds_pred[variable] - ds_ref[variable]).rename("error")
+    err = power_spectrum(diff, dim=list(psd_dims), isotropic=isotropic, **kwargs)
+    err_ds = err.rename("error").to_dataset()
+    if avg_dims is not None:
+        err_ds = drop_negative_frequencies(err_ds, dims=avg_dims, drop=True)
+    return err_ds
+
+
+def psd_score(
+    ds_pred: xr.Dataset,
+    ds_ref: xr.Dataset,
+    variable: str,
+    psd_dims: Sequence[str],
+    avg_dims: Sequence[str] | None = None,
+    isotropic: bool = False,
+    **kwargs: Any,
+) -> xr.Dataset:
+    """Normalized PSD score ``1 - PSD(err) / PSD(ref)``.
+
+    A score of ``1`` means the error has no power at that scale; ``0``
+    means the error has as much power as the reference signal.
+
+    Args:
+        ds_pred: Prediction dataset.
+        ds_ref: Reference dataset.
+        variable: Variable to score.
+        psd_dims: Dimensions over which to take the PSD.
+        avg_dims: Optional conditional-average dims applied after PSD.
+        isotropic: If ``True``, use the isotropic power spectrum.
+        **kwargs: Forwarded to the underlying PSD function.
+
+    Returns:
+        Dataset with a single ``"score"`` variable.
+    """
+    err = psd_error(
+        ds_pred, ds_ref, variable, psd_dims, avg_dims, isotropic=isotropic, **kwargs
+    )
+    ref_psd = power_spectrum(
+        ds_ref[variable], dim=list(psd_dims), isotropic=isotropic, **kwargs
+    )
+    ref_ds = ref_psd.rename(variable).to_dataset()
+    if avg_dims is not None:
+        ref_ds = drop_negative_frequencies(ref_ds, dims=avg_dims, drop=True)
+    score = 1.0 - err["error"] / ref_ds[variable]
+    return score.to_dataset(name="score")
+
+
+def resolved_scale(
+    score: xr.DataArray | xr.Dataset,
+    frequency: str,
+    level: float = 0.5,
+) -> float:
+    """Wavelength (``1 / frequency``) at which a PSD score crosses ``level``.
+
+    Args:
+        score: DataArray of PSD-score values along ``frequency``, or a
+            Dataset containing a ``"score"`` variable.
+        frequency: Name of the frequency coordinate.
+        level: Score threshold (default 0.5 — the commonly-used
+            "resolved scale" threshold).
+
+    Returns:
+        Scalar wavelength at which the score first crosses ``level``.
+    """
+    score_da = score["score"] if isinstance(score, xr.Dataset) else score
+    freqs = np.asarray(score_da[frequency].values)
+    vals = np.asarray(score_da.values)
+    positive = freqs > 0
+    freqs = freqs[positive]
+    vals = vals[positive]
+    wavelengths = 1.0 / freqs
+    return find_intercept_1D(x=wavelengths, y=vals, level=level)
+
+
+def find_intercept_1D(
+    x: np.ndarray,
+    y: np.ndarray,
+    level: float = 0.5,
+    kind: str = "slinear",
+    **kwargs: Any,
+) -> float:
+    """Invert a 1-D monotone-ish curve at ``y = level`` and return ``x``.
+
+    Uses :class:`scipy.interpolate.interp1d` on ``(y, x)``. Duplicate
+    ``y`` values (common for plateaued PSD scores) are collapsed to
+    their first occurrence in the sorted order before interpolating,
+    because ``interp1d`` requires a strictly monotone x-axis.
+    Extrapolates silently when ``level`` falls outside the range of the
+    deduplicated ``y``.
+    """
+    y_arr = np.asarray(y, dtype=float)
+    x_arr = np.asarray(x, dtype=float)
+    order = np.argsort(y_arr)
+    y_sorted = y_arr[order]
+    x_sorted = x_arr[order]
+
+    _, first_idx = np.unique(y_sorted, return_index=True)
+    first_idx.sort()
+    y_unique = y_sorted[first_idx]
+    x_unique = x_sorted[first_idx]
+
+    if y_unique.size < 2:
+        return float(x_unique.item()) if x_unique.size else float("nan")
+
+    f = interp1d(
+        y_unique,
+        x_unique,
+        fill_value=kwargs.pop("fill_value", "extrapolate"),
+        kind=kind,
+        **kwargs,
+    )
+    try:
+        return float(np.asarray(f(level)).item())
+    except ValueError:
+        warnings.warn(
+            f"level={level} outside range of y — returning edge value.",
+            stacklevel=2,
+        )
+        y_min, y_max = float(y_unique.min()), float(y_unique.max())
+        edge = y_min if level < y_min else y_max
+        return float(np.asarray(f(edge)).item())
+
+
+# ---------- Layer-1 (Operator wrappers) -----------------------------------
+
+
+class PSDScore(Operator):
+    """Two-input PSD score operator."""
+
+    def __init__(
+        self,
+        variable: str,
+        psd_dims: Sequence[str],
+        avg_dims: Sequence[str] | None = None,
+        isotropic: bool = False,
+        **kwargs: Any,
+    ):
+        self.variable = variable
+        self.psd_dims = list(psd_dims)
+        self.avg_dims = None if avg_dims is None else list(avg_dims)
+        self.isotropic = isotropic
+        self.kwargs = dict(kwargs)
+
+    def _apply(self, ds_pred, ds_ref):
+        return psd_score(
+            ds_pred,
+            ds_ref,
+            self.variable,
+            self.psd_dims,
+            avg_dims=self.avg_dims,
+            isotropic=self.isotropic,
+            **self.kwargs,
+        )
+
+    def get_config(self) -> dict[str, Any]:
+        return {
+            "variable": self.variable,
+            "psd_dims": list(self.psd_dims),
+            "avg_dims": None if self.avg_dims is None else list(self.avg_dims),
+            "isotropic": self.isotropic,
+            **self.kwargs,
+        }
+
+
+__all__ = [
+    "PSDScore",
+    "find_intercept_1D",
+    "psd_error",
+    "psd_score",
+    "resolved_scale",
+]

--- a/src/xr_toolz/metrics/_src/structural.py
+++ b/src/xr_toolz/metrics/_src/structural.py
@@ -1,0 +1,6 @@
+"""Stub: lands with view V2 (Epic).
+
+This module is intentionally empty. It will be populated by the V2
+view epic and is shipped now so downstream PRs can import its path
+without depending on a package layout change.
+"""

--- a/src/xr_toolz/metrics/distributional.py
+++ b/src/xr_toolz/metrics/distributional.py
@@ -1,0 +1,8 @@
+"""Stub: lands with view V2 (Epic).
+
+This module is intentionally empty. It will be populated by the V2
+view epic. Importing it succeeds today so downstream PRs can land
+additively without a package layout change.
+"""
+
+from xr_toolz.metrics._src.distributional import *  # noqa: F403

--- a/src/xr_toolz/metrics/forecast.py
+++ b/src/xr_toolz/metrics/forecast.py
@@ -1,0 +1,8 @@
+"""Stub: lands with view V1 (Epic).
+
+This module is intentionally empty. It will be populated by the V1
+view epic. Importing it succeeds today so downstream PRs can land
+additively without a package layout change.
+"""
+
+from xr_toolz.metrics._src.forecast import *  # noqa: F403

--- a/src/xr_toolz/metrics/lagrangian.py
+++ b/src/xr_toolz/metrics/lagrangian.py
@@ -1,0 +1,8 @@
+"""Stub: lands with view V3 (Epic).
+
+This module is intentionally empty. It will be populated by the V3
+view epic. Importing it succeeds today so downstream PRs can land
+additively without a package layout change.
+"""
+
+from xr_toolz.metrics._src.lagrangian import *  # noqa: F403

--- a/src/xr_toolz/metrics/masked.py
+++ b/src/xr_toolz/metrics/masked.py
@@ -1,0 +1,8 @@
+"""Stub: lands with view V2 (Epic).
+
+This module is intentionally empty. It will be populated by the V2
+view epic. Importing it succeeds today so downstream PRs can land
+additively without a package layout change.
+"""
+
+from xr_toolz.metrics._src.masked import *  # noqa: F403

--- a/src/xr_toolz/metrics/multiscale.py
+++ b/src/xr_toolz/metrics/multiscale.py
@@ -1,0 +1,8 @@
+"""Stub: lands with view V1 (Epic).
+
+This module is intentionally empty. It will be populated by the V1
+view epic. Importing it succeeds today so downstream PRs can land
+additively without a package layout change.
+"""
+
+from xr_toolz.metrics._src.multiscale import *  # noqa: F403

--- a/src/xr_toolz/metrics/object.py
+++ b/src/xr_toolz/metrics/object.py
@@ -1,0 +1,8 @@
+"""Stub: lands with view V5 (Epic).
+
+This module is intentionally empty. It will be populated by the V5
+view epic. Importing it succeeds today so downstream PRs can land
+additively without a package layout change.
+"""
+
+from xr_toolz.metrics._src.object import *  # noqa: F403

--- a/src/xr_toolz/metrics/operators.py
+++ b/src/xr_toolz/metrics/operators.py
@@ -1,0 +1,29 @@
+"""Layer-1 ``Operator`` wrappers for evaluation metrics.
+
+This module re-exports the operator classes from
+:mod:`xr_toolz.metrics._src.pixel` and :mod:`xr_toolz.metrics._src.spectral`
+for ergonomic ``from xr_toolz.metrics.operators import RMSE`` access.
+"""
+
+from xr_toolz.metrics._src.pixel import (
+    MAE,
+    MSE,
+    NRMSE,
+    RMSE,
+    Bias,
+    Correlation,
+    R2Score,
+)
+from xr_toolz.metrics._src.spectral import PSDScore
+
+
+__all__ = [
+    "MAE",
+    "MSE",
+    "NRMSE",
+    "RMSE",
+    "Bias",
+    "Correlation",
+    "PSDScore",
+    "R2Score",
+]

--- a/src/xr_toolz/metrics/physical.py
+++ b/src/xr_toolz/metrics/physical.py
@@ -1,0 +1,8 @@
+"""Stub: lands with view V4 (Epic).
+
+This module is intentionally empty. It will be populated by the V4
+view epic. Importing it succeeds today so downstream PRs can land
+additively without a package layout change.
+"""
+
+from xr_toolz.metrics._src.physical import *  # noqa: F403

--- a/src/xr_toolz/metrics/pixel.py
+++ b/src/xr_toolz/metrics/pixel.py
@@ -1,0 +1,45 @@
+"""Pointwise (pixel-level) evaluation metrics — public re-export.
+
+Layer-0 functions: :func:`mse`, :func:`rmse`, :func:`nrmse`, :func:`mae`,
+:func:`bias`, :func:`correlation`, :func:`r2_score`.
+
+Layer-1 operators: :class:`MSE`, :class:`RMSE`, :class:`NRMSE`,
+:class:`MAE`, :class:`Bias`, :class:`Correlation`, :class:`R2Score`.
+
+Implementation lives in :mod:`xr_toolz.metrics._src.pixel`.
+"""
+
+from xr_toolz.metrics._src.pixel import (
+    MAE,
+    MSE,
+    NRMSE,
+    RMSE,
+    Bias,
+    Correlation,
+    R2Score,
+    bias,
+    correlation,
+    mae,
+    mse,
+    nrmse,
+    r2_score,
+    rmse,
+)
+
+
+__all__ = [
+    "MAE",
+    "MSE",
+    "NRMSE",
+    "RMSE",
+    "Bias",
+    "Correlation",
+    "R2Score",
+    "bias",
+    "correlation",
+    "mae",
+    "mse",
+    "nrmse",
+    "r2_score",
+    "rmse",
+]

--- a/src/xr_toolz/metrics/probabilistic.py
+++ b/src/xr_toolz/metrics/probabilistic.py
@@ -1,0 +1,8 @@
+"""Stub: lands with view V2 (Epic).
+
+This module is intentionally empty. It will be populated by the V2
+view epic. Importing it succeeds today so downstream PRs can land
+additively without a package layout change.
+"""
+
+from xr_toolz.metrics._src.probabilistic import *  # noqa: F403

--- a/src/xr_toolz/metrics/spectral.py
+++ b/src/xr_toolz/metrics/spectral.py
@@ -1,0 +1,26 @@
+"""Spectral evaluation metrics — public re-export.
+
+Layer-0 functions: :func:`psd_error`, :func:`psd_score`,
+:func:`resolved_scale`, :func:`find_intercept_1D`.
+
+Layer-1 operators: :class:`PSDScore`.
+
+Implementation lives in :mod:`xr_toolz.metrics._src.spectral`.
+"""
+
+from xr_toolz.metrics._src.spectral import (
+    PSDScore,
+    find_intercept_1D,
+    psd_error,
+    psd_score,
+    resolved_scale,
+)
+
+
+__all__ = [
+    "PSDScore",
+    "find_intercept_1D",
+    "psd_error",
+    "psd_score",
+    "resolved_scale",
+]

--- a/src/xr_toolz/metrics/structural.py
+++ b/src/xr_toolz/metrics/structural.py
@@ -1,0 +1,8 @@
+"""Stub: lands with view V2 (Epic).
+
+This module is intentionally empty. It will be populated by the V2
+view epic. Importing it succeeds today so downstream PRs can land
+additively without a package layout change.
+"""
+
+from xr_toolz.metrics._src.structural import *  # noqa: F403

--- a/tests/test_metrics_imports.py
+++ b/tests/test_metrics_imports.py
@@ -1,0 +1,196 @@
+"""Import-surface tests for :mod:`xr_toolz.metrics` — guards against
+regressions in the public API as the validation framework lands.
+"""
+
+from __future__ import annotations
+
+import importlib
+import warnings
+
+import pytest
+
+
+# ---- New canonical surface ------------------------------------------------
+
+
+def test_metrics_package_root_exposes_layer0_and_operators():
+    from xr_toolz.metrics import (
+        MAE,
+        MSE,
+        NRMSE,
+        RMSE,
+        Bias,
+        Correlation,
+        PSDScore,
+        R2Score,
+        bias,
+        correlation,
+        find_intercept_1D,
+        mae,
+        mse,
+        nrmse,
+        psd_error,
+        psd_score,
+        r2_score,
+        resolved_scale,
+        rmse,
+    )
+
+    # Sanity-check at least one is callable.
+    assert callable(rmse)
+    assert RMSE.__name__ == "RMSE"
+    assert PSDScore.__name__ == "PSDScore"
+    # Hit unused-import suppression via tuple to keep the comprehensive list.
+    _ = (
+        MAE,
+        MSE,
+        NRMSE,
+        Bias,
+        Correlation,
+        R2Score,
+        bias,
+        correlation,
+        find_intercept_1D,
+        mae,
+        mse,
+        nrmse,
+        psd_error,
+        psd_score,
+        r2_score,
+        resolved_scale,
+    )
+
+
+def test_metrics_pixel_submodule_imports():
+    from xr_toolz.metrics.pixel import (
+        MAE,
+        MSE,
+        NRMSE,
+        RMSE,
+        Bias,
+        Correlation,
+        R2Score,
+        bias,
+        correlation,
+        mae,
+        mse,
+        nrmse,
+        r2_score,
+        rmse,
+    )
+
+    assert callable(mse)
+    _ = (
+        MAE,
+        MSE,
+        NRMSE,
+        RMSE,
+        Bias,
+        Correlation,
+        R2Score,
+        bias,
+        correlation,
+        mae,
+        nrmse,
+        r2_score,
+        rmse,
+    )
+
+
+def test_metrics_spectral_submodule_imports():
+    from xr_toolz.metrics.spectral import (
+        PSDScore,
+        find_intercept_1D,
+        psd_error,
+        psd_score,
+        resolved_scale,
+    )
+
+    assert callable(psd_score)
+    _ = (PSDScore, find_intercept_1D, psd_error, resolved_scale)
+
+
+def test_metrics_operators_submodule_imports():
+    from xr_toolz.metrics.operators import (
+        MAE,
+        MSE,
+        NRMSE,
+        RMSE,
+        Bias,
+        Correlation,
+        PSDScore,
+        R2Score,
+    )
+
+    assert RMSE.__name__ == "RMSE"
+    _ = (MAE, MSE, NRMSE, PSDScore, Bias, Correlation, R2Score)
+
+
+@pytest.mark.parametrize(
+    "submodule",
+    [
+        "forecast",
+        "multiscale",
+        "structural",
+        "probabilistic",
+        "distributional",
+        "masked",
+        "object",
+        "physical",
+        "lagrangian",
+    ],
+)
+def test_metrics_view_stub_submodules_are_importable(submodule):
+    """Importing any V1–V5 stub submodule must succeed even before its
+    epic lands its bodies — this is what unblocks the additive merge order.
+    """
+    importlib.import_module(f"xr_toolz.metrics.{submodule}")
+
+
+# ---- Legacy deprecation surface ------------------------------------------
+
+
+def test_legacy_geo_metric_imports_warn_but_resolve():
+    """``from xr_toolz.geo import rmse`` must keep working for one
+    release with a :class:`DeprecationWarning`.
+    """
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        from xr_toolz.geo import rmse  # noqa: F401
+
+    deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert deprecations, "expected DeprecationWarning on legacy xr_toolz.geo.rmse"
+    assert "xr_toolz.metrics" in str(deprecations[0].message)
+
+
+def test_legacy_geo_operators_metric_imports_warn_but_resolve():
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        from xr_toolz.geo.operators import RMSE  # noqa: F401
+
+    deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert deprecations, "expected DeprecationWarning on geo.operators.RMSE"
+    assert "xr_toolz.metrics.operators" in str(deprecations[0].message)
+
+
+def test_plain_import_xr_toolz_geo_is_silent():
+    """Importing the package itself (without naming a moved metric) must
+    not emit a :class:`DeprecationWarning` — the warning is per-name.
+    """
+    import xr_toolz.geo
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        importlib.reload(xr_toolz.geo)
+
+    metric_deprecations = [
+        w
+        for w in caught
+        if issubclass(w.category, DeprecationWarning)
+        and "xr_toolz.geo." in str(w.message)
+        and "is deprecated" in str(w.message)
+    ]
+    assert not metric_deprecations, (
+        f"plain import of xr_toolz.geo emitted unexpected deprecation warnings: "
+        f"{[str(w.message) for w in metric_deprecations]}"
+    )


### PR DESCRIPTION
## Summary
- Stand up `xr_toolz.metrics` with the submodule layout from `docs/design/validation.md`
- Move the 11 Layer-0 fns (`mse`, `rmse`, `nrmse`, `mae`, `bias`, `correlation`, `r2_score`, `psd_error`, `psd_score`, `resolved_scale`, `find_intercept_1D`) and 8 Layer-1 ops (`MSE`/`RMSE`/`NRMSE`/`MAE`/`Bias`/`Correlation`/`R2Score`/`PSDScore`) into `metrics._src.{pixel,spectral}`
- Add empty stubs for `multiscale`, `structural`, `probabilistic`, `distributional`, `masked`, `forecast`, `object`, `physical`, `lagrangian` so the V1–V5 view PRs land cleanly
- Old paths (`xr_toolz.geo.{rmse,…}` and `xr_toolz.geo.operators.{MSE,…}`) keep working for one release via lazy `__getattr__` shims that emit a `DeprecationWarning` only when a moved name is accessed

**No math changes.** Pure move + re-export.

## Why
F1.1 is the load-bearing piece of the validation-framework refactor: every V1–V6 epic depends on `xr_toolz.metrics.{forecast,spectral,structural,probabilistic,distributional,masked,object,physical,lagrangian}` existing as importable paths. F2 (three-tier type contract) also pilots on `metrics`, so this unblocks both arms of the work.

Closes #23.

## Behaviour
- `from xr_toolz.metrics import RMSE, PSDScore` ✅
- `from xr_toolz.metrics.operators import MSE, ...` ✅
- `from xr_toolz.geo import rmse, ...` ✅ (with `DeprecationWarning`)
- `from xr_toolz.geo.operators import RMSE, ..., PSDScore` ✅ (with `DeprecationWarning`)
- Plain `import xr_toolz.geo` is silent — only the moved names trigger warnings, on actual access

## Test plan
- [x] `uv run pytest --no-cov` — 522 passed, 1 skipped (no test edits)
- [x] `uv run --group lint ruff check .` — clean
- [x] `uv run --group lint ruff format --check .` — clean
- [x] `uv run --group typecheck ty check src/xr_toolz` — same 40 pre-existing diagnostics on `main`, none in metrics/geo

## Follow-ups (separate PRs in this epic)
- #24 — F1.2: public API surface + mkdocs API reference page
- #25 — F1.3: spell out object-metric class names (POD → ProbabilityOfDetection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)