### PR TITLE
refactor(metrics.object): reserve long-form class names for V5 (F1.3)

### DIFF
--- a/docs/design/api/README.md
+++ b/docs/design/api/README.md
@@ -57,7 +57,7 @@ Each submodule provides Layer 0 pure functions and Layer 1 Operator wrappers. La
 | `lagrangian` | Particle and transport diagnostics | `advect_particles`, `pair_dispersion`, `residence_time`, `ftle` | `AdvectParticles`, `PairDispersion`, `FTLE` | v0.4 |
 | `budgets` | Control-volume and conservation diagnostics | `budget_residual`, `heat_budget_residual`, `salt_budget_residual` | `BudgetResidual`, `HeatBudgetResidual` | v0.4 |
 | `phenomena` | Object/event detection and matching | `detect_marine_heatwaves`, `detect_eddies`, `match_objects` | `DetectMarineHeatwaves`, `DetectEddies`, `MatchObjects` | v0.4 |
-| `metrics.object` | Event/object verification scores | `contingency_table`, `pod`, `far`, `csi`, `iou` | `ProbabilityOfDetection`, `FalseAlarmRatio`, `CriticalSuccessIndex`, `IntersectionOverUnion` | v0.4 |
+| `metrics.object` | Event/object verification scores | `contingency_table`, `pod`, `far`, `csi`, `iou` | `ProbabilityOfDetection`, `FalseAlarmRatio`, `CriticalSuccessIndex`, `IntersectionOverUnion`, `DurationError`, `IntensityBias`, `CentroidDistance` | v0.4 |
 
 **Status key:** `v0.1` = Foundation | `v0.2` = Analysis + Inference | `v0.3` = Domain Operators + expanded metrics | `v0.4+` = Validation expansion
 

--- a/src/xr_toolz/metrics/_src/object.py
+++ b/src/xr_toolz/metrics/_src/object.py
@@ -1,6 +1,68 @@
-"""Stub: lands with view V5 (Epic).
+"""Object-verification metric class-name reservations (V5 surface).
 
-This module is intentionally empty. It will be populated by the V5
-view epic and is shipped now so downstream PRs can import its path
-without depending on a package layout change.
+This module is *importable today* and reserves the canonical long-form
+class names per D14 (no short-form ``POD`` / ``FAR`` / ``CSI`` / ``IoU``
+aliases on the public surface). The classes carry no implementation
+yet: each ``__init__`` raises ``NotImplementedError`` so accidental use
+produces a clear failure pointing at V5 (Epic).
+
+V5 (Epic) lands the real implementations, conditional moments, and
+detector / matcher integration. Until then, the public name surface is
+stable so downstream code can ``import`` it without churning when V5
+ships.
 """
+
+from __future__ import annotations
+
+from typing import Any
+
+from xr_toolz.core import Operator
+
+
+class _ObjectMetricStub(Operator):
+    """Common ``NotImplementedError`` shell for V5 stubs."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        raise NotImplementedError(
+            f"{self.__class__.__name__} is a name reservation; "
+            "implementation lands with V5 (Epic V5)."
+        )
+
+
+class ProbabilityOfDetection(_ObjectMetricStub):
+    """Hits / (hits + misses). Implementation pending V5."""
+
+
+class FalseAlarmRatio(_ObjectMetricStub):
+    """False alarms / (hits + false alarms). Implementation pending V5."""
+
+
+class CriticalSuccessIndex(_ObjectMetricStub):
+    """Threat score: ``hits / (hits + misses + false alarms)``. V5 stub."""
+
+
+class IntersectionOverUnion(_ObjectMetricStub):
+    """Object overlap: |A ∩ B| / |A ∪ B|. Implementation pending V5."""
+
+
+class DurationError(_ObjectMetricStub):
+    """Bias in matched-event duration. Implementation pending V5."""
+
+
+class IntensityBias(_ObjectMetricStub):
+    """Bias in matched-event intensity. Implementation pending V5."""
+
+
+class CentroidDistance(_ObjectMetricStub):
+    """Centroid displacement between matched objects. Implementation pending V5."""
+
+
+__all__ = [
+    "CentroidDistance",
+    "CriticalSuccessIndex",
+    "DurationError",
+    "FalseAlarmRatio",
+    "IntensityBias",
+    "IntersectionOverUnion",
+    "ProbabilityOfDetection",
+]

--- a/src/xr_toolz/metrics/object.py
+++ b/src/xr_toolz/metrics/object.py
@@ -1,8 +1,27 @@
-"""Stub: lands with view V5 (Epic).
+"""Object-verification metric class names — public re-export.
 
-This module is intentionally empty. It will be populated by the V5
-view epic. Importing it succeeds today so downstream PRs can land
-additively without a package layout change.
+The classes below are name reservations only (D14: spelled-out canonical
+names). Implementations land with V5 (Epic V5); calling any of them today
+raises ``NotImplementedError``.
 """
 
-from xr_toolz.metrics._src.object import *  # noqa: F403
+from xr_toolz.metrics._src.object import (
+    CentroidDistance,
+    CriticalSuccessIndex,
+    DurationError,
+    FalseAlarmRatio,
+    IntensityBias,
+    IntersectionOverUnion,
+    ProbabilityOfDetection,
+)
+
+
+__all__ = [
+    "CentroidDistance",
+    "CriticalSuccessIndex",
+    "DurationError",
+    "FalseAlarmRatio",
+    "IntensityBias",
+    "IntersectionOverUnion",
+    "ProbabilityOfDetection",
+]

--- a/tests/test_metrics_imports.py
+++ b/tests/test_metrics_imports.py
@@ -135,7 +135,6 @@ def test_metrics_operators_submodule_imports():
         "probabilistic",
         "distributional",
         "masked",
-        "object",
         "physical",
         "lagrangian",
     ],
@@ -145,6 +144,9 @@ def test_metrics_view_stub_submodules_are_importable(submodule):
     epic lands its bodies — this is what unblocks the additive merge order.
     The stub must also expose no public names today; the V epic that
     fills it in is responsible for the public surface.
+
+    ``object`` is excluded: F1.3 pre-reserves the canonical long-form
+    V5 class names there. See ``test_metrics_object_reserved_names``.
     """
     mod = importlib.import_module(f"xr_toolz.metrics.{submodule}")
     public_names = [n for n in dir(mod) if not n.startswith("_")]
@@ -152,6 +154,39 @@ def test_metrics_view_stub_submodules_are_importable(submodule):
         f"xr_toolz.metrics.{submodule} unexpectedly exports public names: "
         f"{public_names}"
     )
+
+
+_RESERVED_OBJECT_CLASSES = (
+    "ProbabilityOfDetection",
+    "FalseAlarmRatio",
+    "CriticalSuccessIndex",
+    "IntersectionOverUnion",
+    "DurationError",
+    "IntensityBias",
+    "CentroidDistance",
+)
+
+
+def test_metrics_object_exposes_all_reserved_names():
+    """``metrics.object`` reserves the V5 long-form names per D14."""
+    import xr_toolz.metrics.object as obj
+
+    assert set(_RESERVED_OBJECT_CLASSES) <= set(dir(obj))
+
+
+@pytest.mark.parametrize("name", _RESERVED_OBJECT_CLASSES)
+def test_metrics_object_reserved_class_raises_notimplementederror(name):
+    """Each V5-reserved class must raise ``NotImplementedError`` on
+    instantiation, with a message that names the class and points at V5.
+    """
+    from xr_toolz.metrics import object as obj_module
+
+    cls = getattr(obj_module, name)
+    with pytest.raises(NotImplementedError) as exc_info:
+        cls()
+    msg = str(exc_info.value)
+    assert name in msg, f"error message for {name} does not name the class: {msg!r}"
+    assert "V5" in msg, f"error message for {name} does not point at V5: {msg!r}"
 
 
 # ---- Legacy deprecation surface ------------------------------------------


### PR DESCRIPTION
**Stacked on #93** (F1.2) → #92 (F1.1). Merge those first.

## Summary
Pre-create the canonical spelled-out object-verification class names per D14 so V5 (Epic) can fill in the implementations later. All 7 stubs share a private `_ObjectMetricStub` whose `__init__` raises `NotImplementedError` — names reserved on the public surface, accidental use fails loudly pointing at V5.

**Reserved names:** `ProbabilityOfDetection`, `FalseAlarmRatio`, `CriticalSuccessIndex`, `IntersectionOverUnion`, `DurationError`, `IntensityBias`, `CentroidDistance`.

## Changes
- `metrics/_src/object.py` — 7 long-form stubs + `__all__`, all raise `NotImplementedError` on instantiation
- `metrics/object.py` — public re-export shim now lists all 7 explicitly
- `docs/design/api/README.md` — extend `metrics.object` inventory row with all 7

## Audit
`docs/design/**` has **zero** short-form (`POD`/`FAR`/`CSI`/`IoU`) class names in code snippets. Only `validation-decisions.md §D14` mentions the abbreviations in prose, alongside the long forms in parentheses — the intended reader-friendly form per the issue's "out of scope" note.

## Behaviour
```python
from xr_toolz.metrics.object import ProbabilityOfDetection
ProbabilityOfDetection()
# NotImplementedError: ProbabilityOfDetection is a name reservation;
#                      implementation lands with V5 (Epic V5).
```

## Test plan
- [x] `uv run pytest --no-cov` — 522 passed, 1 skipped
- [x] `uv run --group lint ruff check .` — clean
- [x] `uv run --group lint ruff format --check .` — clean
- [x] `uv run --group typecheck ty check src/xr_toolz` — same 40 pre-existing diagnostics

Closes #25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)