### PR TITLE
refactor(encoders): consolidate into xr_toolz.transforms.encoders (Epic F5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Deprecated
+
+* `xr_toolz.geo.{cyclical_encode, fourier_features, positional_encoding, random_fourier_features, lat_90_to_180, lat_180_to_90, lon_180_to_360, lon_360_to_180, encode_time_cyclical, encode_time_ordinal, time_rescale, time_unrescale}` — moved to `xr_toolz.transforms.encoders` (D8). The legacy paths still resolve via PEP-562 with a `DeprecationWarning` for one release; removal scheduled for the next minor.
+
 ## 0.0.1 (2026-04-30)
 
 

--- a/src/xr_toolz/geo/__init__.py
+++ b/src/xr_toolz/geo/__init__.py
@@ -45,20 +45,6 @@ from xr_toolz.geo._src.discretize import (
     histogram_2d,
     points_to_grid,
 )
-from xr_toolz.geo._src.encoders import (
-    cyclical_encode,
-    encode_time_cyclical,
-    encode_time_ordinal,
-    fourier_features,
-    lat_90_to_180,
-    lat_180_to_90,
-    lon_180_to_360,
-    lon_360_to_180,
-    positional_encoding,
-    random_fourier_features,
-    time_rescale,
-    time_unrescale,
-)
 from xr_toolz.geo._src.extremes import (
     block_maxima,
     block_minima,
@@ -110,6 +96,23 @@ _DEPRECATED_METRICS = {
     "resolved_scale": "xr_toolz.metrics._src.spectral",
 }
 
+# Encoders moved to xr_toolz.transforms.encoders (D8). Kept importable for
+# one release with a deprecation warning fired only on actual access.
+_DEPRECATED_ENCODERS = {
+    "cyclical_encode": "xr_toolz.transforms._src.encoders.basis",
+    "fourier_features": "xr_toolz.transforms._src.encoders.basis",
+    "positional_encoding": "xr_toolz.transforms._src.encoders.basis",
+    "random_fourier_features": "xr_toolz.transforms._src.encoders.basis",
+    "lat_90_to_180": "xr_toolz.transforms._src.encoders.coord_space",
+    "lat_180_to_90": "xr_toolz.transforms._src.encoders.coord_space",
+    "lon_180_to_360": "xr_toolz.transforms._src.encoders.coord_space",
+    "lon_360_to_180": "xr_toolz.transforms._src.encoders.coord_space",
+    "encode_time_cyclical": "xr_toolz.transforms._src.encoders.coord_time",
+    "encode_time_ordinal": "xr_toolz.transforms._src.encoders.coord_time",
+    "time_rescale": "xr_toolz.transforms._src.encoders.coord_time",
+    "time_unrescale": "xr_toolz.transforms._src.encoders.coord_time",
+}
+
 
 def __getattr__(name: str) -> Any:
     if name in _DEPRECATED_METRICS:
@@ -123,6 +126,18 @@ def __getattr__(name: str) -> Any:
             stacklevel=2,
         )
         module = import_module(_DEPRECATED_METRICS[name])
+        return getattr(module, name)
+    if name in _DEPRECATED_ENCODERS:
+        from importlib import import_module
+
+        warnings.warn(
+            f"xr_toolz.geo.{name} is deprecated; "
+            f"import from xr_toolz.transforms.encoders instead. "
+            f"This re-export will be removed in the next minor release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        module = import_module(_DEPRECATED_ENCODERS[name])
         return getattr(module, name)
     raise AttributeError(f"module 'xr_toolz.geo' has no attribute {name!r}")
 
@@ -147,27 +162,17 @@ __all__ = [
     "calculate_climatology_season",
     "calculate_climatology_smoothed",
     "coarsen",
-    "cyclical_encode",
-    "encode_time_cyclical",
-    "encode_time_ordinal",
     "fillnan_rbf",
     "fillnan_spatial",
     "fillnan_temporal",
-    "fourier_features",
     "get_crs",
     "histogram_2d",
-    "lat_90_to_180",
-    "lat_180_to_90",
-    "lon_180_to_360",
-    "lon_360_to_180",
     "lonlat_to_xy",
     "points_to_grid",
-    "positional_encoding",
     "pot_exceedances",
     "pot_threshold",
     "pp_counts",
     "pp_stats",
-    "random_fourier_features",
     "refine",
     "remove_climatology",
     "rename_coords",
@@ -177,8 +182,6 @@ __all__ = [
     "subset_bbox",
     "subset_time",
     "subset_where",
-    "time_rescale",
-    "time_unrescale",
     "validate_latitude",
     "validate_longitude",
     "xy_to_lonlat",

--- a/src/xr_toolz/geo/_src/encoders.py
+++ b/src/xr_toolz/geo/_src/encoders.py
@@ -1,301 +1,32 @@
-"""Coordinate and positional encoders.
+"""Deep-import shim for the encoders that moved to
+:mod:`xr_toolz.transforms._src.encoders` (D8).
 
-Includes coordinate-range transforms for longitude and latitude, time
-rescaling to/from float offsets, cyclical and Fourier feature encoders,
-and a positional-encoding helper in the style used by NeRF / ViT.
+The public-surface :mod:`xr_toolz.geo` module emits a
+:class:`DeprecationWarning` when these names are accessed via
+``from xr_toolz.geo import <name>``. The functions themselves now live
+under :mod:`xr_toolz.transforms.encoders`; this module is kept only so
+that existing deep imports such as
+``from xr_toolz.geo._src.encoders import cyclical_encode`` continue to
+resolve for one release while downstream code migrates.
 """
 
-from __future__ import annotations
-
-from collections.abc import Sequence
-from typing import Any
-
-import numpy as np
-import pandas as pd
-import xarray as xr
-from numpy.typing import ArrayLike, NDArray
-
-
-def lon_360_to_180(coord: ArrayLike) -> NDArray:
-    """Wrap longitudes from ``[0, 360)`` into ``[-180, 180)``.
-
-    Args:
-        coord: Array of longitude values in the ``[0, 360)`` convention.
-
-    Returns:
-        Array of longitude values in the ``[-180, 180)`` convention, with
-        the same shape as the input.
-    """
-    return (np.asarray(coord) + 180.0) % 360.0 - 180.0
+from xr_toolz.transforms._src.encoders import (
+    cyclical_encode,
+    encode_time_cyclical,
+    encode_time_ordinal,
+    fourier_features,
+    lat_90_to_180,
+    lat_180_to_90,
+    lon_180_to_360,
+    lon_360_to_180,
+    positional_encoding,
+    random_fourier_features,
+    time_rescale,
+    time_unrescale,
+)
 
 
-def lon_180_to_360(coord: ArrayLike) -> NDArray:
-    """Wrap longitudes from ``[-180, 180)`` into ``[0, 360)``.
-
-    Args:
-        coord: Array of longitude values in the ``[-180, 180)`` convention.
-
-    Returns:
-        Array of longitude values in the ``[0, 360)`` convention, with the
-        same shape as the input.
-    """
-    return np.asarray(coord) % 360.0
-
-
-def lat_180_to_90(coord: ArrayLike) -> NDArray:
-    """Wrap latitudes from ``[0, 180)`` into ``[-90, 90)``.
-
-    Useful when a dataset stores latitude as a 0-based index rather than
-    the standard geographic convention.
-
-    Args:
-        coord: Array of latitude values in the ``[0, 180)`` convention.
-
-    Returns:
-        Array of latitude values in the ``[-90, 90)`` convention.
-    """
-    return (np.asarray(coord) + 90.0) % 180.0 - 90.0
-
-
-def lat_90_to_180(coord: ArrayLike) -> NDArray:
-    """Wrap latitudes from ``[-90, 90)`` into ``[0, 180)``.
-
-    Args:
-        coord: Array of latitude values in the ``[-90, 90)`` convention.
-
-    Returns:
-        Array of latitude values in the ``[0, 180)`` convention.
-    """
-    return np.asarray(coord) % 180.0
-
-
-# ---------- time -----------------------------------------------------------
-
-
-def time_rescale(
-    ds: xr.Dataset,
-    freq_dt: float = 1.0,
-    freq_unit: str = "s",
-    t0: str | np.datetime64 | None = None,
-    time: str = "time",
-) -> xr.Dataset:
-    """Rescale a ``datetime64`` time axis to a float offset.
-
-    ``t' = (t - t_0) / freq_dt``, where ``freq_dt`` is expressed in
-    ``freq_unit``. Stores ``t0``, ``freq``, and ``units`` as attrs so
-    that :func:`time_unrescale` can round-trip back to ``datetime64``.
-
-    Args:
-        ds: Input dataset with a ``time`` coordinate.
-        freq_dt: Size of the time step in ``freq_unit`` units.
-        freq_unit: Pandas timedelta unit (``"s"``, ``"m"``, ``"h"``,
-            ``"D"``, ...).
-        t0: Reference time. Defaults to ``ds[time].min()``.
-        time: Name of the time coordinate.
-
-    Returns:
-        Copy of ``ds`` with ``time`` replaced by a ``float32`` offset.
-    """
-    ds = ds.copy()
-    delta = pd.Timedelta(freq_dt, unit=freq_unit)
-    delta_ns = np.int64(delta.asm8.astype("timedelta64[ns]").astype(np.int64))
-
-    if t0 is None:
-        t0_val = np.datetime64(ds[time].min().values, "ns")
-    else:
-        t0_val = np.datetime64(t0, "ns")
-
-    td_ns = (
-        (ds[time].values.astype("datetime64[ns]") - t0_val)
-        .astype("timedelta64[ns]")
-        .astype(np.int64)
-    )
-    rescaled = (td_ns.astype(np.float64) / float(delta_ns)).astype(np.float32)
-    ds = ds.assign_coords({time: rescaled})
-    ds[time].attrs.update(
-        units=freq_unit,
-        freq=float(freq_dt),
-        t0=str(t0_val),
-    )
-    return ds
-
-
-def time_unrescale(ds: xr.Dataset, time: str = "time") -> xr.Dataset:
-    """Inverse of :func:`time_rescale` using its stored attrs."""
-    ds = ds.copy()
-    attrs = ds[time].attrs
-    if "t0" not in attrs or "freq" not in attrs or "units" not in attrs:
-        raise ValueError(
-            "time coord is missing t0/freq/units attrs — rescale with "
-            "time_rescale first."
-        )
-    delta = pd.Timedelta(attrs["freq"], unit=attrs["units"])
-    t0 = np.datetime64(attrs["t0"], "ns")
-    delta_ns = np.int64(delta.asm8.astype("timedelta64[ns]").astype(np.int64))
-    offsets = (ds[time].values.astype(np.float64) * delta_ns).astype("timedelta64[ns]")
-    ds = ds.assign_coords({time: t0 + offsets})
-    ds[time].attrs = {}
-    return ds
-
-
-# ---------- cyclical / Fourier --------------------------------------------
-
-
-def cyclical_encode(
-    values: ArrayLike,
-    period: float,
-) -> tuple[NDArray, NDArray]:
-    """Sin/cos embedding of a periodic variable.
-
-    Args:
-        values: Input values with period ``period``.
-        period: Period length (e.g. 365.25 for day-of-year, 24 for hour
-            of day, ``2 * np.pi`` for radians).
-
-    Returns:
-        ``(sin_component, cos_component)`` pair, each with the same
-        shape as ``values``.
-    """
-    x = 2.0 * np.pi * np.asarray(values) / period
-    return np.sin(x), np.cos(x)
-
-
-def fourier_features(
-    values: ArrayLike,
-    num_freqs: int,
-    scale: float = 1.0,
-) -> NDArray:
-    """Deterministic Fourier-feature encoding.
-
-    Returns an array of shape ``(..., 2 * num_freqs)`` whose columns
-    alternate ``sin(2^k * scale * x)`` and ``cos(2^k * scale * x)``.
-
-    Args:
-        values: Input array.
-        num_freqs: Number of frequency octaves to use.
-        scale: Base frequency.
-    """
-    values = np.asarray(values)
-    freqs = (2.0 ** np.arange(num_freqs)) * scale
-    angles = values[..., None] * freqs
-    return np.concatenate([np.sin(angles), np.cos(angles)], axis=-1)
-
-
-def random_fourier_features(
-    values: ArrayLike,
-    num_features: int,
-    sigma: float = 1.0,
-    seed: int | None = None,
-) -> NDArray:
-    """Random Fourier features in the style of Rahimi & Recht, 2007.
-
-    Approximates the RBF kernel feature map. Returns an array of shape
-    ``(..., num_features)``.
-
-    Args:
-        values: Input array with the feature dim as the last axis, or a
-            1-D scalar coordinate.
-        num_features: Output feature dimension (must be even).
-        sigma: Bandwidth of the underlying RBF kernel.
-        seed: Seed for the RNG used to draw the random frequencies.
-    """
-    if num_features % 2 != 0:
-        raise ValueError("num_features must be even.")
-    values = np.asarray(values)
-    if values.ndim == 0:
-        values = values[None]
-    d = values.shape[-1] if values.ndim > 1 else 1
-    x = values if values.ndim > 1 else values[..., None]
-
-    rng = np.random.default_rng(seed)
-    omega = rng.standard_normal((d, num_features // 2)) / sigma
-    projection = x @ omega  # (..., num_features // 2)
-    return np.concatenate([np.sin(projection), np.cos(projection)], axis=-1)
-
-
-def positional_encoding(
-    values: ArrayLike,
-    num_freqs: int,
-    include_input: bool = True,
-) -> NDArray:
-    """NeRF-style positional encoding.
-
-    Output shape is ``(..., (2 * num_freqs) + include_input)``.
-
-    Args:
-        values: Input array.
-        num_freqs: Number of octave frequencies.
-        include_input: If ``True``, concatenate the raw input as an
-            additional column.
-    """
-    encoded = fourier_features(values, num_freqs=num_freqs, scale=np.pi)
-    if include_input:
-        values = np.asarray(values)[..., None]
-        return np.concatenate([values, encoded], axis=-1)
-    return encoded
-
-
-def encode_time_cyclical(
-    ds: xr.Dataset,
-    components: Sequence[str] = ("dayofyear", "hour"),
-    time: str = "time",
-) -> xr.Dataset:
-    """Attach sin/cos encodings of datetime components as new variables.
-
-    For each ``component`` in ``components`` (any name accepted by
-    xarray's ``.dt`` accessor), two coordinates are added:
-    ``{component}_sin`` and ``{component}_cos``.
-
-    Args:
-        ds: Input dataset with a ``time`` coordinate.
-        components: Iterable of datetime attributes to encode.
-        time: Name of the time coordinate.
-
-    Returns:
-        Dataset with the requested encodings attached.
-    """
-    periods = {
-        "dayofyear": 366.0,
-        "day": 31.0,
-        "month": 12.0,
-        "hour": 24.0,
-        "minute": 60.0,
-        "second": 60.0,
-        "weekday": 7.0,
-    }
-    ds = ds.copy()
-    for name in components:
-        if name not in periods:
-            raise ValueError(
-                f"Unknown time component {name!r}; known: {sorted(periods)}."
-            )
-        values = getattr(ds[time].dt, name).values.astype(float)
-        sin, cos = cyclical_encode(values, period=periods[name])
-        ds = ds.assign_coords({f"{name}_sin": (time, sin), f"{name}_cos": (time, cos)})
-    return ds
-
-
-def encode_time_ordinal(
-    ds: xr.Dataset,
-    reference_date: str | np.datetime64 | None = None,
-    time: str = "time",
-    unit: str = "D",
-) -> xr.Dataset:
-    """Attach an ordinal float-day encoding of the time coordinate.
-
-    Adds a ``{time}_ordinal`` coord to ``ds``.
-    """
-    ref = (
-        np.datetime64(ds[time].min().values)
-        if reference_date is None
-        else np.datetime64(reference_date)
-    )
-    delta = pd.Timedelta(1, unit=unit)
-    ordinal = ((ds[time].values - ref) / delta).astype(np.float64)
-    return ds.assign_coords({f"{time}_ordinal": (time, ordinal)})
-
-
-__all__: list[str] = [
+__all__ = [
     "cyclical_encode",
     "encode_time_cyclical",
     "encode_time_ordinal",
@@ -309,7 +40,3 @@ __all__: list[str] = [
     "time_rescale",
     "time_unrescale",
 ]
-
-
-# Silence "unused import" lints for types only touched in annotations.
-_ANNOTATION_ONLY: tuple[Any, ...] = (ArrayLike, NDArray)

--- a/src/xr_toolz/geo/_src/encoders.py
+++ b/src/xr_toolz/geo/_src/encoders.py
@@ -10,6 +10,8 @@ that existing deep imports such as
 resolve for one release while downstream code migrates.
 """
 
+from __future__ import annotations
+
 from xr_toolz.transforms._src.encoders import (
     cyclical_encode,
     encode_time_cyclical,

--- a/src/xr_toolz/geo/_src/validation.py
+++ b/src/xr_toolz/geo/_src/validation.py
@@ -10,7 +10,10 @@ from __future__ import annotations
 
 import xarray as xr
 
-from xr_toolz.geo._src.encoders import lat_180_to_90, lon_360_to_180
+from xr_toolz.transforms._src.encoders.coord_space import (
+    lat_180_to_90,
+    lon_360_to_180,
+)
 
 
 _LONGITUDE_ALIASES = ("longitude",)

--- a/src/xr_toolz/transforms/_src/encoders/__init__.py
+++ b/src/xr_toolz/transforms/_src/encoders/__init__.py
@@ -5,6 +5,8 @@ the top-level :mod:`xr_toolz.transforms.encoders` shim re-exports the public
 names for convenience.
 """
 
+from __future__ import annotations
+
 from xr_toolz.transforms._src.encoders.basis import (
     cyclical_encode,
     fourier_features,

--- a/src/xr_toolz/transforms/_src/encoders/__init__.py
+++ b/src/xr_toolz/transforms/_src/encoders/__init__.py
@@ -1,0 +1,41 @@
+"""Encoder primitives — coordinate-space, coordinate-time, and basis encodings.
+
+Pure functions organized by what they encode. Each submodule is import-stable;
+the top-level :mod:`xr_toolz.transforms.encoders` shim re-exports the public
+names for convenience.
+"""
+
+from xr_toolz.transforms._src.encoders.basis import (
+    cyclical_encode,
+    fourier_features,
+    positional_encoding,
+    random_fourier_features,
+)
+from xr_toolz.transforms._src.encoders.coord_space import (
+    lat_90_to_180,
+    lat_180_to_90,
+    lon_180_to_360,
+    lon_360_to_180,
+)
+from xr_toolz.transforms._src.encoders.coord_time import (
+    encode_time_cyclical,
+    encode_time_ordinal,
+    time_rescale,
+    time_unrescale,
+)
+
+
+__all__ = [
+    "cyclical_encode",
+    "encode_time_cyclical",
+    "encode_time_ordinal",
+    "fourier_features",
+    "lat_90_to_180",
+    "lat_180_to_90",
+    "lon_180_to_360",
+    "lon_360_to_180",
+    "positional_encoding",
+    "random_fourier_features",
+    "time_rescale",
+    "time_unrescale",
+]

--- a/src/xr_toolz/transforms/_src/encoders/basis.py
+++ b/src/xr_toolz/transforms/_src/encoders/basis.py
@@ -1,0 +1,114 @@
+"""Basis-function encoders — cyclical, Fourier, random Fourier, positional."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+from numpy.typing import ArrayLike, NDArray
+
+
+def cyclical_encode(
+    values: ArrayLike,
+    period: float,
+) -> tuple[NDArray, NDArray]:
+    """Sin/cos embedding of a periodic variable.
+
+    Args:
+        values: Input values with period ``period``.
+        period: Period length (e.g. 365.25 for day-of-year, 24 for hour
+            of day, ``2 * np.pi`` for radians).
+
+    Returns:
+        ``(sin_component, cos_component)`` pair, each with the same
+        shape as ``values``.
+    """
+    x = 2.0 * np.pi * np.asarray(values) / period
+    return np.sin(x), np.cos(x)
+
+
+def fourier_features(
+    values: ArrayLike,
+    num_freqs: int,
+    scale: float = 1.0,
+) -> NDArray:
+    """Deterministic Fourier-feature encoding.
+
+    Returns an array of shape ``(..., 2 * num_freqs)`` whose columns
+    alternate ``sin(2^k * scale * x)`` and ``cos(2^k * scale * x)``.
+
+    Args:
+        values: Input array.
+        num_freqs: Number of frequency octaves to use.
+        scale: Base frequency.
+    """
+    values = np.asarray(values)
+    freqs = (2.0 ** np.arange(num_freqs)) * scale
+    angles = values[..., None] * freqs
+    return np.concatenate([np.sin(angles), np.cos(angles)], axis=-1)
+
+
+def random_fourier_features(
+    values: ArrayLike,
+    num_features: int,
+    sigma: float = 1.0,
+    seed: int | None = None,
+) -> NDArray:
+    """Random Fourier features in the style of Rahimi & Recht, 2007.
+
+    Approximates the RBF kernel feature map. Returns an array of shape
+    ``(..., num_features)``.
+
+    Args:
+        values: Input array with the feature dim as the last axis, or a
+            1-D scalar coordinate.
+        num_features: Output feature dimension (must be even).
+        sigma: Bandwidth of the underlying RBF kernel.
+        seed: Seed for the RNG used to draw the random frequencies.
+    """
+    if num_features % 2 != 0:
+        raise ValueError("num_features must be even.")
+    values = np.asarray(values)
+    if values.ndim == 0:
+        values = values[None]
+    d = values.shape[-1] if values.ndim > 1 else 1
+    x = values if values.ndim > 1 else values[..., None]
+
+    rng = np.random.default_rng(seed)
+    omega = rng.standard_normal((d, num_features // 2)) / sigma
+    projection = x @ omega  # (..., num_features // 2)
+    return np.concatenate([np.sin(projection), np.cos(projection)], axis=-1)
+
+
+def positional_encoding(
+    values: ArrayLike,
+    num_freqs: int,
+    include_input: bool = True,
+) -> NDArray:
+    """NeRF-style positional encoding.
+
+    Output shape is ``(..., (2 * num_freqs) + include_input)``.
+
+    Args:
+        values: Input array.
+        num_freqs: Number of octave frequencies.
+        include_input: If ``True``, concatenate the raw input as an
+            additional column.
+    """
+    encoded = fourier_features(values, num_freqs=num_freqs, scale=np.pi)
+    if include_input:
+        values = np.asarray(values)[..., None]
+        return np.concatenate([values, encoded], axis=-1)
+    return encoded
+
+
+__all__ = [
+    "cyclical_encode",
+    "fourier_features",
+    "positional_encoding",
+    "random_fourier_features",
+]
+
+
+# Silence "unused import" lints for types only touched in annotations.
+_ANNOTATION_ONLY: tuple[Any, ...] = (ArrayLike, NDArray)

--- a/src/xr_toolz/transforms/_src/encoders/coord_space.py
+++ b/src/xr_toolz/transforms/_src/encoders/coord_space.py
@@ -1,0 +1,67 @@
+"""Coordinate-space range conversions for longitude and latitude."""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import ArrayLike, NDArray
+
+
+def lon_360_to_180(coord: ArrayLike) -> NDArray:
+    """Wrap longitudes from ``[0, 360)`` into ``[-180, 180)``.
+
+    Args:
+        coord: Array of longitude values in the ``[0, 360)`` convention.
+
+    Returns:
+        Array of longitude values in the ``[-180, 180)`` convention, with
+        the same shape as the input.
+    """
+    return (np.asarray(coord) + 180.0) % 360.0 - 180.0
+
+
+def lon_180_to_360(coord: ArrayLike) -> NDArray:
+    """Wrap longitudes from ``[-180, 180)`` into ``[0, 360)``.
+
+    Args:
+        coord: Array of longitude values in the ``[-180, 180)`` convention.
+
+    Returns:
+        Array of longitude values in the ``[0, 360)`` convention, with the
+        same shape as the input.
+    """
+    return np.asarray(coord) % 360.0
+
+
+def lat_180_to_90(coord: ArrayLike) -> NDArray:
+    """Wrap latitudes from ``[0, 180)`` into ``[-90, 90)``.
+
+    Useful when a dataset stores latitude as a 0-based index rather than
+    the standard geographic convention.
+
+    Args:
+        coord: Array of latitude values in the ``[0, 180)`` convention.
+
+    Returns:
+        Array of latitude values in the ``[-90, 90)`` convention.
+    """
+    return (np.asarray(coord) + 90.0) % 180.0 - 90.0
+
+
+def lat_90_to_180(coord: ArrayLike) -> NDArray:
+    """Wrap latitudes from ``[-90, 90)`` into ``[0, 180)``.
+
+    Args:
+        coord: Array of latitude values in the ``[-90, 90)`` convention.
+
+    Returns:
+        Array of latitude values in the ``[0, 180)`` convention.
+    """
+    return np.asarray(coord) % 180.0
+
+
+__all__ = [
+    "lat_90_to_180",
+    "lat_180_to_90",
+    "lon_180_to_360",
+    "lon_360_to_180",
+]

--- a/src/xr_toolz/transforms/_src/encoders/coord_time.py
+++ b/src/xr_toolz/transforms/_src/encoders/coord_time.py
@@ -1,0 +1,145 @@
+"""Coordinate-time encoders — rescaling and periodic time-component encodings."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+from xr_toolz.transforms._src.encoders.basis import cyclical_encode
+
+
+def time_rescale(
+    ds: xr.Dataset,
+    freq_dt: float = 1.0,
+    freq_unit: str = "s",
+    t0: str | np.datetime64 | None = None,
+    time: str = "time",
+) -> xr.Dataset:
+    """Rescale a ``datetime64`` time axis to a float offset.
+
+    ``t' = (t - t_0) / freq_dt``, where ``freq_dt`` is expressed in
+    ``freq_unit``. Stores ``t0``, ``freq``, and ``units`` as attrs so
+    that :func:`time_unrescale` can round-trip back to ``datetime64``.
+
+    Args:
+        ds: Input dataset with a ``time`` coordinate.
+        freq_dt: Size of the time step in ``freq_unit`` units.
+        freq_unit: Pandas timedelta unit (``"s"``, ``"m"``, ``"h"``,
+            ``"D"``, ...).
+        t0: Reference time. Defaults to ``ds[time].min()``.
+        time: Name of the time coordinate.
+
+    Returns:
+        Copy of ``ds`` with ``time`` replaced by a ``float32`` offset.
+    """
+    ds = ds.copy()
+    delta = pd.Timedelta(freq_dt, unit=freq_unit)
+    delta_ns = np.int64(delta.asm8.astype("timedelta64[ns]").astype(np.int64))
+
+    if t0 is None:
+        t0_val = np.datetime64(ds[time].min().values, "ns")
+    else:
+        t0_val = np.datetime64(t0, "ns")
+
+    td_ns = (
+        (ds[time].values.astype("datetime64[ns]") - t0_val)
+        .astype("timedelta64[ns]")
+        .astype(np.int64)
+    )
+    rescaled = (td_ns.astype(np.float64) / float(delta_ns)).astype(np.float32)
+    ds = ds.assign_coords({time: rescaled})
+    ds[time].attrs.update(
+        units=freq_unit,
+        freq=float(freq_dt),
+        t0=str(t0_val),
+    )
+    return ds
+
+
+def time_unrescale(ds: xr.Dataset, time: str = "time") -> xr.Dataset:
+    """Inverse of :func:`time_rescale` using its stored attrs."""
+    ds = ds.copy()
+    attrs = ds[time].attrs
+    if "t0" not in attrs or "freq" not in attrs or "units" not in attrs:
+        raise ValueError(
+            "time coord is missing t0/freq/units attrs — rescale with "
+            "time_rescale first."
+        )
+    delta = pd.Timedelta(attrs["freq"], unit=attrs["units"])
+    t0 = np.datetime64(attrs["t0"], "ns")
+    delta_ns = np.int64(delta.asm8.astype("timedelta64[ns]").astype(np.int64))
+    offsets = (ds[time].values.astype(np.float64) * delta_ns).astype("timedelta64[ns]")
+    ds = ds.assign_coords({time: t0 + offsets})
+    ds[time].attrs = {}
+    return ds
+
+
+def encode_time_cyclical(
+    ds: xr.Dataset,
+    components: Sequence[str] = ("dayofyear", "hour"),
+    time: str = "time",
+) -> xr.Dataset:
+    """Attach sin/cos encodings of datetime components as new variables.
+
+    For each ``component`` in ``components`` (any name accepted by
+    xarray's ``.dt`` accessor), two coordinates are added:
+    ``{component}_sin`` and ``{component}_cos``.
+
+    Args:
+        ds: Input dataset with a ``time`` coordinate.
+        components: Iterable of datetime attributes to encode.
+        time: Name of the time coordinate.
+
+    Returns:
+        Dataset with the requested encodings attached.
+    """
+    periods = {
+        "dayofyear": 366.0,
+        "day": 31.0,
+        "month": 12.0,
+        "hour": 24.0,
+        "minute": 60.0,
+        "second": 60.0,
+        "weekday": 7.0,
+    }
+    ds = ds.copy()
+    for name in components:
+        if name not in periods:
+            raise ValueError(
+                f"Unknown time component {name!r}; known: {sorted(periods)}."
+            )
+        values = getattr(ds[time].dt, name).values.astype(float)
+        sin, cos = cyclical_encode(values, period=periods[name])
+        ds = ds.assign_coords({f"{name}_sin": (time, sin), f"{name}_cos": (time, cos)})
+    return ds
+
+
+def encode_time_ordinal(
+    ds: xr.Dataset,
+    reference_date: str | np.datetime64 | None = None,
+    time: str = "time",
+    unit: str = "D",
+) -> xr.Dataset:
+    """Attach an ordinal float-day encoding of the time coordinate.
+
+    Adds a ``{time}_ordinal`` coord to ``ds``.
+    """
+    ref = (
+        np.datetime64(ds[time].min().values)
+        if reference_date is None
+        else np.datetime64(reference_date)
+    )
+    delta = pd.Timedelta(1, unit=unit)
+    ordinal = ((ds[time].values - ref) / delta).astype(np.float64)
+    return ds.assign_coords({f"{time}_ordinal": (time, ordinal)})
+
+
+__all__ = [
+    "encode_time_cyclical",
+    "encode_time_ordinal",
+    "time_rescale",
+    "time_unrescale",
+]

--- a/src/xr_toolz/transforms/encoders/__init__.py
+++ b/src/xr_toolz/transforms/encoders/__init__.py
@@ -6,20 +6,22 @@ also importable as ``xr_toolz.transforms.encoders.<sub>`` for callers
 who want a narrower import.
 """
 
-from xr_toolz.transforms.encoders import basis, coord_space, coord_time
-from xr_toolz.transforms.encoders.basis import (
+from __future__ import annotations
+
+from . import basis, coord_space, coord_time
+from .basis import (
     cyclical_encode,
     fourier_features,
     positional_encoding,
     random_fourier_features,
 )
-from xr_toolz.transforms.encoders.coord_space import (
+from .coord_space import (
     lat_90_to_180,
     lat_180_to_90,
     lon_180_to_360,
     lon_360_to_180,
 )
-from xr_toolz.transforms.encoders.coord_time import (
+from .coord_time import (
     encode_time_cyclical,
     encode_time_ordinal,
     time_rescale,

--- a/src/xr_toolz/transforms/encoders/__init__.py
+++ b/src/xr_toolz/transforms/encoders/__init__.py
@@ -1,0 +1,46 @@
+"""Public encoder surface — coord-space, coord-time, and basis encodings.
+
+Re-exports the pure functions from :mod:`xr_toolz.transforms._src.encoders`.
+Submodules :mod:`coord_space`, :mod:`coord_time`, and :mod:`basis` are
+also importable as ``xr_toolz.transforms.encoders.<sub>`` for callers
+who want a narrower import.
+"""
+
+from xr_toolz.transforms.encoders import basis, coord_space, coord_time
+from xr_toolz.transforms.encoders.basis import (
+    cyclical_encode,
+    fourier_features,
+    positional_encoding,
+    random_fourier_features,
+)
+from xr_toolz.transforms.encoders.coord_space import (
+    lat_90_to_180,
+    lat_180_to_90,
+    lon_180_to_360,
+    lon_360_to_180,
+)
+from xr_toolz.transforms.encoders.coord_time import (
+    encode_time_cyclical,
+    encode_time_ordinal,
+    time_rescale,
+    time_unrescale,
+)
+
+
+__all__ = [
+    "basis",
+    "coord_space",
+    "coord_time",
+    "cyclical_encode",
+    "encode_time_cyclical",
+    "encode_time_ordinal",
+    "fourier_features",
+    "lat_90_to_180",
+    "lat_180_to_90",
+    "lon_180_to_360",
+    "lon_360_to_180",
+    "positional_encoding",
+    "random_fourier_features",
+    "time_rescale",
+    "time_unrescale",
+]

--- a/src/xr_toolz/transforms/encoders/basis.py
+++ b/src/xr_toolz/transforms/encoders/basis.py
@@ -1,0 +1,16 @@
+"""Public re-export of basis encoders."""
+
+from xr_toolz.transforms._src.encoders.basis import (
+    cyclical_encode,
+    fourier_features,
+    positional_encoding,
+    random_fourier_features,
+)
+
+
+__all__ = [
+    "cyclical_encode",
+    "fourier_features",
+    "positional_encoding",
+    "random_fourier_features",
+]

--- a/src/xr_toolz/transforms/encoders/basis.py
+++ b/src/xr_toolz/transforms/encoders/basis.py
@@ -1,5 +1,7 @@
 """Public re-export of basis encoders."""
 
+from __future__ import annotations
+
 from xr_toolz.transforms._src.encoders.basis import (
     cyclical_encode,
     fourier_features,

--- a/src/xr_toolz/transforms/encoders/coord_space.py
+++ b/src/xr_toolz/transforms/encoders/coord_space.py
@@ -1,5 +1,7 @@
 """Public re-export of coord-space encoders."""
 
+from __future__ import annotations
+
 from xr_toolz.transforms._src.encoders.coord_space import (
     lat_90_to_180,
     lat_180_to_90,

--- a/src/xr_toolz/transforms/encoders/coord_space.py
+++ b/src/xr_toolz/transforms/encoders/coord_space.py
@@ -1,0 +1,16 @@
+"""Public re-export of coord-space encoders."""
+
+from xr_toolz.transforms._src.encoders.coord_space import (
+    lat_90_to_180,
+    lat_180_to_90,
+    lon_180_to_360,
+    lon_360_to_180,
+)
+
+
+__all__ = [
+    "lat_90_to_180",
+    "lat_180_to_90",
+    "lon_180_to_360",
+    "lon_360_to_180",
+]

--- a/src/xr_toolz/transforms/encoders/coord_time.py
+++ b/src/xr_toolz/transforms/encoders/coord_time.py
@@ -1,5 +1,7 @@
 """Public re-export of coord-time encoders."""
 
+from __future__ import annotations
+
 from xr_toolz.transforms._src.encoders.coord_time import (
     encode_time_cyclical,
     encode_time_ordinal,

--- a/src/xr_toolz/transforms/encoders/coord_time.py
+++ b/src/xr_toolz/transforms/encoders/coord_time.py
@@ -1,0 +1,16 @@
+"""Public re-export of coord-time encoders."""
+
+from xr_toolz.transforms._src.encoders.coord_time import (
+    encode_time_cyclical,
+    encode_time_ordinal,
+    time_rescale,
+    time_unrescale,
+)
+
+
+__all__ = [
+    "encode_time_cyclical",
+    "encode_time_ordinal",
+    "time_rescale",
+    "time_unrescale",
+]

--- a/tests/test_encoder_imports.py
+++ b/tests/test_encoder_imports.py
@@ -1,0 +1,159 @@
+"""Import-surface tests for :mod:`xr_toolz.transforms.encoders` (D8).
+
+Guards against regressions in the encoder taxonomy after the move from
+``xr_toolz.geo.encoders`` to ``xr_toolz.transforms.encoders``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import warnings
+
+import pytest
+
+
+# ---- New canonical surface ------------------------------------------------
+
+
+def test_transforms_encoders_root_exposes_all_names():
+    from xr_toolz.transforms.encoders import (
+        cyclical_encode,
+        encode_time_cyclical,
+        encode_time_ordinal,
+        fourier_features,
+        lat_90_to_180,
+        lat_180_to_90,
+        lon_180_to_360,
+        lon_360_to_180,
+        positional_encoding,
+        random_fourier_features,
+        time_rescale,
+        time_unrescale,
+    )
+
+    assert callable(cyclical_encode)
+    _ = (
+        encode_time_cyclical,
+        encode_time_ordinal,
+        fourier_features,
+        lat_90_to_180,
+        lat_180_to_90,
+        lon_180_to_360,
+        lon_360_to_180,
+        positional_encoding,
+        random_fourier_features,
+        time_rescale,
+        time_unrescale,
+    )
+
+
+def test_coord_space_submodule_imports():
+    from xr_toolz.transforms.encoders.coord_space import (
+        lat_90_to_180,
+        lat_180_to_90,
+        lon_180_to_360,
+        lon_360_to_180,
+    )
+
+    assert callable(lon_360_to_180)
+    _ = (lat_90_to_180, lat_180_to_90, lon_180_to_360)
+
+
+def test_coord_time_submodule_imports():
+    from xr_toolz.transforms.encoders.coord_time import (
+        encode_time_cyclical,
+        encode_time_ordinal,
+        time_rescale,
+        time_unrescale,
+    )
+
+    assert callable(time_rescale)
+    _ = (encode_time_cyclical, encode_time_ordinal, time_unrescale)
+
+
+def test_basis_submodule_imports():
+    from xr_toolz.transforms.encoders.basis import (
+        cyclical_encode,
+        fourier_features,
+        positional_encoding,
+        random_fourier_features,
+    )
+
+    assert callable(cyclical_encode)
+    _ = (fourier_features, positional_encoding, random_fourier_features)
+
+
+def test_root_and_submodule_paths_resolve_to_same_object():
+    from xr_toolz.transforms.encoders import (
+        cyclical_encode as root_ce,
+        lon_360_to_180 as root_lon,
+        time_rescale as root_t,
+    )
+    from xr_toolz.transforms.encoders.basis import cyclical_encode as sub_ce
+    from xr_toolz.transforms.encoders.coord_space import (
+        lon_360_to_180 as sub_lon,
+    )
+    from xr_toolz.transforms.encoders.coord_time import time_rescale as sub_t
+
+    assert root_ce is sub_ce
+    assert root_lon is sub_lon
+    assert root_t is sub_t
+
+
+# ---- Legacy deprecation surface ------------------------------------------
+
+
+_DEPRECATED_ENCODER_NAMES = (
+    "cyclical_encode",
+    "fourier_features",
+    "positional_encoding",
+    "random_fourier_features",
+    "lat_90_to_180",
+    "lat_180_to_90",
+    "lon_180_to_360",
+    "lon_360_to_180",
+    "encode_time_cyclical",
+    "encode_time_ordinal",
+    "time_rescale",
+    "time_unrescale",
+)
+
+
+@pytest.mark.parametrize("name", _DEPRECATED_ENCODER_NAMES)
+def test_legacy_geo_encoder_imports_warn_but_resolve(name):
+    """Each legacy ``from xr_toolz.geo import <name>`` must keep working
+    for one release with a :class:`DeprecationWarning` that points at
+    :mod:`xr_toolz.transforms.encoders`.
+    """
+    import xr_toolz.geo as geo
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        obj = getattr(geo, name)
+
+    assert callable(obj)
+    deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert deprecations, f"expected DeprecationWarning on legacy xr_toolz.geo.{name}"
+    assert "xr_toolz.transforms.encoders" in str(deprecations[0].message)
+
+
+def test_plain_import_xr_toolz_geo_is_silent_for_encoders():
+    """Reloading the package itself (without naming a moved encoder) must
+    not emit a :class:`DeprecationWarning` — the warning is per-name.
+    """
+    import xr_toolz.geo
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        importlib.reload(xr_toolz.geo)
+
+    encoder_deprecations = [
+        w
+        for w in caught
+        if issubclass(w.category, DeprecationWarning)
+        and "xr_toolz.transforms.encoders" in str(w.message)
+    ]
+    assert not encoder_deprecations, (
+        f"plain import of xr_toolz.geo emitted unexpected encoder deprecations: "
+        f"{[str(w.message) for w in encoder_deprecations]}"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -3074,7 +3074,7 @@ wheels = [
 
 [[package]]
 name = "xr-toolz"
-version = "0.0.0"
+version = "0.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "finitediffx" },
@@ -3182,8 +3182,8 @@ docs = [
     { name = "mkdocs-jupyter", specifier = ">=0.26.2" },
     { name = "mkdocs-material", specifier = ">=9.7.6" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=1.0.3" },
-    { name = "pygments", specifier = ">=2.19,<2.20" },
-    { name = "watermark", specifier = ">=2.4" },
+    { name = "pygments", specifier = ">=2.19,<2.21" },
+    { name = "watermark", specifier = ">=2.6.0" },
 ]
 lint = [{ name = "ruff", specifier = ">=0.15.10" }]
 typecheck = [{ name = "ty", specifier = ">=0.0.30" }]


### PR DESCRIPTION
## Summary

Closes #76 (Epic F5), #82 (F5.1), #83 (F5.2), #84 (F5.3). Single bundled PR per request.

Adopts D8: moves the 12 encoder Layer-0 functions from `xr_toolz.geo._src.encoders` into `xr_toolz.transforms._src.encoders/`, organized by what they encode:

| Submodule | Functions |
|---|---|
| `coord_space.py` | `lon_360_to_180`, `lon_180_to_360`, `lat_180_to_90`, `lat_90_to_180` |
| `coord_time.py` | `time_rescale`, `time_unrescale`, `encode_time_cyclical`, `encode_time_ordinal` |
| `basis.py` | `cyclical_encode`, `fourier_features`, `random_fourier_features`, `positional_encoding` |

Public surface lives at `xr_toolz.transforms.encoders` (subpackage). Both forms work:

```python
from xr_toolz.transforms.encoders import cyclical_encode
from xr_toolz.transforms.encoders.coord_space import lon_360_to_180
```

## What's in each sub-issue

**F5.1 (#82)** — pure move, behaviour-identical. Internal callsite in `geo/_src/validation.py` updated to import from the new home directly. `geo/_src/encoders.py` becomes a deep-import shim re-exporting from `transforms._src.encoders` so legacy `from xr_toolz.geo._src.encoders import …` still resolves for one release.

**F5.2 (#83)** — audited [transforms/operators.py](src/xr_toolz/transforms/operators.py): **no encoder Tier C operators exist today** (only Fourier / DCT / wavelet are wrapped). Acceptance criterion 1 ("imports from new home") is satisfied vacuously. Filed follow-up #95 to add `CyclicalEncode` / `FourierFeatures` / `PositionalEncoding` etc. wrappers — out of scope for this refactor.

**F5.3 (#84)** — `geo/__init__.py` drops the 12 direct encoder imports from `__all__` and routes them through PEP-562 `__getattr__` with a `DeprecationWarning` pointing at `xr_toolz.transforms.encoders`. Mirrors the F1 metrics deprecation pattern exactly. CHANGELOG `Unreleased / Deprecated` section enumerates all 12 names.

## Tests

`tests/test_encoder_imports.py` adds **+18 tests**:
- canonical surface (root + 3 submodules)
- identity equivalence between root and per-submodule import paths
- parametrized deprecation surface (12 names) — each emits `DeprecationWarning` mentioning `xr_toolz.transforms.encoders`
- plain `import xr_toolz.geo` is silent (warning is per-name)

Existing `tests/test_geo.py` and `tests/test_geo_extended.py` are intentionally left importing from `xr_toolz.geo` so the deprecation shim keeps integration coverage during the deprecation window.

## Verification

```
pytest:    563 passed, 1 skipped (was 545)
ruff:      All checks passed
ruff fmt:  171 files already formatted
ty:        40 diagnostics (down from 43 baseline)
mkdocs --strict: 3 warnings — all pre-existing, unrelated
```

## Out of scope

- New encoder Tier C operators — see follow-up #95.
- Removal of `geo.encoders` re-exports — scheduled next minor.
- D11 three-tier restructure — F2.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)