### PR TITLE
feat(transforms): tier c encoder operators (#95)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+* `xr_toolz.transforms.operators` — Tier C wrappers for the encoder primitives: `CyclicalEncode`, `FourierFeatures`, `RandomFourierFeatures`, `PositionalEncoding`, `EncodeTimeCyclical`, `EncodeTimeOrdinal`, `TimeRescale`, `TimeUnrescale` (#95).
+
 ### Removed
 
 * Value-resampling primitives moved out of `xr_toolz.geo` into the new `xr_toolz.interpolate` package (D8/D12, Epic F3). No deprecation shim — the package is pre-1.0 and has no external users.

--- a/docs/design/api/components.md
+++ b/docs/design/api/components.md
@@ -548,6 +548,41 @@ class PolynomialFeatures(Operator):
 
 All encoder Operators have the standard `Dataset → Dataset` shape — they add new variables / coords carrying the encoded features. Stateless (no `fit` step required), so they slot into `Sequential` directly.
 
+#### Shipped Tier C surface (xr_toolz.transforms.operators)
+
+The encoder Operators currently exported from `xr_toolz.transforms.operators` (#95):
+
+```python
+# basis encoders — wrap a single ds[variable]
+class CyclicalEncode(Operator):
+    def __init__(self, variable: str, period: float): ...
+class FourierFeatures(Operator):
+    def __init__(self, variable: str, num_freqs: int, scale: float = 1.0,
+                 *, output_name: str | None = None, feature_dim: str = "feature"): ...
+class RandomFourierFeatures(Operator):
+    def __init__(self, variable: str, num_features: int, sigma: float = 1.0,
+                 seed: int | None = None, *, output_name: str | None = None,
+                 feature_dim: str = "feature"): ...
+class PositionalEncoding(Operator):
+    def __init__(self, variable: str, num_freqs: int, include_input: bool = True,
+                 *, output_name: str | None = None, feature_dim: str = "feature"): ...
+
+# coord-time encoders — operate on the dataset's time coord
+class EncodeTimeCyclical(Operator):
+    def __init__(self, components: Sequence[str] = ("dayofyear", "hour"),
+                 time: str = "time"): ...
+class EncodeTimeOrdinal(Operator):
+    def __init__(self, reference_date: str | np.datetime64 | None = None,
+                 time: str = "time", unit: str = "D"): ...
+class TimeRescale(Operator):
+    def __init__(self, freq_dt: float = 1.0, freq_unit: str = "s",
+                 t0: str | np.datetime64 | None = None, time: str = "time"): ...
+class TimeUnrescale(Operator):
+    def __init__(self, time: str = "time"): ...
+```
+
+The basis encoders take a single `variable` (rather than the aspirational `coords: list[str]` form earlier in this section) and emit a new variable with a trailing `feature_dim`. `RandomFourierFeatures` is rank-aware: 1-D inputs gain a feature axis; ≥2-D vector inputs have their trailing axis replaced with the feature axis (the underlying `random_fourier_features` projects via a `(d, num_features/2)` matrix).
+
 ---
 
 ## `extremes` — *Deferred*

--- a/src/xr_toolz/transforms/operators.py
+++ b/src/xr_toolz/transforms/operators.py
@@ -26,6 +26,10 @@ from xr_toolz.transforms._src import (
     fourier as _fourier,
     wavelet as _wavelet,
 )
+from xr_toolz.transforms._src.encoders import (
+    basis as _basis,
+    coord_time as _coord_time,
+)
 
 
 # ---------- Fourier --------------------------------------------------------
@@ -270,6 +274,248 @@ class CWT(Operator):
         }
 
 
+# ---------- Encoders -------------------------------------------------------
+
+
+class CyclicalEncode(Operator):
+    """Sin/cos embedding of a periodic variable.
+
+    Reads ``ds[variable]``, calls :func:`cyclical_encode`, and attaches
+    two new data variables ``{variable}_sin`` and ``{variable}_cos`` to
+    the dataset (preserving all other variables).
+    """
+
+    def __init__(self, variable: str, period: float) -> None:
+        self.variable = variable
+        self.period = float(period)
+
+    def _apply(self, ds: xr.Dataset) -> xr.Dataset:
+        da = ds[self.variable]
+        sin, cos = _basis.cyclical_encode(da.values, period=self.period)
+        return ds.assign(
+            {
+                f"{self.variable}_sin": (da.dims, sin),
+                f"{self.variable}_cos": (da.dims, cos),
+            }
+        )
+
+    def get_config(self) -> dict[str, Any]:
+        return {"variable": self.variable, "period": self.period}
+
+
+class FourierFeatures(Operator):
+    """Deterministic Fourier-feature encoding of ``ds[variable]``.
+
+    Output is a new variable with one extra trailing ``feature_dim``
+    axis of length ``2 * num_freqs``.
+    """
+
+    def __init__(
+        self,
+        variable: str,
+        num_freqs: int,
+        scale: float = 1.0,
+        *,
+        output_name: str | None = None,
+        feature_dim: str = "feature",
+    ) -> None:
+        self.variable = variable
+        self.num_freqs = int(num_freqs)
+        self.scale = float(scale)
+        self.output_name = output_name
+        self.feature_dim = feature_dim
+
+    def _apply(self, ds: xr.Dataset) -> xr.Dataset:
+        da = ds[self.variable]
+        encoded = _basis.fourier_features(
+            da.values, num_freqs=self.num_freqs, scale=self.scale
+        )
+        name = self.output_name or f"{self.variable}_fourier"
+        return ds.assign({name: ((*da.dims, self.feature_dim), encoded)})
+
+    def get_config(self) -> dict[str, Any]:
+        return {
+            "variable": self.variable,
+            "num_freqs": self.num_freqs,
+            "scale": self.scale,
+            "output_name": self.output_name,
+            "feature_dim": self.feature_dim,
+        }
+
+
+class RandomFourierFeatures(Operator):
+    """Random Fourier features (Rahimi & Recht, 2007) of ``ds[variable]``."""
+
+    def __init__(
+        self,
+        variable: str,
+        num_features: int,
+        sigma: float = 1.0,
+        seed: int | None = None,
+        *,
+        output_name: str | None = None,
+        feature_dim: str = "feature",
+    ) -> None:
+        self.variable = variable
+        self.num_features = int(num_features)
+        self.sigma = float(sigma)
+        self.seed = seed
+        self.output_name = output_name
+        self.feature_dim = feature_dim
+
+    def _apply(self, ds: xr.Dataset) -> xr.Dataset:
+        da = ds[self.variable]
+        encoded = _basis.random_fourier_features(
+            da.values,
+            num_features=self.num_features,
+            sigma=self.sigma,
+            seed=self.seed,
+        )
+        name = self.output_name or f"{self.variable}_rff"
+        return ds.assign({name: ((*da.dims, self.feature_dim), encoded)})
+
+    def get_config(self) -> dict[str, Any]:
+        return {
+            "variable": self.variable,
+            "num_features": self.num_features,
+            "sigma": self.sigma,
+            "seed": self.seed,
+            "output_name": self.output_name,
+            "feature_dim": self.feature_dim,
+        }
+
+
+class PositionalEncoding(Operator):
+    """NeRF-style positional encoding of ``ds[variable]``."""
+
+    def __init__(
+        self,
+        variable: str,
+        num_freqs: int,
+        include_input: bool = True,
+        *,
+        output_name: str | None = None,
+        feature_dim: str = "feature",
+    ) -> None:
+        self.variable = variable
+        self.num_freqs = int(num_freqs)
+        self.include_input = bool(include_input)
+        self.output_name = output_name
+        self.feature_dim = feature_dim
+
+    def _apply(self, ds: xr.Dataset) -> xr.Dataset:
+        da = ds[self.variable]
+        encoded = _basis.positional_encoding(
+            da.values, num_freqs=self.num_freqs, include_input=self.include_input
+        )
+        name = self.output_name or f"{self.variable}_posenc"
+        return ds.assign({name: ((*da.dims, self.feature_dim), encoded)})
+
+    def get_config(self) -> dict[str, Any]:
+        return {
+            "variable": self.variable,
+            "num_freqs": self.num_freqs,
+            "include_input": self.include_input,
+            "output_name": self.output_name,
+            "feature_dim": self.feature_dim,
+        }
+
+
+class EncodeTimeCyclical(Operator):
+    """Wrap :func:`xr_toolz.transforms.encoders.encode_time_cyclical`."""
+
+    def __init__(
+        self,
+        components: Sequence[str] = ("dayofyear", "hour"),
+        time: str = "time",
+    ) -> None:
+        self.components = tuple(components)
+        self.time = time
+
+    def _apply(self, ds: xr.Dataset) -> xr.Dataset:
+        return _coord_time.encode_time_cyclical(
+            ds, components=self.components, time=self.time
+        )
+
+    def get_config(self) -> dict[str, Any]:
+        return {"components": list(self.components), "time": self.time}
+
+
+class EncodeTimeOrdinal(Operator):
+    """Wrap :func:`xr_toolz.transforms.encoders.encode_time_ordinal`."""
+
+    def __init__(
+        self,
+        reference_date: str | None = None,
+        time: str = "time",
+        unit: str = "D",
+    ) -> None:
+        self.reference_date = reference_date
+        self.time = time
+        self.unit = unit
+
+    def _apply(self, ds: xr.Dataset) -> xr.Dataset:
+        return _coord_time.encode_time_ordinal(
+            ds,
+            reference_date=self.reference_date,
+            time=self.time,
+            unit=self.unit,
+        )
+
+    def get_config(self) -> dict[str, Any]:
+        return {
+            "reference_date": self.reference_date,
+            "time": self.time,
+            "unit": self.unit,
+        }
+
+
+class TimeRescale(Operator):
+    """Wrap :func:`xr_toolz.transforms.encoders.time_rescale`."""
+
+    def __init__(
+        self,
+        freq_dt: float = 1.0,
+        freq_unit: str = "s",
+        t0: str | None = None,
+        time: str = "time",
+    ) -> None:
+        self.freq_dt = float(freq_dt)
+        self.freq_unit = freq_unit
+        self.t0 = t0
+        self.time = time
+
+    def _apply(self, ds: xr.Dataset) -> xr.Dataset:
+        return _coord_time.time_rescale(
+            ds,
+            freq_dt=self.freq_dt,
+            freq_unit=self.freq_unit,
+            t0=self.t0,
+            time=self.time,
+        )
+
+    def get_config(self) -> dict[str, Any]:
+        return {
+            "freq_dt": self.freq_dt,
+            "freq_unit": self.freq_unit,
+            "t0": self.t0,
+            "time": self.time,
+        }
+
+
+class TimeUnrescale(Operator):
+    """Wrap :func:`xr_toolz.transforms.encoders.time_unrescale`."""
+
+    def __init__(self, time: str = "time") -> None:
+        self.time = time
+
+    def _apply(self, ds: xr.Dataset) -> xr.Dataset:
+        return _coord_time.time_unrescale(ds, time=self.time)
+
+    def get_config(self) -> dict[str, Any]:
+        return {"time": self.time}
+
+
 __all__ = [
     "CWT",
     "DCT",
@@ -277,5 +523,13 @@ __all__ = [
     "STFT",
     "Coherence",
     "CrossSpectrum",
+    "CyclicalEncode",
+    "EncodeTimeCyclical",
+    "EncodeTimeOrdinal",
+    "FourierFeatures",
+    "PositionalEncoding",
     "PowerSpectrum",
+    "RandomFourierFeatures",
+    "TimeRescale",
+    "TimeUnrescale",
 ]

--- a/src/xr_toolz/transforms/operators.py
+++ b/src/xr_toolz/transforms/operators.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import Any
 
+import numpy as np
 import xarray as xr
 
 from xr_toolz.core import Operator
@@ -30,6 +31,13 @@ from xr_toolz.transforms._src.encoders import (
     basis as _basis,
     coord_time as _coord_time,
 )
+
+
+def _datetime_to_jsonable(value: str | np.datetime64 | None) -> str | None:
+    """Stringify ``np.datetime64`` for JSON-serializable ``get_config``."""
+    if value is None or isinstance(value, str):
+        return value
+    return str(value)
 
 
 # ---------- Fourier --------------------------------------------------------
@@ -372,7 +380,14 @@ class RandomFourierFeatures(Operator):
             seed=self.seed,
         )
         name = self.output_name or f"{self.variable}_rff"
-        return ds.assign({name: ((*da.dims, self.feature_dim), encoded)})
+        # random_fourier_features appends a feature axis for 1-D / scalar
+        # inputs but *replaces* the trailing feature axis for ≥ 2-D
+        # vector inputs (it projects via a (d, num_features/2) matrix).
+        if da.ndim <= 1:
+            out_dims: tuple[str, ...] = (*da.dims, self.feature_dim)
+        else:
+            out_dims = (*da.dims[:-1], self.feature_dim)
+        return ds.assign({name: (out_dims, encoded)})
 
     def get_config(self) -> dict[str, Any]:
         return {
@@ -446,7 +461,7 @@ class EncodeTimeOrdinal(Operator):
 
     def __init__(
         self,
-        reference_date: str | None = None,
+        reference_date: str | np.datetime64 | None = None,
         time: str = "time",
         unit: str = "D",
     ) -> None:
@@ -464,7 +479,7 @@ class EncodeTimeOrdinal(Operator):
 
     def get_config(self) -> dict[str, Any]:
         return {
-            "reference_date": self.reference_date,
+            "reference_date": _datetime_to_jsonable(self.reference_date),
             "time": self.time,
             "unit": self.unit,
         }
@@ -477,7 +492,7 @@ class TimeRescale(Operator):
         self,
         freq_dt: float = 1.0,
         freq_unit: str = "s",
-        t0: str | None = None,
+        t0: str | np.datetime64 | None = None,
         time: str = "time",
     ) -> None:
         self.freq_dt = float(freq_dt)
@@ -498,7 +513,7 @@ class TimeRescale(Operator):
         return {
             "freq_dt": self.freq_dt,
             "freq_unit": self.freq_unit,
-            "t0": self.t0,
+            "t0": _datetime_to_jsonable(self.t0),
             "time": self.time,
         }
 

--- a/src/xr_toolz/transforms/operators.py
+++ b/src/xr_toolz/transforms/operators.py
@@ -373,6 +373,11 @@ class RandomFourierFeatures(Operator):
 
     def _apply(self, ds: xr.Dataset) -> xr.Dataset:
         da = ds[self.variable]
+        if da.ndim == 0:
+            raise ValueError(
+                "RandomFourierFeatures requires a non-scalar input variable; "
+                f"ds[{self.variable!r}] has ndim=0."
+            )
         encoded = _basis.random_fourier_features(
             da.values,
             num_features=self.num_features,
@@ -380,11 +385,11 @@ class RandomFourierFeatures(Operator):
             seed=self.seed,
         )
         name = self.output_name or f"{self.variable}_rff"
-        # random_fourier_features appends a feature axis for 1-D / scalar
-        # inputs but *replaces* the trailing feature axis for ≥ 2-D
-        # vector inputs (it projects via a (d, num_features/2) matrix).
-        if da.ndim <= 1:
-            out_dims: tuple[str, ...] = (*da.dims, self.feature_dim)
+        # random_fourier_features appends a feature axis for 1-D inputs
+        # but *replaces* the trailing feature axis for ≥ 2-D vector
+        # inputs (it projects via a (d, num_features/2) matrix).
+        if da.ndim == 1:
+            out_dims = (*da.dims, self.feature_dim)
         else:
             out_dims = (*da.dims[:-1], self.feature_dim)
         return ds.assign({name: (out_dims, encoded)})

--- a/tests/transforms/test_encoder_operators.py
+++ b/tests/transforms/test_encoder_operators.py
@@ -1,0 +1,145 @@
+"""Behavioral tests for the Tier-C encoder operators (#95)."""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+from xr_toolz.transforms.encoders import (
+    cyclical_encode,
+    encode_time_cyclical,
+    encode_time_ordinal,
+    fourier_features,
+    positional_encoding,
+    random_fourier_features,
+    time_rescale,
+    time_unrescale,
+)
+from xr_toolz.transforms.operators import (
+    CyclicalEncode,
+    EncodeTimeCyclical,
+    EncodeTimeOrdinal,
+    FourierFeatures,
+    PositionalEncoding,
+    RandomFourierFeatures,
+    TimeRescale,
+    TimeUnrescale,
+)
+
+
+# ---------- fixtures ------------------------------------------------------
+
+
+@pytest.fixture
+def ds_scalar() -> xr.Dataset:
+    rng = np.random.default_rng(0)
+    return xr.Dataset(
+        {"angle": (("sample",), rng.uniform(0, 2 * np.pi, size=8))},
+        coords={"sample": np.arange(8)},
+    )
+
+
+@pytest.fixture
+def ds_time() -> xr.Dataset:
+    time = pd.date_range("2020-01-01", periods=10, freq="6h")
+    return xr.Dataset(
+        {"x": (("time",), np.arange(10, dtype=float))},
+        coords={"time": time},
+    )
+
+
+# ---------- parity --------------------------------------------------------
+
+
+def test_cyclical_encode_parity(ds_scalar: xr.Dataset) -> None:
+    op = CyclicalEncode(variable="angle", period=2 * np.pi)
+    out = op(ds_scalar)
+    sin_e, cos_e = cyclical_encode(ds_scalar["angle"].values, period=2 * np.pi)
+    np.testing.assert_allclose(out["angle_sin"].values, sin_e)
+    np.testing.assert_allclose(out["angle_cos"].values, cos_e)
+    assert "angle" in out  # original preserved
+
+
+def test_fourier_features_parity(ds_scalar: xr.Dataset) -> None:
+    op = FourierFeatures(variable="angle", num_freqs=4, scale=2.0)
+    out = op(ds_scalar)
+    expected = fourier_features(ds_scalar["angle"].values, num_freqs=4, scale=2.0)
+    np.testing.assert_allclose(out["angle_fourier"].values, expected)
+    assert out["angle_fourier"].dims == ("sample", "feature")
+    assert out.sizes["feature"] == 8
+
+
+def test_random_fourier_features_parity(ds_scalar: xr.Dataset) -> None:
+    op = RandomFourierFeatures(variable="angle", num_features=10, sigma=1.5, seed=42)
+    out = op(ds_scalar)
+    expected = random_fourier_features(
+        ds_scalar["angle"].values, num_features=10, sigma=1.5, seed=42
+    )
+    np.testing.assert_allclose(out["angle_rff"].values, expected)
+
+
+def test_positional_encoding_parity(ds_scalar: xr.Dataset) -> None:
+    op = PositionalEncoding(variable="angle", num_freqs=3, include_input=True)
+    out = op(ds_scalar)
+    expected = positional_encoding(
+        ds_scalar["angle"].values, num_freqs=3, include_input=True
+    )
+    np.testing.assert_allclose(out["angle_posenc"].values, expected)
+
+
+def test_encode_time_cyclical_parity(ds_time: xr.Dataset) -> None:
+    op = EncodeTimeCyclical(components=("hour", "dayofyear"))
+    out = op(ds_time)
+    expected = encode_time_cyclical(ds_time, components=("hour", "dayofyear"))
+    xr.testing.assert_identical(out, expected)
+
+
+def test_encode_time_ordinal_parity(ds_time: xr.Dataset) -> None:
+    op = EncodeTimeOrdinal(unit="h")
+    out = op(ds_time)
+    expected = encode_time_ordinal(ds_time, unit="h")
+    xr.testing.assert_identical(out, expected)
+
+
+def test_time_rescale_unrescale_round_trip(ds_time: xr.Dataset) -> None:
+    rescale = TimeRescale(freq_dt=6.0, freq_unit="h")
+    unrescale = TimeUnrescale()
+    rescaled = rescale(ds_time)
+    np.testing.assert_array_equal(
+        time_rescale(ds_time, freq_dt=6.0, freq_unit="h")["time"].values,
+        rescaled["time"].values,
+    )
+    restored = unrescale(rescaled)
+    xr.testing.assert_allclose(
+        restored["time"].astype("datetime64[ns]").astype(np.int64),
+        ds_time["time"].astype("datetime64[ns]").astype(np.int64),
+    )
+    # And via direct round-trip:
+    direct = time_unrescale(time_rescale(ds_time, freq_dt=6.0, freq_unit="h"))
+    xr.testing.assert_identical(restored, direct)
+
+
+# ---------- get_config ----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "op",
+    [
+        CyclicalEncode(variable="x", period=24.0),
+        FourierFeatures(variable="x", num_freqs=4),
+        RandomFourierFeatures(variable="x", num_features=8, seed=0),
+        PositionalEncoding(variable="x", num_freqs=3),
+        EncodeTimeCyclical(components=("hour",)),
+        EncodeTimeOrdinal(unit="D"),
+        TimeRescale(freq_dt=1.0, freq_unit="h"),
+        TimeUnrescale(),
+    ],
+    ids=lambda op: type(op).__name__,
+)
+def test_get_config_json_round_trips(op) -> None:
+    cfg = op.get_config()
+    assert json.loads(json.dumps(cfg)) == cfg

--- a/tests/transforms/test_encoder_operators.py
+++ b/tests/transforms/test_encoder_operators.py
@@ -83,6 +83,13 @@ def test_random_fourier_features_parity(ds_scalar: xr.Dataset) -> None:
     assert out["angle_rff"].dims == ("sample", "feature")
 
 
+def test_random_fourier_features_rejects_scalar_input() -> None:
+    ds = xr.Dataset({"x": ((), np.float64(1.5))})
+    op = RandomFourierFeatures(variable="x", num_features=4, seed=0)
+    with pytest.raises(ValueError, match="non-scalar"):
+        op(ds)
+
+
 def test_random_fourier_features_replaces_trailing_axis_for_vector_input() -> None:
     rng = np.random.default_rng(0)
     ds = xr.Dataset(

--- a/tests/transforms/test_encoder_operators.py
+++ b/tests/transforms/test_encoder_operators.py
@@ -80,6 +80,24 @@ def test_random_fourier_features_parity(ds_scalar: xr.Dataset) -> None:
         ds_scalar["angle"].values, num_features=10, sigma=1.5, seed=42
     )
     np.testing.assert_allclose(out["angle_rff"].values, expected)
+    assert out["angle_rff"].dims == ("sample", "feature")
+
+
+def test_random_fourier_features_replaces_trailing_axis_for_vector_input() -> None:
+    rng = np.random.default_rng(0)
+    ds = xr.Dataset(
+        {"x": (("sample", "channel"), rng.standard_normal((6, 3)))},
+        coords={"sample": np.arange(6), "channel": np.arange(3)},
+    )
+    op = RandomFourierFeatures(variable="x", num_features=8, sigma=1.0, seed=1)
+    out = op(ds)
+    expected = random_fourier_features(
+        ds["x"].values, num_features=8, sigma=1.0, seed=1
+    )
+    # Output should be 2-D (sample, feature) — trailing channel axis replaced.
+    assert out["x_rff"].dims == ("sample", "feature")
+    assert out["x_rff"].shape == (6, 8)
+    np.testing.assert_allclose(out["x_rff"].values, expected)
 
 
 def test_positional_encoding_parity(ds_scalar: xr.Dataset) -> None:
@@ -143,3 +161,11 @@ def test_time_rescale_unrescale_round_trip(ds_time: xr.Dataset) -> None:
 def test_get_config_json_round_trips(op) -> None:
     cfg = op.get_config()
     assert json.loads(json.dumps(cfg)) == cfg
+
+
+def test_time_ops_stringify_datetime64_in_config() -> None:
+    t0 = np.datetime64("2020-06-15T00:00:00")
+    rescale = TimeRescale(freq_dt=1.0, freq_unit="D", t0=t0)
+    ordinal = EncodeTimeOrdinal(reference_date=t0)
+    for cfg in (rescale.get_config(), ordinal.get_config()):
+        assert json.loads(json.dumps(cfg)) == cfg


### PR DESCRIPTION
## Summary

Closes #95. F5.2 follow-up — adds eight Tier C \`Operator\` wrappers around the encoder primitives moved to \`xr_toolz.transforms.encoders\` during Epic F5.

## New operators

| Operator | Wraps |
|---|---|
| \`CyclicalEncode\` | \`cyclical_encode\` |
| \`FourierFeatures\` | \`fourier_features\` |
| \`RandomFourierFeatures\` | \`random_fourier_features\` |
| \`PositionalEncoding\` | \`positional_encoding\` |
| \`EncodeTimeCyclical\` | \`encode_time_cyclical\` |
| \`EncodeTimeOrdinal\` | \`encode_time_ordinal\` |
| \`TimeRescale\` | \`time_rescale\` |
| \`TimeUnrescale\` | \`time_unrescale\` |

All live in \`xr_toolz.transforms.operators\` (added to the existing module rather than splitting; size still manageable at ~530 lines).

## Test plan
- [x] \`uv run pytest --no-cov tests/transforms/test_encoder_operators.py\` — 15 passed (parity + get_config round-trip)
- [x] \`uv run --group lint ruff check src tests\` clean for this PR's files
- [x] \`uv run --group lint ruff format --check src tests\` clean for this PR's files

🤖 Generated with [Claude Code](https://claude.com/claude-code)