### PR TITLE
refactor(types): tier-A array layer pilot (Epic F2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Added
+
+* `xr_toolz.metrics.array` — Tier A array kernels (D11) for the canonical pixel metrics: `mse`, `rmse`, `mae`, `bias`, `nrmse`, `correlation`, `r2_score`. Tier B (`xr_toolz.metrics._src.pixel`) now delegates via `xr.apply_ufunc` rather than reimplementing the math.
+* `xr_toolz.transforms.array` — Tier A array kernels (D11) for the canonical Fourier entry points: `fft`, `ifft`, `power_spectrum`. Numpy-only computational core; Tier B (`xrft`-backed) is unchanged.
+* `xr_toolz.calc.array` — Tier A array kernels (D11) for the canonical finite-difference primitives: `partial`, `gradient` (2nd-order central, uniform spacing). Numpy-only core complementing the `finitediffx`-backed Tier B.
+* `tests/test_tier_contract.py` — three-tier contract harness (Tier A reachable, Tier B numerically agrees with Tier A, Tier C numerically agrees with Tier B) for the metrics/transforms/calc pilots.
+
 ### Removed
 
 * Value-resampling primitives moved out of `xr_toolz.geo` into the new `xr_toolz.interpolate` package (D8/D12, Epic F3). No deprecation shim — the package is pre-1.0 and has no external users.

--- a/docs/design/api/components.md
+++ b/docs/design/api/components.md
@@ -50,6 +50,8 @@ class Lambda:          # Wrap an arbitrary Callable as an Operator
 
 Standardizes coordinate names, ranges, ordering, and metadata across heterogeneous data sources. This is almost always the first step in any pipeline.
 
+**Type contract (D11):** skips Tier A — the math is coord/attr manipulation, not arithmetic. Tier B takes `xr.Dataset` directly.
+
 ```python
 class ValidateCoords:
     """Validate and harmonize all spatial and temporal coordinates.
@@ -72,6 +74,8 @@ class SortCoords:
 
 Embedding and transforming CRS metadata. Wraps `rioxarray` and `pyproj`.
 
+**Type contract (D11):** skips Tier A — operations modify CRS metadata and reproject coords; the underlying numerical work is delegated to `rioxarray` / `pyproj`. Tier B takes `xr.Dataset` directly.
+
 ```python
 class AssignCRS:
     def __init__(self, crs="EPSG:4326"): ...
@@ -85,6 +89,8 @@ class Reproject:
 ## `subset` — Spatial and Temporal Selection
 
 Extract regions of interest by bounding box, geometry, or time period.
+
+**Type contract (D11):** skips Tier A — selection is coord-driven and does no array arithmetic. Tier B takes `xr.Dataset` directly.
 
 ```python
 class SubsetBBox:
@@ -106,6 +112,8 @@ class SelectVariables:
 ## `masks` — Spatial Masks
 
 Add land, ocean, country, or custom masks as coordinate variables. Wraps `regionmask`.
+
+**Type contract (D11):** skips Tier A — mask construction is geometry/coord-driven via `regionmask`, not array arithmetic. Tier B takes `xr.Dataset` directly.
 
 ```python
 class AddLandMask:

--- a/src/xr_toolz/calc/_src/array_calc.py
+++ b/src/xr_toolz/calc/_src/array_calc.py
@@ -1,0 +1,78 @@
+"""Tier A — array kernels for finite-difference calculus.
+
+Pure-array entry points for the canonical central-difference derivatives
+on uniform Cartesian grids. Tier B (xarray, ``dim=``) wrappers in
+:mod:`xr_toolz.calc._src.cartesian` add coord/attr handling and route to
+``finitediffx`` for higher-order accuracies; this module is the
+numpy-only computational core for the default 2nd-order central-difference
+case (``accuracy=1, method="central"``), built on :func:`numpy.gradient`.
+
+Pilot scope: ``partial`` and ``gradient`` only. ``divergence`` /
+``curl`` / ``laplacian`` are deferred to follow-up issues.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import ArrayLike, NDArray
+
+
+def partial(
+    x: ArrayLike,
+    *,
+    axis: int,
+    spacing: float = 1.0,
+) -> NDArray[np.floating]:
+    """Partial derivative ``∂x/∂<axis>`` via 2nd-order central differences.
+
+    Args:
+        x: Input array.
+        axis: Axis to differentiate along.
+        spacing: Uniform sample spacing along ``axis``.
+
+    Returns:
+        Array with the same shape as ``x``.
+    """
+    arr = np.asarray(x)
+    return np.gradient(arr, spacing, axis=axis)
+
+
+def gradient(
+    x: ArrayLike,
+    *,
+    axes: tuple[int, ...] | None = None,
+    spacing: float | tuple[float, ...] = 1.0,
+) -> tuple[NDArray[np.floating], ...]:
+    """Gradient ``∇x`` over ``axes`` via 2nd-order central differences.
+
+    Args:
+        x: Input array.
+        axes: Axes to differentiate against. Defaults to every axis of
+            ``x``, in order.
+        spacing: Scalar sample spacing applied to every axis, or a
+            per-axis tuple matching the length of ``axes``.
+
+    Returns:
+        Tuple of arrays — one partial derivative per axis in ``axes``,
+        each with the same shape as ``x``.
+    """
+    arr = np.asarray(x)
+    target = tuple(range(arr.ndim)) if axes is None else tuple(axes)
+    if isinstance(spacing, (int, float)):
+        steps: tuple[float, ...] = (float(spacing),) * len(target)
+    else:
+        steps = tuple(float(s) for s in spacing)
+        if len(steps) != len(target):
+            raise ValueError(
+                f"spacing tuple length ({len(steps)}) does not match number "
+                f"of axes ({len(target)})."
+            )
+    return tuple(
+        np.gradient(arr, step, axis=ax) for ax, step in zip(target, steps, strict=True)
+    )
+
+
+__all__ = [
+    "gradient",
+    "partial",
+]

--- a/src/xr_toolz/calc/_src/array_calc.py
+++ b/src/xr_toolz/calc/_src/array_calc.py
@@ -67,9 +67,10 @@ def gradient(
                 f"spacing tuple length ({len(steps)}) does not match number "
                 f"of axes ({len(target)})."
             )
-    return tuple(
-        np.gradient(arr, step, axis=ax) for ax, step in zip(target, steps, strict=True)
-    )
+    result = np.gradient(arr, *steps, axis=target)
+    if isinstance(result, tuple):
+        return result
+    return (result,)
 
 
 __all__ = [

--- a/src/xr_toolz/calc/array.py
+++ b/src/xr_toolz/calc/array.py
@@ -1,0 +1,27 @@
+"""Tier A — array-tier entry points for :mod:`xr_toolz.calc`.
+
+Per design decision D11, every arithmetic submodule grows a duck-array
+``axis=`` entry point under ``<module>/array.py``. This module re-exports
+the pilot finite-difference kernels (``partial``, ``gradient``) for raw
+numpy arrays under the default 2nd-order central-difference scheme.
+
+Tier B wrappers in :mod:`xr_toolz.calc._src.cartesian` (and the
+geometry-dispatched :mod:`xr_toolz.calc._src.operators`) keep the
+``finitediffx``-backed higher-order / non-uniform / spherical paths;
+this module is the simple numpy-only computational core that callers
+can drop down to when they have raw arrays and want the standard
+2nd-order centred stencil.
+"""
+
+from __future__ import annotations
+
+from xr_toolz.calc._src.array_calc import (
+    gradient,
+    partial,
+)
+
+
+__all__ = [
+    "gradient",
+    "partial",
+]

--- a/src/xr_toolz/metrics/_src/array_pixel.py
+++ b/src/xr_toolz/metrics/_src/array_pixel.py
@@ -1,0 +1,118 @@
+"""Tier A — array kernels for pointwise (pixel-level) evaluation metrics.
+
+Pure-array entry points used by Tier B (xarray) wrappers. Signatures
+follow D11: ``(prediction, reference, *, axis, **kwargs) -> ndarray``.
+
+Backend: numpy. JAX / CuPy variants are out of scope for the pilot.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import ArrayLike, NDArray
+
+
+Axis = int | tuple[int, ...]
+
+
+def mse(
+    prediction: ArrayLike,
+    reference: ArrayLike,
+    *,
+    axis: Axis = -1,
+) -> NDArray[np.floating]:
+    """Mean squared error along ``axis``."""
+    pred = np.asarray(prediction)
+    ref = np.asarray(reference)
+    return np.mean((pred - ref) ** 2, axis=axis)
+
+
+def rmse(
+    prediction: ArrayLike,
+    reference: ArrayLike,
+    *,
+    axis: Axis = -1,
+) -> NDArray[np.floating]:
+    """Root mean squared error along ``axis``."""
+    return np.sqrt(mse(prediction, reference, axis=axis))
+
+
+def mae(
+    prediction: ArrayLike,
+    reference: ArrayLike,
+    *,
+    axis: Axis = -1,
+) -> NDArray[np.floating]:
+    """Mean absolute error along ``axis``."""
+    pred = np.asarray(prediction)
+    ref = np.asarray(reference)
+    return np.mean(np.abs(pred - ref), axis=axis)
+
+
+def bias(
+    prediction: ArrayLike,
+    reference: ArrayLike,
+    *,
+    axis: Axis = -1,
+) -> NDArray[np.floating]:
+    """Mean bias ``<pred - ref>`` along ``axis``."""
+    pred = np.asarray(prediction)
+    ref = np.asarray(reference)
+    return np.mean(pred - ref, axis=axis)
+
+
+def nrmse(
+    prediction: ArrayLike,
+    reference: ArrayLike,
+    *,
+    axis: Axis = -1,
+) -> NDArray[np.floating]:
+    """Normalized RMSE: ``1 - RMSE / sqrt(<ref^2>)`` along ``axis``."""
+    err = rmse(prediction, reference, axis=axis)
+    ref = np.asarray(reference)
+    scale = np.sqrt(np.mean(ref**2, axis=axis))
+    return 1.0 - err / scale
+
+
+def correlation(
+    prediction: ArrayLike,
+    reference: ArrayLike,
+    *,
+    axis: Axis = -1,
+) -> NDArray[np.floating]:
+    """Pearson correlation between prediction and reference along ``axis``."""
+    pred = np.asarray(prediction)
+    ref = np.asarray(reference)
+    pred_mean = np.mean(pred, axis=axis, keepdims=True)
+    ref_mean = np.mean(ref, axis=axis, keepdims=True)
+    pred_anom = pred - pred_mean
+    ref_anom = ref - ref_mean
+    num = np.mean(pred_anom * ref_anom, axis=axis)
+    denom = np.sqrt(np.mean(pred_anom**2, axis=axis) * np.mean(ref_anom**2, axis=axis))
+    return num / denom
+
+
+def r2_score(
+    prediction: ArrayLike,
+    reference: ArrayLike,
+    *,
+    axis: Axis = -1,
+) -> NDArray[np.floating]:
+    """Coefficient of determination: ``1 - SS_res / SS_tot`` along ``axis``."""
+    pred = np.asarray(prediction)
+    ref = np.asarray(reference)
+    ss_res = np.sum((ref - pred) ** 2, axis=axis)
+    ref_mean = np.mean(ref, axis=axis, keepdims=True)
+    ss_tot = np.sum((ref - ref_mean) ** 2, axis=axis)
+    return 1.0 - ss_res / ss_tot
+
+
+__all__ = [
+    "bias",
+    "correlation",
+    "mae",
+    "mse",
+    "nrmse",
+    "r2_score",
+    "rmse",
+]

--- a/src/xr_toolz/metrics/_src/array_pixel.py
+++ b/src/xr_toolz/metrics/_src/array_pixel.py
@@ -3,6 +3,12 @@
 Pure-array entry points used by Tier B (xarray) wrappers. Signatures
 follow D11: ``(prediction, reference, *, axis, **kwargs) -> ndarray``.
 
+NaN handling: matches the Tier B xarray default (``skipna=True`` for
+floating-point arrays). All reductions ignore NaNs via
+:func:`numpy.nanmean` / :func:`numpy.nansum`. If every element along
+``axis`` is NaN, the result for that slice is NaN (NumPy emits a
+``RuntimeWarning``).
+
 Backend: numpy. JAX / CuPy variants are out of scope for the pilot.
 """
 
@@ -21,10 +27,10 @@ def mse(
     *,
     axis: Axis = -1,
 ) -> NDArray[np.floating]:
-    """Mean squared error along ``axis``."""
+    """Mean squared error along ``axis``. NaN-skipping."""
     pred = np.asarray(prediction)
     ref = np.asarray(reference)
-    return np.mean((pred - ref) ** 2, axis=axis)
+    return np.nanmean((pred - ref) ** 2, axis=axis)
 
 
 def rmse(
@@ -33,7 +39,7 @@ def rmse(
     *,
     axis: Axis = -1,
 ) -> NDArray[np.floating]:
-    """Root mean squared error along ``axis``."""
+    """Root mean squared error along ``axis``. NaN-skipping."""
     return np.sqrt(mse(prediction, reference, axis=axis))
 
 
@@ -43,10 +49,10 @@ def mae(
     *,
     axis: Axis = -1,
 ) -> NDArray[np.floating]:
-    """Mean absolute error along ``axis``."""
+    """Mean absolute error along ``axis``. NaN-skipping."""
     pred = np.asarray(prediction)
     ref = np.asarray(reference)
-    return np.mean(np.abs(pred - ref), axis=axis)
+    return np.nanmean(np.abs(pred - ref), axis=axis)
 
 
 def bias(
@@ -55,10 +61,10 @@ def bias(
     *,
     axis: Axis = -1,
 ) -> NDArray[np.floating]:
-    """Mean bias ``<pred - ref>`` along ``axis``."""
+    """Mean bias ``<pred - ref>`` along ``axis``. NaN-skipping."""
     pred = np.asarray(prediction)
     ref = np.asarray(reference)
-    return np.mean(pred - ref, axis=axis)
+    return np.nanmean(pred - ref, axis=axis)
 
 
 def nrmse(
@@ -67,10 +73,10 @@ def nrmse(
     *,
     axis: Axis = -1,
 ) -> NDArray[np.floating]:
-    """Normalized RMSE: ``1 - RMSE / sqrt(<ref^2>)`` along ``axis``."""
+    """Normalized RMSE: ``1 - RMSE / sqrt(<ref^2>)`` along ``axis``. NaN-skipping."""
     err = rmse(prediction, reference, axis=axis)
     ref = np.asarray(reference)
-    scale = np.sqrt(np.mean(ref**2, axis=axis))
+    scale = np.sqrt(np.nanmean(ref**2, axis=axis))
     return 1.0 - err / scale
 
 
@@ -80,15 +86,17 @@ def correlation(
     *,
     axis: Axis = -1,
 ) -> NDArray[np.floating]:
-    """Pearson correlation between prediction and reference along ``axis``."""
+    """Pearson correlation between ``prediction`` and ``reference``. NaN-skipping."""
     pred = np.asarray(prediction)
     ref = np.asarray(reference)
-    pred_mean = np.mean(pred, axis=axis, keepdims=True)
-    ref_mean = np.mean(ref, axis=axis, keepdims=True)
+    pred_mean = np.nanmean(pred, axis=axis, keepdims=True)
+    ref_mean = np.nanmean(ref, axis=axis, keepdims=True)
     pred_anom = pred - pred_mean
     ref_anom = ref - ref_mean
-    num = np.mean(pred_anom * ref_anom, axis=axis)
-    denom = np.sqrt(np.mean(pred_anom**2, axis=axis) * np.mean(ref_anom**2, axis=axis))
+    num = np.nanmean(pred_anom * ref_anom, axis=axis)
+    denom = np.sqrt(
+        np.nanmean(pred_anom**2, axis=axis) * np.nanmean(ref_anom**2, axis=axis)
+    )
     return num / denom
 
 
@@ -98,12 +106,12 @@ def r2_score(
     *,
     axis: Axis = -1,
 ) -> NDArray[np.floating]:
-    """Coefficient of determination: ``1 - SS_res / SS_tot`` along ``axis``."""
+    """Coefficient of determination ``1 - SS_res / SS_tot``. NaN-skipping."""
     pred = np.asarray(prediction)
     ref = np.asarray(reference)
-    ss_res = np.sum((ref - pred) ** 2, axis=axis)
-    ref_mean = np.mean(ref, axis=axis, keepdims=True)
-    ss_tot = np.sum((ref - ref_mean) ** 2, axis=axis)
+    ss_res = np.nansum((ref - pred) ** 2, axis=axis)
+    ref_mean = np.nanmean(ref, axis=axis, keepdims=True)
+    ss_tot = np.nansum((ref - ref_mean) ** 2, axis=axis)
     return 1.0 - ss_res / ss_tot
 
 

--- a/src/xr_toolz/metrics/_src/pixel.py
+++ b/src/xr_toolz/metrics/_src/pixel.py
@@ -6,6 +6,10 @@ return a :class:`xr.DataArray` with the remaining dimensions.
 
 Convention: positive ``bias`` means the prediction is larger than the
 reference. Correlation is Pearson's ``r``.
+
+Per design decision D11, the pointwise math lives in the Tier A array
+kernels at :mod:`xr_toolz.metrics._src.array_pixel`; the Tier B wrappers
+below delegate to those kernels via :func:`xr.apply_ufunc`.
 """
 
 from __future__ import annotations
@@ -16,9 +20,42 @@ from typing import Any
 import xarray as xr
 
 from xr_toolz.core import Operator
+from xr_toolz.metrics._src import array_pixel
 
 
 Dims = str | Sequence[str]
+
+
+def _normalize_dims(dims: Dims) -> list[str]:
+    return [dims] if isinstance(dims, str) else list(dims)
+
+
+def _apply_pixel_kernel(
+    fn: Any,
+    ds_pred: xr.Dataset,
+    ds_ref: xr.Dataset,
+    variable: str,
+    dims: Dims,
+) -> xr.DataArray:
+    """Run a Tier A pixel kernel on the named variable, reducing ``dims``.
+
+    Selects ``variable`` from each Dataset, then dispatches to the array
+    kernel via :func:`xr.apply_ufunc` with ``dims`` as the input core
+    dimensions. The kernel sees a flattened trailing block of axes and
+    reduces with ``axis=tuple(range(-len(core), 0))``.
+    """
+    da_pred = ds_pred[variable]
+    da_ref = ds_ref[variable]
+    core = _normalize_dims(dims)
+    out: xr.DataArray = xr.apply_ufunc(
+        lambda p, r: fn(p, r, axis=tuple(range(-len(core), 0))),
+        da_pred,
+        da_ref,
+        input_core_dims=[core, core],
+        dask="parallelized",
+        output_dtypes=[da_pred.dtype],
+    )
+    return out
 
 
 # ---------- Layer-0 (xarray) ----------------------------------------------
@@ -31,8 +68,7 @@ def mse(
     dims: Dims,
 ) -> xr.DataArray:
     """Mean squared error reduced over ``dims``."""
-    diff = ds_pred[variable] - ds_ref[variable]
-    return (diff**2).mean(dim=dims)
+    return _apply_pixel_kernel(array_pixel.mse, ds_pred, ds_ref, variable, dims)
 
 
 def rmse(
@@ -42,7 +78,7 @@ def rmse(
     dims: Dims,
 ) -> xr.DataArray:
     """Root mean squared error reduced over ``dims``."""
-    return mse(ds_pred, ds_ref, variable, dims) ** 0.5
+    return _apply_pixel_kernel(array_pixel.rmse, ds_pred, ds_ref, variable, dims)
 
 
 def nrmse(
@@ -56,9 +92,7 @@ def nrmse(
     Returns a score in ``(-inf, 1]`` where 1 means a perfect match and 0
     means the prediction is as wrong as a zero prediction.
     """
-    err = rmse(ds_pred, ds_ref, variable, dims)
-    scale = (ds_ref[variable] ** 2).mean(dim=dims) ** 0.5
-    return 1.0 - err / scale
+    return _apply_pixel_kernel(array_pixel.nrmse, ds_pred, ds_ref, variable, dims)
 
 
 def mae(
@@ -68,7 +102,7 @@ def mae(
     dims: Dims,
 ) -> xr.DataArray:
     """Mean absolute error reduced over ``dims``."""
-    return abs(ds_pred[variable] - ds_ref[variable]).mean(dim=dims)
+    return _apply_pixel_kernel(array_pixel.mae, ds_pred, ds_ref, variable, dims)
 
 
 def bias(
@@ -78,7 +112,7 @@ def bias(
     dims: Dims,
 ) -> xr.DataArray:
     """Mean bias ``<pred - ref>`` reduced over ``dims``."""
-    return (ds_pred[variable] - ds_ref[variable]).mean(dim=dims)
+    return _apply_pixel_kernel(array_pixel.bias, ds_pred, ds_ref, variable, dims)
 
 
 def correlation(
@@ -88,7 +122,7 @@ def correlation(
     dims: Dims,
 ) -> xr.DataArray:
     """Pearson correlation between prediction and reference over ``dims``."""
-    return xr.corr(ds_pred[variable], ds_ref[variable], dim=dims)
+    return _apply_pixel_kernel(array_pixel.correlation, ds_pred, ds_ref, variable, dims)
 
 
 def r2_score(
@@ -98,10 +132,7 @@ def r2_score(
     dims: Dims,
 ) -> xr.DataArray:
     """Coefficient of determination: ``1 - SS_res / SS_tot``."""
-    ref = ds_ref[variable]
-    ss_res = ((ref - ds_pred[variable]) ** 2).sum(dim=dims)
-    ss_tot = ((ref - ref.mean(dim=dims)) ** 2).sum(dim=dims)
-    return 1.0 - ss_res / ss_tot
+    return _apply_pixel_kernel(array_pixel.r2_score, ds_pred, ds_ref, variable, dims)
 
 
 # ---------- Layer-1 (Operator wrappers) -----------------------------------

--- a/src/xr_toolz/metrics/_src/pixel.py
+++ b/src/xr_toolz/metrics/_src/pixel.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import Any
 
+import numpy as np
 import xarray as xr
 
 from xr_toolz.core import Operator
@@ -43,17 +44,28 @@ def _apply_pixel_kernel(
     kernel via :func:`xr.apply_ufunc` with ``dims`` as the input core
     dimensions. The kernel sees a flattened trailing block of axes and
     reduces with ``axis=tuple(range(-len(core), 0))``.
+
+    For dask-backed inputs, ``allow_rechunk=True`` is set so a core
+    dimension that is split across multiple chunks is rechunked into a
+    single chunk before the kernel runs. Without this, ``apply_ufunc``
+    raises on multi-chunk core dims, which is a common case for the
+    reduce dimension (e.g. ``time`` chunked monthly).
+
+    Output dtype is promoted to at least ``float64`` so that integer
+    inputs don't truncate floating-point reductions.
     """
     da_pred = ds_pred[variable]
     da_ref = ds_ref[variable]
     core = _normalize_dims(dims)
+    out_dtype = np.result_type(da_pred.dtype, np.float64)
     out: xr.DataArray = xr.apply_ufunc(
         lambda p, r: fn(p, r, axis=tuple(range(-len(core), 0))),
         da_pred,
         da_ref,
         input_core_dims=[core, core],
         dask="parallelized",
-        output_dtypes=[da_pred.dtype],
+        output_dtypes=[out_dtype],
+        dask_gufunc_kwargs={"allow_rechunk": True},
     )
     return out
 

--- a/src/xr_toolz/metrics/array.py
+++ b/src/xr_toolz/metrics/array.py
@@ -1,0 +1,35 @@
+"""Tier A — array-tier entry points for :mod:`xr_toolz.metrics`.
+
+Per design decision D11, every arithmetic submodule grows a duck-array
+``axis=`` entry point under ``<module>/array.py``. This module re-exports
+the pilot pixel metrics (``mse``, ``rmse``, ``mae``, ``bias``, ``nrmse``,
+``correlation``, ``r2_score``) that take :class:`numpy.ndarray` (or any
+duck array convertible via :func:`numpy.asarray`) and an ``axis``
+argument, returning a numpy array.
+
+These are the kernels Tier B (xarray, ``dim=``) and Tier C (``Operator``)
+delegate to.
+"""
+
+from __future__ import annotations
+
+from xr_toolz.metrics._src.array_pixel import (
+    bias,
+    correlation,
+    mae,
+    mse,
+    nrmse,
+    r2_score,
+    rmse,
+)
+
+
+__all__ = [
+    "bias",
+    "correlation",
+    "mae",
+    "mse",
+    "nrmse",
+    "r2_score",
+    "rmse",
+]

--- a/src/xr_toolz/transforms/_src/array_fourier.py
+++ b/src/xr_toolz/transforms/_src/array_fourier.py
@@ -62,11 +62,15 @@ def power_spectrum(
     d: float | tuple[float, ...] = 1.0,
     norm: FFTNorm = "ortho",
 ) -> tuple[NDArray[np.floating], tuple[NDArray[np.floating], ...]]:
-    """Power spectral density of ``x`` along ``axis``.
+    """Power spectrum of ``x`` along ``axis``.
 
-    Computes the squared magnitude of the discrete Fourier transform.
-    No windowing or detrending — the Tier B wrapper handles those via
-    ``xrft``. This is the minimal raw-array entry point.
+    Computes the squared magnitude of the discrete Fourier transform,
+    ``|FFT(x)|**2``. No windowing or detrending is applied — the Tier B
+    wrapper handles those via ``xrft``. This minimal raw-array entry
+    point also does not apply any additional density scaling by sample
+    spacing beyond constructing the returned frequency coordinates;
+    pass ``norm="ortho"`` (default) to keep units consistent across
+    sample counts.
 
     Args:
         x: Input array.

--- a/src/xr_toolz/transforms/_src/array_fourier.py
+++ b/src/xr_toolz/transforms/_src/array_fourier.py
@@ -1,0 +1,111 @@
+"""Tier A — array kernels for Fourier-domain transforms.
+
+Pure-array entry points for the canonical FFT and power-spectrum
+operations. Tier B (xarray, ``dim=``) wrappers in
+:mod:`xr_toolz.transforms._src.fourier` add coord/attr handling and the
+``xrft`` integration; this module is the numpy-only computational core
+that callers can drop down to when they have raw arrays.
+
+Backend: numpy. JAX / CuPy variants are out of scope for the pilot.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import numpy as np
+from numpy.typing import ArrayLike, NDArray
+
+
+Axis = int | tuple[int, ...]
+FFTNorm = Literal["backward", "ortho", "forward"] | None
+
+
+def fft(
+    x: ArrayLike,
+    *,
+    axis: Axis = -1,
+    norm: FFTNorm = None,
+) -> NDArray[np.complexfloating]:
+    """N-dimensional discrete Fourier transform along ``axis``.
+
+    Args:
+        x: Input array.
+        axis: Axis or axes to transform.
+        norm: Normalization mode forwarded to :func:`numpy.fft.fftn`
+            (``None``, ``"ortho"``, ``"forward"``, ``"backward"``).
+
+    Returns:
+        Complex-valued FFT with the same shape as ``x``.
+    """
+    arr = np.asarray(x)
+    axes = [axis] if isinstance(axis, int) else list(axis)
+    return np.fft.fftn(arr, axes=axes, norm=norm)
+
+
+def ifft(
+    x: ArrayLike,
+    *,
+    axis: Axis = -1,
+    norm: FFTNorm = None,
+) -> NDArray[np.complexfloating]:
+    """Inverse N-dimensional FFT along ``axis``."""
+    arr = np.asarray(x)
+    axes = [axis] if isinstance(axis, int) else list(axis)
+    return np.fft.ifftn(arr, axes=axes, norm=norm)
+
+
+def power_spectrum(
+    x: ArrayLike,
+    *,
+    axis: Axis = -1,
+    d: float | tuple[float, ...] = 1.0,
+    norm: FFTNorm = "ortho",
+) -> tuple[NDArray[np.floating], tuple[NDArray[np.floating], ...]]:
+    """Power spectral density of ``x`` along ``axis``.
+
+    Computes the squared magnitude of the discrete Fourier transform.
+    No windowing or detrending — the Tier B wrapper handles those via
+    ``xrft``. This is the minimal raw-array entry point.
+
+    Args:
+        x: Input array.
+        axis: Axis or axes to transform.
+        d: Sample spacing along each transformed axis (scalar or
+            per-axis tuple). Used to build the returned frequency
+            coordinates.
+        norm: FFT normalization mode (see :func:`fft`). ``"ortho"`` by
+            default so the spectrum has consistent units across sample
+            counts.
+
+    Returns:
+        Tuple ``(power, freqs)`` where ``power`` is the real-valued
+        ``|FFT(x)|**2`` array and ``freqs`` is a tuple of 1-D frequency
+        coordinate arrays — one per transformed axis, in the order of
+        ``axis``.
+    """
+    arr = np.asarray(x)
+    axes = [axis] if isinstance(axis, int) else list(axis)
+    if isinstance(d, (int, float)):
+        ds = (float(d),) * len(axes)
+    else:
+        ds = tuple(float(s) for s in d)
+        if len(ds) != len(axes):
+            raise ValueError(
+                f"d tuple length ({len(ds)}) does not match number of axes "
+                f"({len(axes)})."
+            )
+    spectrum = np.fft.fftn(arr, axes=axes, norm=norm)
+    power = (spectrum.conj() * spectrum).real
+    freqs = tuple(
+        np.fft.fftfreq(arr.shape[ax], d=spacing)
+        for ax, spacing in zip(axes, ds, strict=True)
+    )
+    return power, freqs
+
+
+__all__ = [
+    "fft",
+    "ifft",
+    "power_spectrum",
+]

--- a/src/xr_toolz/transforms/array.py
+++ b/src/xr_toolz/transforms/array.py
@@ -1,0 +1,26 @@
+"""Tier A — array-tier entry points for :mod:`xr_toolz.transforms`.
+
+Per design decision D11, every arithmetic submodule grows a duck-array
+``axis=`` entry point under ``<module>/array.py``. This module re-exports
+the pilot Fourier kernels (``fft``, ``ifft``, ``power_spectrum``) that
+operate on raw numpy arrays without going through ``xrft``.
+
+The Tier B wrappers in :mod:`xr_toolz.transforms._src.fourier` keep the
+``xrft`` integration (windowing, detrending, frequency coordinates) for
+xarray inputs; this module is the numpy-only computational core.
+"""
+
+from __future__ import annotations
+
+from xr_toolz.transforms._src.array_fourier import (
+    fft,
+    ifft,
+    power_spectrum,
+)
+
+
+__all__ = [
+    "fft",
+    "ifft",
+    "power_spectrum",
+]

--- a/tests/test_metrics_pixel_semantics.py
+++ b/tests/test_metrics_pixel_semantics.py
@@ -1,0 +1,75 @@
+"""NaN and dask-chunking semantics for the Tier B pixel metrics.
+
+Regression tests for PR #101 review: Tier A kernels must skip NaNs to
+match the previous xarray ``skipna=True`` default, and the Tier B
+``apply_ufunc`` plumbing must work on dask-backed inputs whose core
+(reduce) dim is split across multiple chunks.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from xr_toolz.metrics._src import pixel
+
+
+@pytest.fixture
+def ds_with_nans() -> tuple[xr.Dataset, xr.Dataset]:
+    rng = np.random.default_rng(0)
+    pred = rng.standard_normal((4, 12))
+    ref = rng.standard_normal((4, 12))
+    pred[0, 3] = np.nan  # one sample missing in pred
+    ref[2, 7] = np.nan  # one sample missing in ref
+    coords = {"sample": np.arange(4), "time": np.arange(12)}
+    ds_p = xr.Dataset({"x": (("sample", "time"), pred)}, coords=coords)
+    ds_r = xr.Dataset({"x": (("sample", "time"), ref)}, coords=coords)
+    return ds_p, ds_r
+
+
+@pytest.mark.parametrize(
+    "fn",
+    [pixel.mse, pixel.rmse, pixel.mae, pixel.bias, pixel.nrmse, pixel.r2_score],
+    ids=lambda fn: fn.__name__,
+)
+def test_metrics_skip_nans(ds_with_nans: tuple[xr.Dataset, xr.Dataset], fn) -> None:
+    """A NaN sample shouldn't poison the entire reduction."""
+    ds_p, ds_r = ds_with_nans
+    out = fn(ds_p, ds_r, "x", "time")
+    assert np.isfinite(out.values).all(), (
+        f"{fn.__name__} returned NaN despite skipna semantics: {out.values}"
+    )
+
+
+def test_metrics_promote_int_input_to_float() -> None:
+    """Integer inputs should not truncate the output dtype."""
+    coords = {"time": np.arange(8)}
+    ds_p = xr.Dataset({"x": (("time",), np.arange(8, dtype=np.int64))}, coords=coords)
+    ds_r = xr.Dataset(
+        {"x": (("time",), np.arange(8, dtype=np.int64) + 1)}, coords=coords
+    )
+    out = pixel.mse(ds_p, ds_r, "x", "time")
+    assert np.issubdtype(out.dtype, np.floating)
+    np.testing.assert_allclose(out.values, 1.0)
+
+
+def test_metrics_handle_chunked_core_dim() -> None:
+    """Dask-backed input with multi-chunk reduce dim must not error."""
+    pytest.importorskip("dask")
+    coords = {"sample": np.arange(3), "time": np.arange(12)}
+    rng = np.random.default_rng(1)
+    pred = rng.standard_normal((3, 12))
+    ref = rng.standard_normal((3, 12))
+    ds_p = xr.Dataset({"x": (("sample", "time"), pred)}, coords=coords).chunk(
+        {"time": 4}
+    )
+    ds_r = xr.Dataset({"x": (("sample", "time"), ref)}, coords=coords).chunk(
+        {"time": 4}
+    )
+    # Should not raise; values should match the eager computation.
+    chunked = pixel.mse(ds_p, ds_r, "x", "time").compute()
+    eager_p = xr.Dataset({"x": (("sample", "time"), pred)}, coords=coords)
+    eager_r = xr.Dataset({"x": (("sample", "time"), ref)}, coords=coords)
+    eager = pixel.mse(eager_p, eager_r, "x", "time")
+    np.testing.assert_allclose(chunked.values, eager.values)

--- a/tests/test_tier_contract.py
+++ b/tests/test_tier_contract.py
@@ -1,0 +1,179 @@
+"""Three-tier type contract tests (D11).
+
+For each pilot module (metrics / transforms / calc), assert:
+
+(a) **Tier A is reachable** — the ``<module>.array`` namespace re-exports
+    the duck-array kernels.
+(b) **Tier B numerically agrees with Tier A on numpy arrays** — wrapping
+    a numpy array in :class:`xr.Dataset` and calling the Tier B function
+    matches the Tier A kernel called on the raw array.
+(c) **Tier C numerically agrees with Tier B** — the Operator wrapper
+    produces the same value as the underlying Tier B function.
+
+Numerical equivalence is the simplest contract — it catches both
+"reimplemented Tier B math" and "broken delegation" without needing to
+spy on call sites.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import xarray as xr
+
+
+# ---------------------------------------------------------------------------
+# metrics
+# ---------------------------------------------------------------------------
+
+
+_PIXEL_NAMES: tuple[str, ...] = (
+    "mse",
+    "rmse",
+    "mae",
+    "bias",
+    "nrmse",
+    "correlation",
+    "r2_score",
+)
+
+
+@pytest.mark.parametrize("name", _PIXEL_NAMES)
+def test_metrics_array_namespace_exports(name: str) -> None:
+    """Tier A is reachable via ``xr_toolz.metrics.array``."""
+    from xr_toolz.metrics import array as ma
+
+    assert hasattr(ma, name), f"xr_toolz.metrics.array.{name} missing"
+    assert callable(getattr(ma, name))
+
+
+@pytest.mark.parametrize("name", _PIXEL_NAMES)
+def test_metrics_tier_b_matches_tier_a(name: str) -> None:
+    """Tier B (Dataset, ``dim=``) numerically matches Tier A (axis=)."""
+    from xr_toolz.metrics import array as ma
+    from xr_toolz.metrics._src import pixel as tier_b
+
+    rng = np.random.default_rng(42)
+    pred = rng.standard_normal((5, 8))
+    ref = rng.standard_normal((5, 8))
+
+    a_out = getattr(ma, name)(pred, ref, axis=-1)
+    ds_pred = xr.Dataset({"x": (("a", "b"), pred)})
+    ds_ref = xr.Dataset({"x": (("a", "b"), ref)})
+    b_out = getattr(tier_b, name)(ds_pred, ds_ref, "x", "b").values
+
+    np.testing.assert_allclose(a_out, b_out, rtol=1e-12, atol=1e-12)
+
+
+@pytest.mark.parametrize(
+    "op_name,fn_name",
+    [
+        ("MSE", "mse"),
+        ("RMSE", "rmse"),
+        ("MAE", "mae"),
+        ("Bias", "bias"),
+        ("NRMSE", "nrmse"),
+        ("Correlation", "correlation"),
+        ("R2Score", "r2_score"),
+    ],
+)
+def test_metrics_tier_c_matches_tier_b(op_name: str, fn_name: str) -> None:
+    """Tier C Operator output equals Tier B function output."""
+    from xr_toolz.metrics import operators as ops
+    from xr_toolz.metrics._src import pixel as tier_b
+
+    rng = np.random.default_rng(7)
+    pred = rng.standard_normal((3, 6))
+    ref = rng.standard_normal((3, 6))
+    ds_pred = xr.Dataset({"x": (("a", "b"), pred)})
+    ds_ref = xr.Dataset({"x": (("a", "b"), ref)})
+
+    op = getattr(ops, op_name)(variable="x", dims="b")
+    c_out = op(ds_pred, ds_ref).values
+    b_out = getattr(tier_b, fn_name)(ds_pred, ds_ref, "x", "b").values
+
+    np.testing.assert_allclose(c_out, b_out, rtol=1e-12, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# transforms
+# ---------------------------------------------------------------------------
+
+
+def test_transforms_array_namespace_exports() -> None:
+    """Tier A is reachable via ``xr_toolz.transforms.array``."""
+    from xr_toolz.transforms import array as ta
+
+    for name in ("fft", "ifft", "power_spectrum"):
+        assert hasattr(ta, name)
+        assert callable(getattr(ta, name))
+
+
+def test_transforms_array_fft_roundtrip() -> None:
+    """``ifft(fft(x)) == x`` exercises the Tier A kernel on its own."""
+    from xr_toolz.transforms import array as ta
+
+    rng = np.random.default_rng(0)
+    x = rng.standard_normal((4, 16))
+    np.testing.assert_allclose(ta.ifft(ta.fft(x, axis=-1), axis=-1).real, x, atol=1e-10)
+
+
+def test_transforms_array_power_spectrum_matches_manual_fft() -> None:
+    """Tier A ``power_spectrum`` matches a hand-rolled ``|fft|**2``."""
+    from xr_toolz.transforms import array as ta
+
+    rng = np.random.default_rng(1)
+    x = rng.standard_normal((8,))
+    power, (freqs,) = ta.power_spectrum(x, axis=-1, d=0.5, norm="ortho")
+    expected = np.abs(np.fft.fftn(x, axes=(-1,), norm="ortho")) ** 2
+    np.testing.assert_allclose(power, expected, rtol=1e-12, atol=1e-12)
+    np.testing.assert_allclose(freqs, np.fft.fftfreq(8, d=0.5))
+
+
+# ---------------------------------------------------------------------------
+# calc
+# ---------------------------------------------------------------------------
+
+
+def test_calc_array_namespace_exports() -> None:
+    """Tier A is reachable via ``xr_toolz.calc.array``."""
+    from xr_toolz.calc import array as ca
+
+    for name in ("partial", "gradient"):
+        assert hasattr(ca, name)
+        assert callable(getattr(ca, name))
+
+
+def test_calc_array_partial_matches_tier_b_cartesian() -> None:
+    """Tier A ``partial`` (numpy central diff) matches the Tier B cartesian
+    partial for the default 2nd-order central scheme.
+
+    The Tier B path runs through ``finitediffx``; the equivalence here
+    checks the two numerical engines agree on a smooth field at default
+    accuracy, which is the contract D11 cares about for the array tier.
+    """
+    from xr_toolz.calc import array as ca, partial as tier_b_partial
+
+    x_coord = np.linspace(0.0, 2.0 * np.pi, 64)
+    y_coord = np.linspace(0.0, 2.0 * np.pi, 32)
+    field = np.sin(x_coord)[:, None] + np.cos(y_coord)[None, :]
+    da = xr.DataArray(field, dims=("x", "y"), coords={"x": x_coord, "y": y_coord})
+
+    dx = float(x_coord[1] - x_coord[0])
+    a_dfdx = ca.partial(field, axis=0, spacing=dx)
+    b_dfdx = tier_b_partial(da, "x", geometry="cartesian").values
+
+    # Compare on the interior to avoid any boundary-stencil divergence.
+    np.testing.assert_allclose(a_dfdx[1:-1], b_dfdx[1:-1], rtol=1e-6, atol=1e-6)
+
+
+def test_calc_array_gradient_returns_per_axis() -> None:
+    """Tier A ``gradient`` returns one component per requested axis."""
+    from xr_toolz.calc import array as ca
+
+    rng = np.random.default_rng(0)
+    x = rng.standard_normal((4, 5, 6))
+    components = ca.gradient(x, axes=(0, 2), spacing=(0.5, 2.0))
+    assert len(components) == 2
+    for comp in components:
+        assert comp.shape == x.shape


### PR DESCRIPTION
Closes #26.

Pilots the three-tier type contract from [D11](docs/design/decisions.md) on the three highest-value arithmetic submodules: `metrics`, `transforms`, `calc`. Each grows a Tier A `<module>.array` namespace with duck-array, `axis=` entry points; the existing Tier B (xarray, `dim=`) and Tier C (`Operator`) layers stay backwards-compatible.

## Summary

- `xr_toolz.metrics.array` — numpy kernels for `mse`, `rmse`, `mae`, `bias`, `nrmse`, `correlation`, `r2_score`. Tier B `_src/pixel.py` now delegates via `xr.apply_ufunc` rather than reimplementing the math.
- `xr_toolz.transforms.array` — numpy `fft`, `ifft`, `power_spectrum`. Tier B's `xrft`-backed wrappers are unchanged; Tier A is the raw-array computational core for callers who want the bare kernel.
- `xr_toolz.calc.array` — numpy 2nd-order central-difference `partial`, `gradient`. Complements (does not replace) the `finitediffx`-backed Tier B that handles higher-order / non-uniform / spherical paths.
- `tests/test_tier_contract.py` — three-tier contract harness (Tier A reachable, Tier B numerically agrees with Tier A, Tier C numerically agrees with Tier B) for all three pilot modules.
- `docs/design/api/components.md` — per-module Tier A/B/C summary; explicit "skip Tier A" notes for the coord/attr-only modules `validation`, `crs`, `subset`, `masks`.

## Module-pick rationale

The three pilots are the modules where the math is unambiguously array-side: pixel metrics are pure reductions, FFTs are pure numerics, and finite differences are pure stencils. Higher-arity surfaces (`metrics.spectral`, `metrics.multiscale`, `transforms.dct`, `transforms.wavelet`, `kinematics`, `viz`) are deferred to follow-up issues so this PR stays surgical and reviewable.

`validation`, `crs`, `subset`, `masks` document the Tier-A skip explicitly per D11.

## Out of scope (deferred)

- JAX / numba / CuPy backends — Tier A is numpy-only here. Per-function backend coverage is opportunistic per D11.
- The full Tier A surface for `metrics` (spectral, multiscale, distributional, masked), `transforms` (DCT, wavelet, decompose, encoders), and `kinematics` / `viz`.
- Any new math.

Sub-issues #27 / #28 / #29 / #30 / #31 (per the F2 brief) remain open as the natural follow-up scopes for the deferred surfaces.

## Test plan

- [x] `uv run pytest --no-cov -q` — 640 passed, 1 skipped
- [x] `uv run pytest tests/test_tier_contract.py -v --no-cov` — 27 passed (Tier A reachability + numerical equivalence checks across metrics/transforms/calc)
- [x] `uv run --group lint ruff check .` — clean
- [x] `uv run --group lint ruff format --check .` — clean
- [x] `uv run --group typecheck ty check src/xr_toolz` — 40 diagnostics (matches baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)