### PR TITLE
feat(metrics): add v1.1 SkillByLeadTime + v1.2 EvaluateByRegion

### DIFF
--- a/src/xr_toolz/metrics/__init__.py
+++ b/src/xr_toolz/metrics/__init__.py
@@ -15,6 +15,12 @@ Layer-1 ``Operator`` wrappers are re-exported flat from this package
 and from :mod:`xr_toolz.metrics.operators`.
 """
 
+from xr_toolz.metrics._src.forecast import SkillByLeadTime, skill_by_lead_time
+from xr_toolz.metrics._src.multiscale import (
+    EvaluateByRegion,
+    evaluate_by_region,
+    normalize_regions,
+)
 from xr_toolz.metrics._src.pixel import (
     MAE,
     MSE,
@@ -47,17 +53,22 @@ __all__ = [
     "RMSE",
     "Bias",
     "Correlation",
+    "EvaluateByRegion",
     "PSDScore",
     "R2Score",
+    "SkillByLeadTime",
     "bias",
     "correlation",
+    "evaluate_by_region",
     "find_intercept_1D",
     "mae",
     "mse",
+    "normalize_regions",
     "nrmse",
     "psd_error",
     "psd_score",
     "r2_score",
     "resolved_scale",
     "rmse",
+    "skill_by_lead_time",
 ]

--- a/src/xr_toolz/metrics/_src/forecast.py
+++ b/src/xr_toolz/metrics/_src/forecast.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from typing import Any
 
+import numpy as np
 import xarray as xr
 
 from xr_toolz.core import Operator
@@ -50,8 +51,24 @@ def skill_by_lead_time(
         )
 
     leads = ds_pred[lead_dim].values
-    pieces: list[xr.DataArray | xr.Dataset] = []
     ref_has_lead = lead_dim in ds_ref.dims
+    if ref_has_lead:
+        if ds_ref.sizes[lead_dim] != ds_pred.sizes[lead_dim]:
+            raise ValueError(
+                f"Reference {lead_dim!r} size {ds_ref.sizes[lead_dim]} does "
+                f"not match prediction size {ds_pred.sizes[lead_dim]}."
+            )
+        if (
+            lead_dim in ds_ref.coords
+            and lead_dim in ds_pred.coords
+            and not np.array_equal(ds_ref[lead_dim].values, leads)
+        ):
+            raise ValueError(
+                f"Reference {lead_dim!r} coordinate values differ from "
+                f"prediction; align them with `xr.align(...)` upstream."
+            )
+
+    pieces: list[xr.DataArray | xr.Dataset] = []
     for i in range(len(leads)):
         pred_i = ds_pred.isel({lead_dim: i})
         ref_i = ds_ref.isel({lead_dim: i}) if ref_has_lead else ds_ref

--- a/src/xr_toolz/metrics/_src/forecast.py
+++ b/src/xr_toolz/metrics/_src/forecast.py
@@ -1,6 +1,108 @@
-"""Stub: lands with view V1 (Epic).
+"""Forecast-skill metrics — skill broken down by forecast lead time.
 
-This module is intentionally empty. It will be populated by the V1
-view epic and is shipped now so downstream PRs can import its path
-without depending on a package layout change.
+This module implements the lead-time slice of validation.md §1
+("Scales of Evaluation"). The :class:`SkillByLeadTime` operator
+applies any inner metric (an :class:`xr_toolz.core.Operator`) per
+lead-time slice, returning skill as a function of forecast horizon.
+
+The inner-metric type is :class:`~xr_toolz.core.Operator` rather than
+a bare callable so :meth:`get_config` can introspect the full skill
+configuration (per V1.1 acceptance criteria).
 """
+
+from __future__ import annotations
+
+from typing import Any
+
+import xarray as xr
+
+from xr_toolz.core import Operator
+
+
+# ---------- Layer-0 (xarray) ----------------------------------------------
+
+
+def skill_by_lead_time(
+    ds_pred: xr.Dataset,
+    ds_ref: xr.Dataset,
+    *,
+    metric: Operator,
+    lead_dim: str = "lead_time",
+) -> xr.DataArray | xr.Dataset:
+    """Apply ``metric`` per lead-time slice and stack along ``lead_dim``.
+
+    Args:
+        ds_pred: Prediction dataset with a ``lead_dim`` axis.
+        ds_ref: Reference dataset. May share or omit the ``lead_dim``
+            axis; if omitted the same reference is used for every lead.
+        metric: Inner :class:`Operator` taking ``(pred_ds, ref_ds)``
+            and returning an :class:`xr.DataArray` or :class:`xr.Dataset`.
+        lead_dim: Name of the lead-time dimension (default ``"lead_time"``).
+
+    Returns:
+        The metric stacked along ``lead_dim``; a :class:`xr.DataArray`
+        if the inner metric returns one, otherwise a :class:`xr.Dataset`.
+    """
+    if lead_dim not in ds_pred.dims:
+        raise ValueError(
+            f"Prediction is missing lead dim {lead_dim!r}; "
+            f"got dims={tuple(ds_pred.dims)}."
+        )
+
+    leads = ds_pred[lead_dim].values
+    pieces: list[xr.DataArray | xr.Dataset] = []
+    ref_has_lead = lead_dim in ds_ref.dims
+    for i in range(len(leads)):
+        pred_i = ds_pred.isel({lead_dim: i})
+        ref_i = ds_ref.isel({lead_dim: i}) if ref_has_lead else ds_ref
+        pieces.append(metric(pred_i, ref_i))
+
+    return xr.concat(pieces, dim=ds_pred[lead_dim])
+
+
+# ---------- Layer-1 (Operator) --------------------------------------------
+
+
+class SkillByLeadTime(Operator):
+    """Apply an inner metric per lead-time slice.
+
+    Args:
+        metric: Inner :class:`Operator` (e.g. ``RMSE("ssh", dims="time")``)
+            evaluated on each ``lead_dim`` slice independently.
+        lead_dim: Name of the lead-time dimension on the prediction
+            dataset. Defaults to ``"lead_time"``.
+
+    Example:
+        >>> from xr_toolz.metrics import RMSE, SkillByLeadTime
+        >>> op = SkillByLeadTime(RMSE("ssh", dims=("lat", "lon")))
+        >>> skill = op(pred_ds, ref_ds)  # DataArray indexed by lead_time
+    """
+
+    def __init__(self, metric: Operator, *, lead_dim: str = "lead_time") -> None:
+        if not isinstance(metric, Operator):
+            raise TypeError(
+                f"SkillByLeadTime requires an Operator, got "
+                f"{type(metric).__name__!r}; pass an instantiated metric like "
+                "RMSE(...) so its config is introspectable."
+            )
+        self.metric = metric
+        self.lead_dim = lead_dim
+
+    def _apply(
+        self, ds_pred: xr.Dataset, ds_ref: xr.Dataset
+    ) -> xr.DataArray | xr.Dataset:
+        return skill_by_lead_time(
+            ds_pred, ds_ref, metric=self.metric, lead_dim=self.lead_dim
+        )
+
+    def get_config(self) -> dict[str, Any]:
+        return {
+            "metric": {
+                "class": type(self.metric).__name__,
+                "config": self.metric.get_config(),
+            },
+            "lead_dim": self.lead_dim,
+        }
+
+
+__all__ = ["SkillByLeadTime", "skill_by_lead_time"]

--- a/src/xr_toolz/metrics/_src/multiscale.py
+++ b/src/xr_toolz/metrics/_src/multiscale.py
@@ -144,7 +144,7 @@ def evaluate_by_region(
     # metric on the first non-empty region and then multiplying by NaN —
     # the operator's contract for empty regions becomes deterministic
     # rather than dependent on the inner metric's NaN behaviour.
-    pieces: list[xr.Dataset] = [None] * len(region_ids)  # type: ignore[list-item]
+    slots: list[xr.Dataset | None] = [None] * len(region_ids)
     nan_template: xr.Dataset | None = None
     for idx, rid in enumerate(region_ids):
         sel = mask == rid
@@ -155,7 +155,7 @@ def evaluate_by_region(
         result = metric(pred_r, ref_r)
         if isinstance(result, xr.DataArray):
             result = result.to_dataset(name=result.name or "score")
-        pieces[idx] = result
+        slots[idx] = result
         if nan_template is None:
             nan_template = result * np.nan
 
@@ -165,7 +165,7 @@ def evaluate_by_region(
             "build a NaN-template result. Check that the mask intersects the "
             "data grid."
         )
-    pieces = [p if p is not None else nan_template for p in pieces]
+    pieces: list[xr.Dataset] = [p if p is not None else nan_template for p in slots]
 
     out = xr.concat(pieces, dim="region")
     out = out.assign_coords(region=("region", [names[i] for i in region_ids]))

--- a/src/xr_toolz/metrics/_src/multiscale.py
+++ b/src/xr_toolz/metrics/_src/multiscale.py
@@ -1,6 +1,200 @@
-"""Stub: lands with view V1 (Epic).
+"""Multiscale evaluation — skill broken down by region.
 
-This module is intentionally empty. It will be populated by the V1
-view epic and is shipped now so downstream PRs can import its path
-without depending on a package layout change.
+Implements the regional slice of validation.md §1. The
+:class:`EvaluateByRegion` operator applies any inner metric per
+region and returns the per-region scores stacked along a ``region``
+axis.
+
+Region inputs are normalized internally so callers can pass any of:
+
+* a ``regionmask.Regions`` object (lazy-imported only when used),
+* an integer-encoded mask :class:`xr.DataArray` (one label per
+  region, NaN/-1 outside),
+* a ``dict[str, xr.DataArray[bool]]`` of named boolean masks.
+
+The normalization helper :func:`normalize_regions` is exposed so a
+caller can pre-build the mask once and reuse across many metrics.
 """
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import numpy as np
+import xarray as xr
+
+from xr_toolz.core import Operator
+
+
+def _import_regionmask() -> Any:
+    try:
+        import regionmask
+    except ImportError as exc:
+        raise ImportError(
+            "EvaluateByRegion received a regionmask.Regions input but "
+            "`regionmask` is not installed. Install with "
+            "`pip install regionmask` or pass an integer mask / dict "
+            "of boolean masks instead."
+        ) from exc
+    return regionmask
+
+
+def normalize_regions(
+    regions: Any,
+    template: xr.Dataset | xr.DataArray,
+) -> tuple[xr.DataArray, dict[int, str]]:
+    """Normalize an arbitrary region spec to ``(int_mask, names)``.
+
+    Args:
+        regions: One of: ``regionmask.Regions``, integer-mask
+            :class:`xr.DataArray`, or ``dict[str, DataArray[bool]]``.
+        template: Dataset / DataArray supplying the lat/lon grid that
+            the mask must align with (used only when ``regions`` is a
+            ``regionmask.Regions``).
+
+    Returns:
+        ``(mask, names)`` where ``mask`` is an integer DataArray
+        (``-1`` outside any region) and ``names`` maps integer labels
+        to human-readable region names.
+    """
+    if isinstance(regions, xr.DataArray):
+        mask = regions
+        labels = np.unique(mask.values)
+        labels = (
+            labels[~np.isnan(labels)]
+            if np.issubdtype(labels.dtype, np.floating)
+            else labels
+        )
+        labels = [int(lbl) for lbl in labels if int(lbl) >= 0]
+        names = {lbl: f"region_{lbl}" for lbl in labels}
+        return mask.astype("int64"), names
+
+    if isinstance(regions, Mapping):
+        if not regions:
+            raise ValueError("dict-of-masks regions must be non-empty.")
+        names = {}
+        out: xr.DataArray | None = None
+        for i, (name, m) in enumerate(regions.items()):
+            if not isinstance(m, xr.DataArray):
+                raise TypeError(
+                    f"region {name!r}: expected boolean xr.DataArray, "
+                    f"got {type(m).__name__}"
+                )
+            names[i] = name
+            contrib = xr.where(m, np.int64(i), np.int64(-1))
+            out = contrib if out is None else xr.where(m, np.int64(i), out)
+        assert out is not None
+        return out.astype("int64"), names
+
+    regionmask = _import_regionmask()
+    if isinstance(regions, regionmask.Regions):
+        lat = template["lat"] if "lat" in template.coords else template["latitude"]
+        lon = template["lon"] if "lon" in template.coords else template["longitude"]
+        mask = regions.mask(lon, lat)
+        names = {int(i): str(n) for i, n in enumerate(regions.names)}
+        mask = xr.where(mask.notnull(), mask, np.int64(-1)).astype("int64")
+        return mask, names
+
+    raise TypeError(
+        f"Unsupported regions type {type(regions).__name__!r}; expected "
+        "regionmask.Regions, int-mask DataArray, or dict[str, DataArray]."
+    )
+
+
+# ---------- Layer-0 (xarray) ----------------------------------------------
+
+
+def evaluate_by_region(
+    ds_pred: xr.Dataset,
+    ds_ref: xr.Dataset,
+    *,
+    metric: Operator,
+    regions: Any,
+) -> xr.Dataset:
+    """Apply ``metric`` per region and return per-region scores.
+
+    Args:
+        ds_pred: Prediction dataset.
+        ds_ref: Reference dataset, aligned on the same grid as
+            ``ds_pred``.
+        metric: Inner :class:`Operator` taking ``(pred_ds, ref_ds)``.
+        regions: Region spec (see :func:`normalize_regions`).
+
+    Returns:
+        Dataset indexed by ``region`` with one variable per metric
+        output (a single ``"score"`` variable when the inner metric
+        returns a :class:`xr.DataArray`).
+    """
+    mask, names = normalize_regions(regions, ds_pred)
+    region_ids = sorted(names)
+    pieces: list[xr.DataArray | xr.Dataset] = []
+    for rid in region_ids:
+        sel = mask == rid
+        pred_r = ds_pred.where(sel)
+        ref_r = ds_ref.where(sel)
+        result = metric(pred_r, ref_r)
+        if isinstance(result, xr.DataArray):
+            result = result.to_dataset(name=result.name or "score")
+        pieces.append(result)
+
+    out = xr.concat(pieces, dim="region")
+    out = out.assign_coords(region=("region", [names[i] for i in region_ids]))
+    return out
+
+
+# ---------- Layer-1 (Operator) --------------------------------------------
+
+
+class EvaluateByRegion(Operator):
+    """Apply an inner metric per region.
+
+    Args:
+        metric: Inner :class:`Operator` evaluated per region.
+        regions: One of:
+            * a ``regionmask.Regions`` instance (requires the optional
+              ``regionmask`` dep),
+            * an integer-encoded mask :class:`xr.DataArray`,
+            * a ``dict[str, xr.DataArray[bool]]``.
+
+    Pre-normalize once and reuse via :func:`normalize_regions` if you
+    intend to evaluate multiple metrics over the same regions:
+
+        >>> mask, names = normalize_regions(natural_earth, ds)
+        >>> EvaluateByRegion(RMSE(...), regions=mask)
+    """
+
+    def __init__(self, metric: Operator, *, regions: Any) -> None:
+        if not isinstance(metric, Operator):
+            raise TypeError(
+                f"EvaluateByRegion requires an Operator, got {type(metric).__name__!r}."
+            )
+        self.metric = metric
+        self.regions = regions
+
+    def _apply(self, ds_pred: xr.Dataset, ds_ref: xr.Dataset) -> xr.Dataset:
+        return evaluate_by_region(
+            ds_pred, ds_ref, metric=self.metric, regions=self.regions
+        )
+
+    def get_config(self) -> dict[str, Any]:
+        if isinstance(self.regions, xr.DataArray):
+            regions_repr = "<DataArray>"
+        elif isinstance(self.regions, Mapping):
+            regions_repr = list(self.regions.keys())
+        else:
+            regions_repr = type(self.regions).__name__
+        return {
+            "metric": {
+                "class": type(self.metric).__name__,
+                "config": self.metric.get_config(),
+            },
+            "regions": regions_repr,
+        }
+
+
+__all__ = [
+    "EvaluateByRegion",
+    "evaluate_by_region",
+    "normalize_regions",
+]

--- a/src/xr_toolz/metrics/_src/multiscale.py
+++ b/src/xr_toolz/metrics/_src/multiscale.py
@@ -59,15 +59,22 @@ def normalize_regions(
         to human-readable region names.
     """
     if isinstance(regions, xr.DataArray):
+        # Float masks are allowed to use NaN for "outside any region"
+        # (matching the docstring); fill NaNs with -1 before casting
+        # so they don't silently turn into a garbage int64 value.
         mask = regions
+        if np.issubdtype(mask.dtype, np.floating):
+            non_nan = mask.values[~np.isnan(mask.values)]
+            if non_nan.size and not np.allclose(non_nan, non_nan.astype(np.int64)):
+                raise ValueError(
+                    "Integer-mask DataArray inputs must encode region labels as "
+                    "whole numbers (NaN allowed for outside); got non-integer "
+                    "values."
+                )
+            mask = xr.where(mask.notnull(), mask, np.int64(-1))
         labels = np.unique(mask.values)
-        labels = (
-            labels[~np.isnan(labels)]
-            if np.issubdtype(labels.dtype, np.floating)
-            else labels
-        )
-        labels = [int(lbl) for lbl in labels if int(lbl) >= 0]
-        names = {lbl: f"region_{lbl}" for lbl in labels}
+        labels_list = [int(lbl) for lbl in labels if int(lbl) >= 0]
+        names = {lbl: f"region_{lbl}" for lbl in labels_list}
         return mask.astype("int64"), names
 
     if isinstance(regions, Mapping):
@@ -87,14 +94,18 @@ def normalize_regions(
         assert out is not None
         return out.astype("int64"), names
 
-    regionmask = _import_regionmask()
-    if isinstance(regions, regionmask.Regions):
-        lat = template["lat"] if "lat" in template.coords else template["latitude"]
-        lon = template["lon"] if "lon" in template.coords else template["longitude"]
-        mask = regions.mask(lon, lat)
-        names = {int(i): str(n) for i, n in enumerate(regions.names)}
-        mask = xr.where(mask.notnull(), mask, np.int64(-1)).astype("int64")
-        return mask, names
+    # Detect a regionmask.Regions object by module name *without* importing
+    # regionmask — that way unsupported types raise TypeError below even
+    # when regionmask isn't installed.
+    if type(regions).__module__.startswith("regionmask"):
+        regionmask = _import_regionmask()
+        if isinstance(regions, regionmask.Regions):
+            lat = template["lat"] if "lat" in template.coords else template["latitude"]
+            lon = template["lon"] if "lon" in template.coords else template["longitude"]
+            mask = regions.mask(lon, lat)
+            names = {int(i): str(n) for i, n in enumerate(regions.names)}
+            mask = xr.where(mask.notnull(), mask, np.int64(-1)).astype("int64")
+            return mask, names
 
     raise TypeError(
         f"Unsupported regions type {type(regions).__name__!r}; expected "
@@ -128,15 +139,33 @@ def evaluate_by_region(
     """
     mask, names = normalize_regions(regions, ds_pred)
     region_ids = sorted(names)
-    pieces: list[xr.DataArray | xr.Dataset] = []
-    for rid in region_ids:
+
+    # Build a NaN template for empty regions. We do this by calling the
+    # metric on the first non-empty region and then multiplying by NaN —
+    # the operator's contract for empty regions becomes deterministic
+    # rather than dependent on the inner metric's NaN behaviour.
+    pieces: list[xr.Dataset] = [None] * len(region_ids)  # type: ignore[list-item]
+    nan_template: xr.Dataset | None = None
+    for idx, rid in enumerate(region_ids):
         sel = mask == rid
+        if not bool(sel.any()):
+            continue
         pred_r = ds_pred.where(sel)
         ref_r = ds_ref.where(sel)
         result = metric(pred_r, ref_r)
         if isinstance(result, xr.DataArray):
             result = result.to_dataset(name=result.name or "score")
-        pieces.append(result)
+        pieces[idx] = result
+        if nan_template is None:
+            nan_template = result * np.nan
+
+    if nan_template is None:
+        raise ValueError(
+            "evaluate_by_region: every region selected zero pixels — cannot "
+            "build a NaN-template result. Check that the mask intersects the "
+            "data grid."
+        )
+    pieces = [p if p is not None else nan_template for p in pieces]
 
     out = xr.concat(pieces, dim="region")
     out = out.assign_coords(region=("region", [names[i] for i in region_ids]))

--- a/src/xr_toolz/metrics/operators.py
+++ b/src/xr_toolz/metrics/operators.py
@@ -5,6 +5,8 @@ This module re-exports the operator classes from
 for ergonomic ``from xr_toolz.metrics.operators import RMSE`` access.
 """
 
+from xr_toolz.metrics._src.forecast import SkillByLeadTime
+from xr_toolz.metrics._src.multiscale import EvaluateByRegion
 from xr_toolz.metrics._src.pixel import (
     MAE,
     MSE,
@@ -24,6 +26,8 @@ __all__ = [
     "RMSE",
     "Bias",
     "Correlation",
+    "EvaluateByRegion",
     "PSDScore",
     "R2Score",
+    "SkillByLeadTime",
 ]

--- a/tests/test_metrics_imports.py
+++ b/tests/test_metrics_imports.py
@@ -129,8 +129,6 @@ def test_metrics_operators_submodule_imports():
 @pytest.mark.parametrize(
     "submodule",
     [
-        "forecast",
-        "multiscale",
         "structural",
         "probabilistic",
         "distributional",

--- a/tests/test_metrics_v1_scales.py
+++ b/tests/test_metrics_v1_scales.py
@@ -214,14 +214,11 @@ def test_normalize_regions_dict_round_trip(
     assert set(np.unique(mask.values).tolist()) == {0, 1}
 
 
-def test_evaluate_by_region_regionmask_lazy_import_error() -> None:
-    """Passing an unknown object that isn't a regionmask.Regions raises TypeError,
-    not ImportError — the regionmask import only fires for objects that
-    look like regionmask.Regions."""
+def test_evaluate_by_region_regionmask_happy_path() -> None:
+    """A regionmask.Regions input is normalized via the regionmask backend."""
     pytest.importorskip("regionmask")
     import regionmask
 
-    # Build a tiny custom Regions instance.
     regions = regionmask.Regions(
         outlines=[np.array([[-1.0, -1.0], [1.0, -1.0], [1.0, 1.0], [-1.0, 1.0]])],
         names=["square"],
@@ -242,6 +239,97 @@ def test_evaluate_by_region_regionmask_lazy_import_error() -> None:
     out = op(ds_p, ds_r)
     assert "region" in out.dims
     assert "square" in out["region"].values.tolist()
+
+
+def test_normalize_regions_unsupported_type_does_not_import_regionmask(
+    monkeypatch,
+) -> None:
+    """Unsupported `regions` types raise TypeError without importing regionmask.
+
+    Guards the lazy-import contract: only `regionmask.Regions` instances
+    cause `regionmask` to be imported. Anything else must raise TypeError
+    immediately (so missing-regionmask environments still get a useful
+    error, not an ImportError).
+    """
+    import builtins
+
+    real_import = builtins.__import__
+
+    def blocked_import(name, *args, **kwargs):
+        if name == "regionmask":
+            raise ImportError("regionmask blocked for this test")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", blocked_import)
+    ds = xr.Dataset({"x": (("t",), np.zeros(3))})
+    with pytest.raises(TypeError, match="Unsupported regions type"):
+        normalize_regions(42, ds)
+
+
+def test_normalize_regions_float_mask_with_nans() -> None:
+    """A float mask with NaN outside-region values is supported."""
+    rng = np.random.default_rng(20)
+    coords = {"lat": np.arange(6), "lon": np.arange(8)}
+    vals = np.full((6, 8), np.nan)
+    vals[:3, :] = 0.0  # region 0
+    vals[3:, :] = 1.0  # region 1
+    mask = xr.DataArray(vals, dims=("lat", "lon"), coords=coords)
+    int_mask, names = normalize_regions(mask, None)
+    assert int_mask.dtype == np.int64
+    assert names == {0: "region_0", 1: "region_1"}
+    # NaN positions become -1.
+    assert not (int_mask.values == -1).any()  # no NaNs in this fixture
+    # Regression: make sure NaN-containing input doesn't blow up.
+    vals_with_holes = vals.copy()
+    vals_with_holes[0, 0] = np.nan
+    mask2 = xr.DataArray(vals_with_holes, dims=("lat", "lon"), coords=coords)
+    int_mask2, _ = normalize_regions(mask2, None)
+    assert int(int_mask2.sel(lat=0, lon=0).values) == -1
+    # And EvaluateByRegion runs with the float-NaN mask end-to-end.
+    rng2 = rng
+    ds_p = xr.Dataset(
+        {"x": (("lat", "lon"), rng2.standard_normal((6, 8)))}, coords=coords
+    )
+    ds_r = xr.Dataset(
+        {"x": (("lat", "lon"), rng2.standard_normal((6, 8)))}, coords=coords
+    )
+    out = EvaluateByRegion(RMSE("x", ("lat", "lon")), regions=mask2)(ds_p, ds_r)
+    assert "region" in out.dims
+
+
+def test_normalize_regions_float_mask_rejects_non_integer_labels() -> None:
+    coords = {"lat": np.arange(4)}
+    mask = xr.DataArray(np.array([0.5, 0.5, 1.0, 1.0]), dims="lat", coords=coords)
+    with pytest.raises(ValueError, match="whole numbers"):
+        normalize_regions(mask, None)
+
+
+def test_skill_by_lead_time_ref_size_mismatch_raises() -> None:
+    rng = np.random.default_rng(21)
+    ds_p = xr.Dataset(
+        {"x": (("lead_time", "t"), rng.standard_normal((4, 5)))},
+        coords={"lead_time": np.arange(4), "t": np.arange(5)},
+    )
+    ds_r = xr.Dataset(
+        {"x": (("lead_time", "t"), rng.standard_normal((3, 5)))},
+        coords={"lead_time": np.arange(3), "t": np.arange(5)},
+    )
+    with pytest.raises(ValueError, match="size"):
+        SkillByLeadTime(RMSE("x", "t"))(ds_p, ds_r)
+
+
+def test_skill_by_lead_time_ref_coords_differ_raises() -> None:
+    rng = np.random.default_rng(22)
+    ds_p = xr.Dataset(
+        {"x": (("lead_time", "t"), rng.standard_normal((4, 5)))},
+        coords={"lead_time": np.arange(4), "t": np.arange(5)},
+    )
+    ds_r = xr.Dataset(
+        {"x": (("lead_time", "t"), rng.standard_normal((4, 5)))},
+        coords={"lead_time": np.arange(10, 14), "t": np.arange(5)},
+    )
+    with pytest.raises(ValueError, match="coordinate values"):
+        SkillByLeadTime(RMSE("x", "t"))(ds_p, ds_r)
 
 
 def test_evaluate_by_region_get_config_json_safe(

--- a/tests/test_metrics_v1_scales.py
+++ b/tests/test_metrics_v1_scales.py
@@ -1,0 +1,268 @@
+"""Tests for V1 (Scales of Evaluation): SkillByLeadTime, EvaluateByRegion.
+
+Covers parity vs manual loops, support for the three region input
+formats, the inner-Operator constraint, and graceful NaN handling.
+"""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from xr_toolz.metrics import (
+    MAE,
+    RMSE,
+    Bias,
+    Correlation,
+    EvaluateByRegion,
+    PSDScore,
+    SkillByLeadTime,
+    evaluate_by_region,
+    normalize_regions,
+    skill_by_lead_time,
+)
+
+
+# ---------- fixtures ------------------------------------------------------
+
+
+@pytest.fixture
+def lead_time_pair() -> tuple[xr.Dataset, xr.Dataset]:
+    rng = np.random.default_rng(0)
+    pred = rng.standard_normal((4, 6, 8))
+    ref = rng.standard_normal((4, 6, 8))
+    coords = {
+        "lead_time": np.arange(4),
+        "lat": np.linspace(-1.0, 1.0, 6),
+        "lon": np.linspace(0.0, 1.0, 8),
+    }
+    ds_p = xr.Dataset({"x": (("lead_time", "lat", "lon"), pred)}, coords=coords)
+    ds_r = xr.Dataset({"x": (("lead_time", "lat", "lon"), ref)}, coords=coords)
+    return ds_p, ds_r
+
+
+@pytest.fixture
+def regional_pair() -> tuple[xr.Dataset, xr.Dataset]:
+    rng = np.random.default_rng(1)
+    lat = np.linspace(-2.0, 2.0, 8)
+    lon = np.linspace(-2.0, 2.0, 10)
+    pred = rng.standard_normal((8, 10))
+    ref = rng.standard_normal((8, 10))
+    ds_p = xr.Dataset({"x": (("lat", "lon"), pred)}, coords={"lat": lat, "lon": lon})
+    ds_r = xr.Dataset({"x": (("lat", "lon"), ref)}, coords={"lat": lat, "lon": lon})
+    return ds_p, ds_r
+
+
+# ---------- V1.1 ----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "metric_cls", [RMSE, MAE, Bias, Correlation], ids=lambda c: c.__name__
+)
+def test_skill_by_lead_time_parity(
+    lead_time_pair: tuple[xr.Dataset, xr.Dataset], metric_cls
+) -> None:
+    """Per-lead skill must match a manual isel + metric loop."""
+    ds_p, ds_r = lead_time_pair
+    inner = metric_cls("x", ("lat", "lon"))
+    op = SkillByLeadTime(inner)
+    out = op(ds_p, ds_r)
+
+    expected_pieces = [
+        inner(ds_p.isel(lead_time=i), ds_r.isel(lead_time=i))
+        for i in range(ds_p.sizes["lead_time"])
+    ]
+    expected = xr.concat(expected_pieces, dim=ds_p["lead_time"])
+    np.testing.assert_allclose(out.values, expected.values)
+    assert "lead_time" in out.dims
+
+
+def test_skill_by_lead_time_with_psdscore(
+    lead_time_pair: tuple[xr.Dataset, xr.Dataset],
+) -> None:
+    """Inner Dataset-returning metrics (PSDScore) are stacked along lead_time."""
+    ds_p, ds_r = lead_time_pair
+    inner = PSDScore("x", psd_dims=["lon"])
+    op = SkillByLeadTime(inner)
+    out = op(ds_p, ds_r)
+    assert isinstance(out, xr.Dataset)
+    assert "score" in out.data_vars
+    assert "lead_time" in out.dims
+
+
+def test_skill_by_lead_time_missing_lead_dim_raises() -> None:
+    ds_p = xr.Dataset({"x": (("time",), np.zeros(5))})
+    ds_r = xr.Dataset({"x": (("time",), np.zeros(5))})
+    op = SkillByLeadTime(RMSE("x", dims="time"))
+    with pytest.raises(ValueError, match="lead_time"):
+        op(ds_p, ds_r)
+
+
+def test_skill_by_lead_time_rejects_non_operator() -> None:
+    with pytest.raises(TypeError, match="Operator"):
+        SkillByLeadTime(lambda p, r: p)  # type: ignore[arg-type]
+
+
+def test_skill_by_lead_time_get_config_introspectable() -> None:
+    op = SkillByLeadTime(RMSE("x", ("lat", "lon")), lead_dim="step")
+    cfg = op.get_config()
+    assert cfg["lead_dim"] == "step"
+    assert cfg["metric"]["class"] == "RMSE"
+    assert cfg["metric"]["config"]["variable"] == "x"
+    assert json.loads(json.dumps(cfg)) == cfg
+
+
+def test_skill_by_lead_time_custom_lead_dim() -> None:
+    rng = np.random.default_rng(2)
+    pred = rng.standard_normal((3, 5))
+    ref = rng.standard_normal((3, 5))
+    ds_p = xr.Dataset(
+        {"x": (("step", "time"), pred)},
+        coords={"step": [1, 2, 3], "time": np.arange(5)},
+    )
+    ds_r = xr.Dataset(
+        {"x": (("step", "time"), ref)}, coords={"step": [1, 2, 3], "time": np.arange(5)}
+    )
+    op = SkillByLeadTime(RMSE("x", dims="time"), lead_dim="step")
+    out = op(ds_p, ds_r)
+    assert "step" in out.dims
+    assert out.sizes["step"] == 3
+
+
+# ---------- V1.2 ----------------------------------------------------------
+
+
+def test_evaluate_by_region_dict_of_masks(
+    regional_pair: tuple[xr.Dataset, xr.Dataset],
+) -> None:
+    """A dict of named boolean masks is the simplest spec."""
+    ds_p, ds_r = regional_pair
+    masks = {
+        "north": ds_p["lat"] > 0,
+        "south": ds_p["lat"] <= 0,
+    }
+    op = EvaluateByRegion(RMSE("x", ("lat", "lon")), regions=masks)
+    out = op(ds_p, ds_r)
+    assert isinstance(out, xr.Dataset)
+    assert list(out["region"].values) == ["north", "south"]
+
+    # Parity vs manual where + metric.
+    inner = RMSE("x", ("lat", "lon"))
+    expected_north = inner(ds_p.where(masks["north"]), ds_r.where(masks["north"]))
+    expected_south = inner(ds_p.where(masks["south"]), ds_r.where(masks["south"]))
+    np.testing.assert_allclose(
+        out["x"].sel(region="north").values, expected_north.values
+    )
+    np.testing.assert_allclose(
+        out["x"].sel(region="south").values, expected_south.values
+    )
+
+
+def test_evaluate_by_region_int_mask_dataarray(
+    regional_pair: tuple[xr.Dataset, xr.Dataset],
+) -> None:
+    """An integer label mask DataArray is also accepted."""
+    ds_p, ds_r = regional_pair
+    mask_vals = np.where(
+        np.broadcast_to(ds_p["lat"].values[:, None] > 0, (8, 10)), 0, 1
+    )
+    mask = xr.DataArray(
+        mask_vals, dims=("lat", "lon"), coords={"lat": ds_p["lat"], "lon": ds_p["lon"]}
+    )
+    op = EvaluateByRegion(RMSE("x", ("lat", "lon")), regions=mask)
+    out = op(ds_p, ds_r)
+    assert "region" in out.dims
+    assert out.sizes["region"] == 2
+
+
+def test_evaluate_by_region_empty_region_yields_nan(
+    regional_pair: tuple[xr.Dataset, xr.Dataset],
+) -> None:
+    """A region with zero valid pixels should NaN, not raise."""
+    ds_p, ds_r = regional_pair
+    masks = {
+        "everywhere": xr.ones_like(ds_p["x"], dtype=bool),
+        "nowhere": xr.zeros_like(ds_p["x"], dtype=bool),
+    }
+    op = EvaluateByRegion(RMSE("x", ("lat", "lon")), regions=masks)
+    out = op(ds_p, ds_r)
+    assert np.isfinite(out["x"].sel(region="everywhere").values)
+    assert np.isnan(out["x"].sel(region="nowhere").values)
+
+
+def test_evaluate_by_region_rejects_unknown_type() -> None:
+    with pytest.raises(TypeError, match="Unsupported regions type"):
+        evaluate_by_region(
+            xr.Dataset({"x": (("t",), np.zeros(3))}),
+            xr.Dataset({"x": (("t",), np.zeros(3))}),
+            metric=RMSE("x", "t"),
+            regions=42,
+        )
+
+
+def test_normalize_regions_dict_round_trip(
+    regional_pair: tuple[xr.Dataset, xr.Dataset],
+) -> None:
+    ds_p, _ = regional_pair
+    masks = {"a": ds_p["lat"] > 0, "b": ds_p["lat"] <= 0}
+    mask, names = normalize_regions(masks, ds_p)
+    assert names == {0: "a", 1: "b"}
+    assert mask.dtype == np.int64
+    assert set(np.unique(mask.values).tolist()) == {0, 1}
+
+
+def test_evaluate_by_region_regionmask_lazy_import_error() -> None:
+    """Passing an unknown object that isn't a regionmask.Regions raises TypeError,
+    not ImportError — the regionmask import only fires for objects that
+    look like regionmask.Regions."""
+    pytest.importorskip("regionmask")
+    import regionmask
+
+    # Build a tiny custom Regions instance.
+    regions = regionmask.Regions(
+        outlines=[np.array([[-1.0, -1.0], [1.0, -1.0], [1.0, 1.0], [-1.0, 1.0]])],
+        names=["square"],
+        abbrevs=["sq"],
+    )
+    rng = np.random.default_rng(3)
+    lat = np.linspace(-2.0, 2.0, 8)
+    lon = np.linspace(-2.0, 2.0, 10)
+    ds_p = xr.Dataset(
+        {"x": (("lat", "lon"), rng.standard_normal((8, 10)))},
+        coords={"lat": lat, "lon": lon},
+    )
+    ds_r = xr.Dataset(
+        {"x": (("lat", "lon"), rng.standard_normal((8, 10)))},
+        coords={"lat": lat, "lon": lon},
+    )
+    op = EvaluateByRegion(RMSE("x", ("lat", "lon")), regions=regions)
+    out = op(ds_p, ds_r)
+    assert "region" in out.dims
+    assert "square" in out["region"].values.tolist()
+
+
+def test_evaluate_by_region_get_config_json_safe(
+    regional_pair: tuple[xr.Dataset, xr.Dataset],
+) -> None:
+    ds_p, _ = regional_pair
+    op = EvaluateByRegion(RMSE("x", ("lat", "lon")), regions={"n": ds_p["lat"] > 0})
+    cfg = op.get_config()
+    assert cfg["metric"]["class"] == "RMSE"
+    assert cfg["regions"] == ["n"]
+    assert json.loads(json.dumps(cfg)) == cfg
+
+
+def test_works_inside_graph(lead_time_pair: tuple[xr.Dataset, xr.Dataset]) -> None:
+    from xr_toolz.core import Graph, Input
+
+    ds_p, ds_r = lead_time_pair
+    p = Input("p")
+    r = Input("r")
+    out = SkillByLeadTime(RMSE("x", ("lat", "lon")))(p, r)
+    graph = Graph(inputs={"p": p, "r": r}, outputs={"y": out})
+    result = graph(p=ds_p, r=ds_r)
+    expected = skill_by_lead_time(ds_p, ds_r, metric=RMSE("x", ("lat", "lon")))
+    np.testing.assert_allclose(result["y"].values, expected.values)

--- a/uv.lock
+++ b/uv.lock
@@ -3074,7 +3074,7 @@ wheels = [
 
 [[package]]
 name = "xr-toolz"
-version = "0.0.1"
+version = "0.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "finitediffx" },


### PR DESCRIPTION
## Summary
- Land V1.1 `SkillByLeadTime` (`metrics/_src/forecast.py`): wrap an inner `Operator` and apply it per lead-time slice; results stack along the lead-time axis. Inner metric must be an `Operator` so `get_config()` is preserved.
- Land V1.2 `EvaluateByRegion` (`metrics/_src/multiscale.py`): apply an inner `Operator` per region. Accepts `regionmask.Regions` (lazy import), an integer-mask `xr.DataArray`, or a `dict[str, DataArray[bool]]`. Empty regions → NaN, not raise.
- Public exports updated in `xr_toolz.metrics` + `xr_toolz.metrics.operators`. Stub-import test parametrize trimmed to drop the now-populated `forecast` / `multiscale` cases.

V1.3 (`FrequencyBandSkill` + `BandLimitedRMSE`) will land in a follow-up — the FFT band-pass + units validation has more surface than V1.1/V1.2 combined.

Closes #39 (V1.1) and #40 (V1.2). V1 epic (#38) and V1.3 (#41) remain open pending the follow-up.

## Test plan
- [x] `uv run pytest tests/test_metrics_v1_scales.py` — 17 tests pass
- [x] Parity tests: `SkillByLeadTime` vs manual `isel + metric` loop for `RMSE`, `MAE`, `Bias`, `Correlation`; `PSDScore` (Dataset-returning) also exercised
- [x] All three region input types covered; empty-region NaN; lazy `regionmask` import validated when `regionmask` is installed
- [x] `get_config()` JSON-serializable for both ops
- [x] `SkillByLeadTime` exercised inside `Graph` to confirm symbolic dispatch
- [x] Full suite: 713 passed, 1 skipped
- [x] `uv run --group lint ruff check .` / `ruff format --check .` clean
- [x] `uv run --group typecheck ty check src/xr_toolz` — 41 diagnostics, same as `main` baseline (no new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)