### PR TITLE
feat(metrics): add v2 data-representation metrics (structural / probabilistic / distributional / masked)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "xskillscore>=0.0.26",
     "numpy-groupies>=0.11",
     "finitediffx>=0.1.0",
+    "scikit-image>=0.22",
 ]
 
 [project.optional-dependencies]

--- a/src/xr_toolz/metrics/__init__.py
+++ b/src/xr_toolz/metrics/__init__.py
@@ -15,7 +15,16 @@ Layer-1 ``Operator`` wrappers are re-exported flat from this package
 and from :mod:`xr_toolz.metrics.operators`.
 """
 
+from xr_toolz.metrics._src.distributional import (
+    CRPS,
+    EnergyDistance,
+    Wasserstein1,
+    crps_ensemble,
+    energy_distance,
+    wasserstein_1,
+)
 from xr_toolz.metrics._src.forecast import SkillByLeadTime, skill_by_lead_time
+from xr_toolz.metrics._src.masked import MaskedMetric, masked_metric
 from xr_toolz.metrics._src.multiscale import (
     EvaluateByRegion,
     evaluate_by_region,
@@ -37,6 +46,16 @@ from xr_toolz.metrics._src.pixel import (
     r2_score,
     rmse,
 )
+from xr_toolz.metrics._src.probabilistic import (
+    EnsembleCoverage,
+    RankHistogram,
+    ReliabilityCurve,
+    SpreadSkillRatio,
+    ensemble_coverage,
+    rank_histogram,
+    reliability_curve,
+    spread_skill_ratio,
+)
 from xr_toolz.metrics._src.spectral import (
     PSDScore,
     find_intercept_1D,
@@ -44,31 +63,65 @@ from xr_toolz.metrics._src.spectral import (
     psd_score,
     resolved_scale,
 )
+from xr_toolz.metrics._src.structural import (
+    SSIM,
+    CentroidDisplacement,
+    GradientDifference,
+    PhaseShiftError,
+    centroid_displacement,
+    gradient_difference,
+    phase_shift_error,
+    ssim,
+)
 
 
 __all__ = [
+    "CRPS",
     "MAE",
     "MSE",
     "NRMSE",
     "RMSE",
+    "SSIM",
     "Bias",
+    "CentroidDisplacement",
     "Correlation",
+    "EnergyDistance",
+    "EnsembleCoverage",
     "EvaluateByRegion",
+    "GradientDifference",
+    "MaskedMetric",
     "PSDScore",
+    "PhaseShiftError",
     "R2Score",
+    "RankHistogram",
+    "ReliabilityCurve",
     "SkillByLeadTime",
+    "SpreadSkillRatio",
+    "Wasserstein1",
     "bias",
+    "centroid_displacement",
     "correlation",
+    "crps_ensemble",
+    "energy_distance",
+    "ensemble_coverage",
     "evaluate_by_region",
     "find_intercept_1D",
+    "gradient_difference",
     "mae",
+    "masked_metric",
     "mse",
     "normalize_regions",
     "nrmse",
+    "phase_shift_error",
     "psd_error",
     "psd_score",
     "r2_score",
+    "rank_histogram",
+    "reliability_curve",
     "resolved_scale",
     "rmse",
     "skill_by_lead_time",
+    "spread_skill_ratio",
+    "ssim",
+    "wasserstein_1",
 ]

--- a/src/xr_toolz/metrics/_src/distributional.py
+++ b/src/xr_toolz/metrics/_src/distributional.py
@@ -1,6 +1,305 @@
-"""Stub: lands with view V2 (Epic).
+"""Distributional metrics — CRPS, energy distance, Wasserstein-1.
 
-This module is intentionally empty. It will be populated by the V2
-view epic and is shipped now so downstream PRs can import its path
-without depending on a package layout change.
+V2.3. These metrics compare full distributions rather than point
+estimates:
+
+- :func:`crps_ensemble` for ensemble-vs-deterministic-truth (delegates
+  to :mod:`xskillscore`).
+- :func:`energy_distance` for two-sample distribution comparison
+  (pure :mod:`numpy`).
+- :func:`wasserstein_1` for 1-D distribution comparison via
+  :func:`scipy.stats.wasserstein_distance`.
+
+Member dimension convention follows V2.2: ``ensemble_dim="member"``
+(or ``sample_dim_a`` / ``sample_dim_b`` for two-sample metrics).
 """
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any, cast
+
+import numpy as np
+import xarray as xr
+import xskillscore as xs
+from scipy.stats import energy_distance as _scipy_energy_distance, wasserstein_distance
+
+from xr_toolz.core import Operator
+
+
+def _check_member_dim(da: xr.DataArray, dim: str) -> None:
+    if dim not in da.dims:
+        raise ValueError(
+            f"Variable is missing ensemble/sample dim {dim!r}; "
+            f"got dims={tuple(da.dims)}."
+        )
+    if da.sizes[dim] < 2:
+        raise ValueError(
+            f"Ensemble/sample dim {dim!r} has size {da.sizes[dim]}; need at least 2."
+        )
+
+
+# ---------- CRPS ----------------------------------------------------------
+
+
+def crps_ensemble(
+    ds_ensemble: xr.Dataset,
+    ds_ref: xr.Dataset,
+    *,
+    variable: str,
+    ensemble_dim: str = "member",
+    dims: Sequence[str] | None = None,
+) -> xr.DataArray:
+    """Continuous Ranked Probability Score (ensemble vs deterministic truth).
+
+    Delegates to :func:`xskillscore.crps_ensemble`.
+
+    Args:
+        ds_ensemble: Dataset containing the ensemble forecast variable
+            with an ``ensemble_dim`` axis.
+        ds_ref: Dataset containing the deterministic reference.
+        variable: Variable name (must be present in both datasets).
+        ensemble_dim: Name of the ensemble member dimension. Default
+            ``"member"``.
+        dims: Optional dims to average over after the per-pixel CRPS
+            (e.g. ``("time", "lat", "lon")``); ``None`` keeps full
+            shape.
+    """
+    da_ens = ds_ensemble[variable]
+    da_ref = ds_ref[variable]
+    _check_member_dim(da_ens, ensemble_dim)
+    crps = cast(
+        xr.DataArray,
+        xs.crps_ensemble(da_ref, da_ens, member_dim=ensemble_dim, dim=[]),
+    )
+    if dims:
+        crps = crps.mean(dim=list(dims))
+    return crps
+
+
+# ---------- Energy distance ----------------------------------------------
+
+
+def energy_distance(
+    ds_a: xr.Dataset,
+    ds_b: xr.Dataset,
+    *,
+    variable: str,
+    sample_dim_a: str = "member",
+    sample_dim_b: str = "member",
+    dims: Sequence[str] | None = None,
+) -> xr.DataArray:
+    """Two-sample energy distance.
+
+    For 1-D samples ``a ∈ R^n`` and ``b ∈ R^m``::
+
+        E(a, b) = 2 * E|A - B| - E|A - A'| - E|B - B'|
+
+    where ``A, A'`` are i.i.d. draws from ``a`` and ``B, B'`` from ``b``.
+    The implementation uses pairwise absolute differences along the
+    sample dimensions and is **not** vectorised over additional dims.
+
+    Args:
+        ds_a: Dataset with sample variable along ``sample_dim_a``.
+        ds_b: Dataset with sample variable along ``sample_dim_b``.
+        variable: Variable name in both datasets.
+        sample_dim_a: Sample dim in ``ds_a``.
+        sample_dim_b: Sample dim in ``ds_b``.
+        dims: Optional non-sample dims to average over. ``None`` keeps
+            the result un-reduced (per-pixel energy distance).
+    """
+    da_a = ds_a[variable]
+    da_b = ds_b[variable]
+    _check_member_dim(da_a, sample_dim_a)
+    _check_member_dim(da_b, sample_dim_b)
+
+    # Move sample dims to the leading axis for clarity.
+    a = da_a.transpose(sample_dim_a, ...).values  # (n, *rest)
+    b = da_b.transpose(sample_dim_b, ...).values  # (m, *rest)
+    rest_shape = a.shape[1:]
+
+    a_flat = a.reshape(a.shape[0], -1)  # (n, K)
+    b_flat = b.reshape(b.shape[0], -1)  # (m, K)
+
+    # Per-pixel energy distance via scipy: O(n+m) per pixel rather than
+    # O((n+m)^2), and uses the unbiased self-distance estimator (excludes
+    # i==j pairs) so small ensembles aren't biased downward.
+    energy_flat = np.array(
+        [
+            _scipy_energy_distance(a_flat[:, k], b_flat[:, k])
+            for k in range(a_flat.shape[1])
+        ]
+    )
+    energy = energy_flat.reshape(rest_shape) if rest_shape else energy_flat.item()
+
+    rest_dims = tuple(d for d in da_a.dims if d != sample_dim_a)
+    coords = {
+        name: coord
+        for name, coord in da_a.coords.items()
+        if set(coord.dims).issubset(set(rest_dims))
+    }
+    out = xr.DataArray(np.asarray(energy), dims=rest_dims, coords=coords)
+    if dims:
+        out = out.mean(dim=list(dims))
+    return out
+
+
+# ---------- Wasserstein-1 ------------------------------------------------
+
+
+def wasserstein_1(
+    ds_a: xr.Dataset,
+    ds_b: xr.Dataset,
+    *,
+    variable: str,
+    sample_dim_a: str = "member",
+    sample_dim_b: str = "member",
+    dims: Sequence[str] | None = None,
+) -> xr.DataArray:
+    """1-D Wasserstein (earth-mover's) distance between two sample sets.
+
+    Uses :func:`scipy.stats.wasserstein_distance` along the sample
+    dims; supports broadcasting over the remaining dims.
+
+    Args:
+        ds_a: Dataset whose ``variable`` carries samples along
+            ``sample_dim_a``.
+        ds_b: Same shape (modulo sample dim) as ``ds_a``.
+        variable: Variable name.
+        sample_dim_a, sample_dim_b: Names of the sample dims.
+        dims: Optional non-sample dims to average over.
+    """
+    da_a = ds_a[variable]
+    da_b = ds_b[variable]
+    _check_member_dim(da_a, sample_dim_a)
+    _check_member_dim(da_b, sample_dim_b)
+
+    a = da_a.transpose(sample_dim_a, ...).values
+    b = da_b.transpose(sample_dim_b, ...).values
+    rest_shape = a.shape[1:]
+    a_flat = a.reshape(a.shape[0], -1)
+    b_flat = b.reshape(b.shape[0], -1)
+
+    out_flat = np.array(
+        [
+            wasserstein_distance(a_flat[:, k], b_flat[:, k])
+            for k in range(a_flat.shape[1])
+        ]
+    )
+    out_arr = out_flat.reshape(rest_shape) if rest_shape else out_flat.item()
+
+    rest_dims = tuple(d for d in da_a.dims if d != sample_dim_a)
+    coords = {
+        name: coord
+        for name, coord in da_a.coords.items()
+        if set(coord.dims).issubset(set(rest_dims))
+    }
+    out = xr.DataArray(np.asarray(out_arr), dims=rest_dims, coords=coords)
+    if dims:
+        out = out.mean(dim=list(dims))
+    return out
+
+
+# ---------- Layer-1 -------------------------------------------------------
+
+
+class _DistributionalOp(Operator):
+    _fn: Any = None
+
+    def __init__(
+        self,
+        variable: str,
+        *,
+        ensemble_dim: str = "member",
+        dims: Sequence[str] | None = None,
+    ) -> None:
+        self.variable = variable
+        self.ensemble_dim = ensemble_dim
+        self.dims = None if dims is None else list(dims)
+
+    def get_config(self) -> dict[str, Any]:
+        return {
+            "variable": self.variable,
+            "ensemble_dim": self.ensemble_dim,
+            "dims": None if self.dims is None else list(self.dims),
+        }
+
+
+class CRPS(_DistributionalOp):
+    """Two-input CRPS operator.
+
+    Inputs: ``(ds_ensemble, ds_reference)`` where ``ds_ensemble`` has
+    an ``ensemble_dim`` axis and ``ds_reference`` is deterministic.
+    """
+
+    def _apply(self, ds_ensemble: xr.Dataset, ds_ref: xr.Dataset) -> xr.DataArray:
+        return crps_ensemble(
+            ds_ensemble,
+            ds_ref,
+            variable=self.variable,
+            ensemble_dim=self.ensemble_dim,
+            dims=self.dims,
+        )
+
+
+class _TwoSampleOp(Operator):
+    _fn: Any = None
+
+    def __init__(
+        self,
+        variable: str,
+        *,
+        sample_dim_a: str = "member",
+        sample_dim_b: str = "member",
+        dims: Sequence[str] | None = None,
+    ) -> None:
+        self.variable = variable
+        self.sample_dim_a = sample_dim_a
+        self.sample_dim_b = sample_dim_b
+        self.dims = None if dims is None else list(dims)
+
+    def get_config(self) -> dict[str, Any]:
+        return {
+            "variable": self.variable,
+            "sample_dim_a": self.sample_dim_a,
+            "sample_dim_b": self.sample_dim_b,
+            "dims": None if self.dims is None else list(self.dims),
+        }
+
+
+class EnergyDistance(_TwoSampleOp):
+    """Two-sample energy-distance operator."""
+
+    def _apply(self, ds_a: xr.Dataset, ds_b: xr.Dataset) -> xr.DataArray:
+        return energy_distance(
+            ds_a,
+            ds_b,
+            variable=self.variable,
+            sample_dim_a=self.sample_dim_a,
+            sample_dim_b=self.sample_dim_b,
+            dims=self.dims,
+        )
+
+
+class Wasserstein1(_TwoSampleOp):
+    """1-D Wasserstein-distance operator."""
+
+    def _apply(self, ds_a: xr.Dataset, ds_b: xr.Dataset) -> xr.DataArray:
+        return wasserstein_1(
+            ds_a,
+            ds_b,
+            variable=self.variable,
+            sample_dim_a=self.sample_dim_a,
+            sample_dim_b=self.sample_dim_b,
+            dims=self.dims,
+        )
+
+
+__all__ = [
+    "CRPS",
+    "EnergyDistance",
+    "Wasserstein1",
+    "crps_ensemble",
+    "energy_distance",
+    "wasserstein_1",
+]

--- a/src/xr_toolz/metrics/_src/masked.py
+++ b/src/xr_toolz/metrics/_src/masked.py
@@ -1,6 +1,102 @@
-"""Stub: lands with view V2 (Epic).
+"""Masked-metric wrappers — apply any inner metric on the valid pixels.
 
-This module is intentionally empty. It will be populated by the V2
-view epic and is shipped now so downstream PRs can import its path
-without depending on a package layout change.
+V2.4. The :class:`MaskedMetric` operator wraps any pixel / spectral /
+structural metric and applies it after masking the inputs with a
+boolean (or NaN-aware float) mask. Eliminates the
+``pred.where(mask), ref.where(mask)`` boilerplate that proliferates
+upstream of every metric call.
+
+This is **not** per-region breakdown — that is :class:`EvaluateByRegion`
+in V1.2. ``MaskedMetric`` is single-mask filtering, strictly orthogonal.
 """
+
+from __future__ import annotations
+
+from typing import Any
+
+import xarray as xr
+
+from xr_toolz.core import Operator
+
+
+# ---------- Layer-0 -------------------------------------------------------
+
+
+def masked_metric(
+    ds_pred: xr.Dataset,
+    ds_ref: xr.Dataset,
+    *,
+    metric: Operator,
+    mask: xr.DataArray,
+) -> xr.DataArray | xr.Dataset:
+    """Apply ``metric`` to ``(pred, ref)`` after masking with ``mask``.
+
+    Args:
+        ds_pred: Prediction dataset.
+        ds_ref: Reference dataset.
+        metric: Inner :class:`Operator` (any two-input metric).
+        mask: Boolean :class:`xr.DataArray` (or NaN-aware float).
+            Pixels where ``mask`` is ``False`` / ``NaN`` are dropped.
+            Float masks are coerced via ``mask.fillna(False).astype(bool)``
+            so NaN explicitly maps to False (rather than relying on
+            ``where(NaN)`` truthiness, which is implementation-defined).
+    """
+    mask_bool = mask.fillna(False).astype(bool)
+    return metric(ds_pred.where(mask_bool), ds_ref.where(mask_bool))
+
+
+# ---------- Layer-1 -------------------------------------------------------
+
+
+class MaskedMetric(Operator):
+    """Wrap any inner metric so it operates only on masked-valid pixels.
+
+    Args:
+        metric: Inner two-input :class:`Operator` (e.g. ``RMSE(...)``).
+        mask: Optional default mask. If ``None``, a per-call mask must
+            be supplied via ``__call__(pred, ref, mask=...)``.
+
+    Example:
+        >>> from xr_toolz.metrics import RMSE, MaskedMetric
+        >>> op = MaskedMetric(RMSE("ssh", ("lat", "lon")), mask=ocean)
+        >>> op(pred_ds, ref_ds)
+        >>>
+        >>> op2 = MaskedMetric(RMSE("sst", ("lat", "lon")))
+        >>> op2(pred_ds, ref_ds, mask=cloud_free_today)
+    """
+
+    def __init__(self, metric: Operator, mask: xr.DataArray | None = None) -> None:
+        if not isinstance(metric, Operator):
+            raise TypeError(
+                f"MaskedMetric requires an Operator, got {type(metric).__name__!r}."
+            )
+        self.metric = metric
+        self.mask = mask
+
+    def _apply(
+        self,
+        ds_pred: xr.Dataset,
+        ds_ref: xr.Dataset,
+        *,
+        mask: xr.DataArray | None = None,
+    ) -> xr.DataArray | xr.Dataset:
+        chosen = mask if mask is not None else self.mask
+        if chosen is None:
+            raise ValueError(
+                "MaskedMetric requires a mask either at construction "
+                "(MaskedMetric(metric, mask=...)) or per call "
+                "(op(pred, ref, mask=...))."
+            )
+        return masked_metric(ds_pred, ds_ref, metric=self.metric, mask=chosen)
+
+    def get_config(self) -> dict[str, Any]:
+        return {
+            "metric": {
+                "class": type(self.metric).__name__,
+                "config": self.metric.get_config(),
+            },
+            "mask": "<DataArray>" if self.mask is not None else None,
+        }
+
+
+__all__ = ["MaskedMetric", "masked_metric"]

--- a/src/xr_toolz/metrics/_src/probabilistic.py
+++ b/src/xr_toolz/metrics/_src/probabilistic.py
@@ -1,6 +1,335 @@
-"""Stub: lands with view V2 (Epic).
+"""Probabilistic / ensemble metrics.
 
-This module is intentionally empty. It will be populated by the V2
-view epic and is shipped now so downstream PRs can import its path
-without depending on a package layout change.
+V2.2. Member-dimension convention: by default the ensemble axis is
+named ``"member"`` and is settable per call via ``ensemble_dim=``.
+Inputs are :class:`xr.Dataset`; the variable is selected by name.
+
+Operators:
+
+- :class:`SpreadSkillRatio` — ``ensemble-std / RMSE(ensemble-mean, ref)``
+- :class:`RankHistogram` — Talagrand rank histogram
+- :class:`EnsembleCoverage` — fraction of references inside an
+  ensemble quantile envelope
+- :class:`ReliabilityCurve` — observed event frequency vs forecast
+  probability bin
 """
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+import numpy as np
+import xarray as xr
+
+from xr_toolz.core import Operator
+
+
+def _check_ensemble_dim(da: xr.DataArray, dim: str) -> None:
+    if dim not in da.dims:
+        raise ValueError(
+            f"Variable is missing ensemble dim {dim!r}; got dims={tuple(da.dims)}."
+        )
+    if da.sizes[dim] < 2:
+        raise ValueError(
+            f"Ensemble dim {dim!r} has size {da.sizes[dim]}; need at least 2."
+        )
+
+
+# ---------- Layer-0 -------------------------------------------------------
+
+
+def spread_skill_ratio(
+    ds_ensemble: xr.Dataset,
+    ds_ref: xr.Dataset,
+    *,
+    variable: str,
+    ensemble_dim: str = "member",
+    dims: Sequence[str] | None = None,
+) -> xr.DataArray:
+    """``ensemble-std / RMSE(ensemble-mean, reference)``.
+
+    A perfectly calibrated ensemble has spread/skill ≈ 1: the
+    ensemble standard deviation matches the error of its mean. Values
+    < 1 indicate under-dispersion, > 1 over-dispersion.
+
+    Args:
+        ds_ensemble: Dataset with the ensemble variable.
+        ds_ref: Deterministic reference.
+        variable: Variable name.
+        ensemble_dim: Member dim.
+        dims: Dims to reduce over (e.g. ``("time", "lat", "lon")``).
+            ``None`` reduces over every non-ensemble dim.
+    """
+    da_ens = ds_ensemble[variable]
+    da_ref = ds_ref[variable]
+    _check_ensemble_dim(da_ens, ensemble_dim)
+
+    if dims is None:
+        reduce = [d for d in da_ens.dims if d != ensemble_dim]
+    else:
+        reduce = list(dims)
+
+    ens_mean = da_ens.mean(dim=ensemble_dim)
+    ens_std = da_ens.std(dim=ensemble_dim, ddof=1)
+    spread = (ens_std**2).mean(dim=reduce) ** 0.5
+    skill = ((ens_mean - da_ref) ** 2).mean(dim=reduce) ** 0.5
+    return spread / skill
+
+
+def rank_histogram(
+    ds_ensemble: xr.Dataset,
+    ds_ref: xr.Dataset,
+    *,
+    variable: str,
+    ensemble_dim: str = "member",
+) -> xr.Dataset:
+    """Talagrand rank histogram.
+
+    For each forecast/observation pair, count how many ensemble
+    members are strictly less than the observation; the resulting
+    rank in ``[0, n_members]`` is binned. A perfectly calibrated
+    ensemble produces a flat histogram.
+
+    Args:
+        ds_ensemble: Ensemble forecast.
+        ds_ref: Reference.
+        variable: Variable name.
+        ensemble_dim: Member dim.
+
+    Returns:
+        Dataset with a ``"rank_count"`` variable indexed by ``"rank"``
+        (size ``n_members + 1``).
+    """
+    da_ens = ds_ensemble[variable]
+    da_ref = ds_ref[variable]
+    _check_ensemble_dim(da_ens, ensemble_dim)
+
+    n = da_ens.sizes[ensemble_dim]
+    ens_arr = da_ens.transpose(ensemble_dim, ...).values
+    ref_arr = da_ref.broadcast_like(da_ens.isel({ensemble_dim: 0})).values
+    ranks = np.sum(ens_arr < ref_arr[None, ...], axis=0)
+    counts = np.bincount(ranks.ravel(), minlength=n + 1)
+    return xr.Dataset(
+        {"rank_count": (("rank",), counts.astype(np.int64))},
+        coords={"rank": np.arange(n + 1)},
+    )
+
+
+def ensemble_coverage(
+    ds_ensemble: xr.Dataset,
+    ds_ref: xr.Dataset,
+    *,
+    variable: str,
+    q: tuple[float, float] = (0.05, 0.95),
+    ensemble_dim: str = "member",
+) -> xr.DataArray:
+    """Fraction of reference values inside the ensemble ``q`` envelope.
+
+    For ``q=(0.05, 0.95)`` a calibrated ensemble produces ≈ 0.9.
+
+    Args:
+        ds_ensemble: Ensemble forecast.
+        ds_ref: Reference.
+        variable: Variable name.
+        q: ``(low, high)`` quantiles in ``[0, 1]``.
+        ensemble_dim: Member dim.
+
+    Returns:
+        Scalar fraction (0..1) :class:`xr.DataArray`.
+    """
+    if not 0.0 <= q[0] < q[1] <= 1.0:
+        raise ValueError(f"q must be (low, high) with 0 <= low < high <= 1, got {q}.")
+
+    da_ens = ds_ensemble[variable]
+    da_ref = ds_ref[variable]
+    _check_ensemble_dim(da_ens, ensemble_dim)
+    lo = da_ens.quantile(q[0], dim=ensemble_dim).drop_vars("quantile")
+    hi = da_ens.quantile(q[1], dim=ensemble_dim).drop_vars("quantile")
+    inside = (da_ref >= lo) & (da_ref <= hi)
+    return inside.mean()
+
+
+def reliability_curve(
+    ds_probability: xr.Dataset,
+    ds_event: xr.Dataset,
+    *,
+    variable: str,
+    probability_bins: np.ndarray | None = None,
+) -> xr.Dataset:
+    """Reliability diagram coordinates.
+
+    Bins the forecast probability of an event and reports the
+    observed frequency of the event within each bin. A perfectly
+    calibrated forecast lies on the identity line.
+
+    Args:
+        ds_probability: Dataset whose ``variable`` holds forecast
+            probabilities in ``[0, 1]``.
+        ds_event: Dataset whose ``variable`` is a 0/1 event indicator
+            on the same grid.
+        variable: Variable name (same in both).
+        probability_bins: Bin edges in ``[0, 1]``. Defaults to
+            ``np.linspace(0, 1, 11)`` (10 bins).
+
+    Returns:
+        Dataset with ``forecast_probability``, ``observed_frequency``,
+        and ``count`` variables indexed by ``probability_bin``.
+    """
+    bins = (
+        np.linspace(0.0, 1.0, 11)
+        if probability_bins is None
+        else np.asarray(probability_bins)
+    )
+    p = ds_probability[variable].values.ravel()
+    o = ds_event[variable].values.ravel()
+    valid = np.isfinite(p) & np.isfinite(o)
+    p = p[valid]
+    o = o[valid]
+    idx = np.clip(np.digitize(p, bins) - 1, 0, len(bins) - 2)
+    n_bins = len(bins) - 1
+    fc = np.full(n_bins, np.nan)
+    ob = np.full(n_bins, np.nan)
+    counts = np.zeros(n_bins, dtype=np.int64)
+    for k in range(n_bins):
+        sel = idx == k
+        counts[k] = sel.sum()
+        if counts[k] > 0:
+            fc[k] = p[sel].mean()
+            ob[k] = o[sel].mean()
+    centers = 0.5 * (bins[:-1] + bins[1:])
+    return xr.Dataset(
+        {
+            "forecast_probability": (("probability_bin",), fc),
+            "observed_frequency": (("probability_bin",), ob),
+            "count": (("probability_bin",), counts),
+        },
+        coords={"probability_bin": centers},
+    )
+
+
+# ---------- Layer-1 -------------------------------------------------------
+
+
+class _ProbabilisticOp(Operator):
+    def __init__(
+        self,
+        variable: str,
+        *,
+        ensemble_dim: str = "member",
+    ) -> None:
+        self.variable = variable
+        self.ensemble_dim = ensemble_dim
+
+    def get_config(self) -> dict[str, Any]:
+        return {"variable": self.variable, "ensemble_dim": self.ensemble_dim}
+
+
+class SpreadSkillRatio(_ProbabilisticOp):
+    """``SpreadSkillRatio(variable, ensemble_dim, dims)``."""
+
+    def __init__(
+        self,
+        variable: str,
+        *,
+        ensemble_dim: str = "member",
+        dims: Sequence[str] | None = None,
+    ) -> None:
+        super().__init__(variable, ensemble_dim=ensemble_dim)
+        self.dims = None if dims is None else list(dims)
+
+    def _apply(self, ds_ensemble: xr.Dataset, ds_ref: xr.Dataset) -> xr.DataArray:
+        return spread_skill_ratio(
+            ds_ensemble,
+            ds_ref,
+            variable=self.variable,
+            ensemble_dim=self.ensemble_dim,
+            dims=self.dims,
+        )
+
+    def get_config(self) -> dict[str, Any]:
+        cfg = super().get_config()
+        cfg["dims"] = None if self.dims is None else list(self.dims)
+        return cfg
+
+
+class RankHistogram(_ProbabilisticOp):
+    """Talagrand rank histogram."""
+
+    def _apply(self, ds_ensemble: xr.Dataset, ds_ref: xr.Dataset) -> xr.Dataset:
+        return rank_histogram(
+            ds_ensemble,
+            ds_ref,
+            variable=self.variable,
+            ensemble_dim=self.ensemble_dim,
+        )
+
+
+class EnsembleCoverage(_ProbabilisticOp):
+    """Fraction of references inside the ``q`` ensemble envelope."""
+
+    def __init__(
+        self,
+        variable: str,
+        *,
+        q: tuple[float, float] = (0.05, 0.95),
+        ensemble_dim: str = "member",
+    ) -> None:
+        super().__init__(variable, ensemble_dim=ensemble_dim)
+        self.q = tuple(q)
+
+    def _apply(self, ds_ensemble: xr.Dataset, ds_ref: xr.Dataset) -> xr.DataArray:
+        return ensemble_coverage(
+            ds_ensemble,
+            ds_ref,
+            variable=self.variable,
+            q=self.q,
+            ensemble_dim=self.ensemble_dim,
+        )
+
+    def get_config(self) -> dict[str, Any]:
+        cfg = super().get_config()
+        cfg["q"] = list(self.q)
+        return cfg
+
+
+class ReliabilityCurve(Operator):
+    """Reliability-diagram operator (probability vs event)."""
+
+    def __init__(
+        self, variable: str, *, probability_bins: np.ndarray | None = None
+    ) -> None:
+        self.variable = variable
+        self.probability_bins = (
+            None if probability_bins is None else np.asarray(probability_bins)
+        )
+
+    def _apply(self, ds_probability: xr.Dataset, ds_event: xr.Dataset) -> xr.Dataset:
+        return reliability_curve(
+            ds_probability,
+            ds_event,
+            variable=self.variable,
+            probability_bins=self.probability_bins,
+        )
+
+    def get_config(self) -> dict[str, Any]:
+        return {
+            "variable": self.variable,
+            "probability_bins": (
+                None
+                if self.probability_bins is None
+                else self.probability_bins.tolist()
+            ),
+        }
+
+
+__all__ = [
+    "EnsembleCoverage",
+    "RankHistogram",
+    "ReliabilityCurve",
+    "SpreadSkillRatio",
+    "ensemble_coverage",
+    "rank_histogram",
+    "reliability_curve",
+    "spread_skill_ratio",
+]

--- a/src/xr_toolz/metrics/_src/structural.py
+++ b/src/xr_toolz/metrics/_src/structural.py
@@ -1,6 +1,410 @@
-"""Stub: lands with view V2 (Epic).
+"""Structural metrics — SSIM, gradient/phase displacement.
 
-This module is intentionally empty. It will be populated by the V2
-view epic and is shipped now so downstream PRs can import its path
-without depending on a package layout change.
+V2.1. Diagnose geometry, gradient, and phase rather than pointwise
+differences. Intended for cases where features are roughly correct
+but slightly displaced — e.g. an SSH eddy 20 km off the reference
+location.
+
+Operators:
+
+- :class:`SSIM` — structural similarity index via :mod:`scikit-image`.
+- :class:`GradientDifference` — RMS difference of finite-difference
+  gradients along ``dims``.
+- :class:`PhaseShiftError` — best-aligned shift between prediction
+  and reference via cross-correlation; supports periodic wrap.
+- :class:`CentroidDisplacement` — distance between matched object
+  centroids in two labelled object datasets.
 """
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+import numpy as np
+import xarray as xr
+from skimage.metrics import structural_similarity
+
+from xr_toolz.core import Operator
+
+
+def _normalize_dims(dims: str | Sequence[str]) -> list[str]:
+    return [dims] if isinstance(dims, str) else list(dims)
+
+
+# ---------- SSIM ----------------------------------------------------------
+
+
+def ssim(
+    ds_pred: xr.Dataset,
+    ds_ref: xr.Dataset,
+    *,
+    variable: str,
+    dims: str | Sequence[str],
+    window: int | None = None,
+) -> xr.DataArray:
+    """Structural similarity index over ``dims`` per leading-dim slice.
+
+    Args:
+        ds_pred: Prediction dataset.
+        ds_ref: Reference dataset.
+        variable: Variable name.
+        dims: One or two image dims (e.g. ``("lat", "lon")``).
+        window: Optional :func:`skimage.metrics.structural_similarity`
+            ``win_size`` override.
+
+    Returns:
+        Per-non-image-slice SSIM as a :class:`xr.DataArray` reduced
+        over ``dims``.
+    """
+    core = _normalize_dims(dims)
+    da_p = ds_pred[variable]
+    da_r = ds_ref[variable]
+    rest = [d for d in da_p.dims if d not in core]
+
+    p = da_p.transpose(*rest, *core).values
+    r = da_r.transpose(*rest, *core).values
+    rest_shape = p.shape[: len(rest)]
+    img_shape = p.shape[len(rest) :]
+    p_flat = p.reshape(-1, *img_shape)
+    r_flat = r.reshape(-1, *img_shape)
+
+    base_kw: dict[str, Any] = {}
+    if window is not None:
+        base_kw["win_size"] = window
+
+    def _ssim_slice(p_slc: np.ndarray, r_slc: np.ndarray) -> float:
+        # Compute data_range per-slice; if the reference is constant or
+        # all-NaN the standard formula collapses to 1.0 (perfect match
+        # iff the prediction matches; otherwise no meaningful structural
+        # comparison and we fall back to the equality test).
+        ref_max = np.nanmax(r_slc)
+        ref_min = np.nanmin(r_slc)
+        rng = float(ref_max - ref_min) if np.isfinite(ref_max - ref_min) else 0.0
+        if rng <= 0.0:
+            return 1.0 if np.allclose(p_slc, r_slc, equal_nan=True) else 0.0
+        return float(structural_similarity(p_slc, r_slc, data_range=rng, **base_kw))
+
+    out = np.array([_ssim_slice(p_flat[i], r_flat[i]) for i in range(p_flat.shape[0])])
+    out = out.reshape(rest_shape) if rest_shape else float(out.item())
+    coords = {
+        name: coord
+        for name, coord in da_p.coords.items()
+        if set(coord.dims).issubset(set(rest))
+    }
+    return xr.DataArray(np.asarray(out), dims=tuple(rest), coords=coords)
+
+
+# ---------- Gradient difference ------------------------------------------
+
+
+def gradient_difference(
+    ds_pred: xr.Dataset,
+    ds_ref: xr.Dataset,
+    *,
+    variable: str,
+    dims: str | Sequence[str],
+) -> xr.DataArray:
+    """RMS of the finite-difference gradient discrepancy.
+
+    Computed as ``sqrt(<sum_d (∂_d pred - ∂_d ref)^2>)`` averaged
+    over ``dims``. Constant offsets cancel; pure shifts contribute
+    only at the boundary of the field of view.
+    """
+    core = _normalize_dims(dims)
+    da_p = ds_pred[variable]
+    da_r = ds_ref[variable]
+
+    sq = xr.zeros_like(da_p, dtype=np.float64)
+    for d in core:
+        gp = da_p.differentiate(d)
+        gr = da_r.differentiate(d)
+        sq = sq + (gp - gr) ** 2
+    return sq.mean(dim=core) ** 0.5
+
+
+# ---------- Phase shift error --------------------------------------------
+
+
+def phase_shift_error(
+    ds_pred: xr.Dataset,
+    ds_ref: xr.Dataset,
+    *,
+    variable: str,
+    dims: str | Sequence[str],
+    periodic: bool = False,
+) -> xr.Dataset:
+    """Estimate the integer-pixel shift that best aligns pred with ref.
+
+    Uses the FFT-based cross-correlation peak. Returns one shift per
+    image dim plus the residual RMSE after applying that shift.
+
+    Args:
+        ds_pred: Prediction dataset.
+        ds_ref: Reference dataset.
+        variable: Variable name.
+        dims: Image dims (1-D or 2-D supported).
+        periodic: When True, treat ``dims`` as periodic (longitude
+            wrap). When False the search is still circular but the
+            shift is reported in ``[-N/2, N/2)``; large shifts in
+            non-periodic data should be interpreted with care.
+
+    Returns:
+        Dataset with one ``"shift_<dim>"`` variable per image dim and
+        a ``"residual_rmse"`` variable.
+    """
+    core = _normalize_dims(dims)
+    if len(core) not in (1, 2):
+        raise ValueError("phase_shift_error supports 1-D or 2-D image dims only.")
+    da_p = ds_pred[variable]
+    da_r = ds_ref[variable]
+    rest = [d for d in da_p.dims if d not in core]
+    p = da_p.transpose(*rest, *core).values
+    r = da_r.transpose(*rest, *core).values
+    rest_shape = p.shape[: len(rest)]
+    img_shape = p.shape[len(rest) :]
+    p_flat = p.reshape(-1, *img_shape)
+    r_flat = r.reshape(-1, *img_shape)
+
+    fft = np.fft.fftn
+    ifft = np.fft.ifftn
+    cross = ifft(
+        fft(p_flat, axes=tuple(range(1, 1 + len(core))))
+        * np.conj(fft(r_flat, axes=tuple(range(1, 1 + len(core))))),
+        axes=tuple(range(1, 1 + len(core))),
+    ).real
+
+    shifts: list[np.ndarray] = []
+    residuals = []
+    for i in range(cross.shape[0]):
+        peak = np.unravel_index(np.argmax(cross[i]), img_shape)
+        # Wrap to signed shift if not periodic.
+        signed = []
+        for ax, n in enumerate(img_shape):
+            s = peak[ax]
+            if not periodic and s > n // 2:
+                s = s - n
+            signed.append(s)
+        shifts.append(np.array(signed))
+        # residual RMSE after applying the shift to pred.
+        aligned = np.roll(
+            p_flat[i],
+            shift=tuple(-int(s) for s in signed),
+            axis=tuple(range(len(core))),
+        )
+        residuals.append(float(np.sqrt(np.nanmean((aligned - r_flat[i]) ** 2))))
+
+    shifts_arr = np.stack(shifts)  # (rest, n_dims)
+    rest_dims = tuple(rest)
+    coords = {
+        name: coord
+        for name, coord in da_p.coords.items()
+        if set(coord.dims).issubset(set(rest_dims))
+    }
+    out = xr.Dataset(coords=coords)
+    for ax, d in enumerate(core):
+        arr = (
+            shifts_arr[:, ax].reshape(rest_shape)
+            if rest_shape
+            else int(shifts_arr[0, ax])
+        )
+        out[f"shift_{d}"] = xr.DataArray(np.asarray(arr), dims=rest_dims)
+    res_arr = (
+        np.array(residuals).reshape(rest_shape) if rest_shape else float(residuals[0])
+    )
+    out["residual_rmse"] = xr.DataArray(np.asarray(res_arr), dims=rest_dims)
+    return out
+
+
+# ---------- Centroid displacement ----------------------------------------
+
+
+def centroid_displacement(
+    objects_pred: xr.Dataset,
+    objects_ref: xr.Dataset,
+    *,
+    dims: tuple[str, str] = ("lat", "lon"),
+) -> xr.Dataset:
+    """Distance between paired object centroids.
+
+    Inputs are labelled-object datasets each carrying a single
+    integer-labelled :class:`xr.DataArray` (one variable, ``label``
+    field; 0 = background). Pairing is done by label id: label
+    ``k > 0`` in ``objects_pred`` is paired with label ``k`` in
+    ``objects_ref`` if both exist.
+
+    Args:
+        objects_pred: Dataset with a ``"label"`` variable (integer).
+        objects_ref: Same shape & dims, ``"label"`` variable.
+        dims: Pair of physical dims used to compute centroids
+            (default ``("lat", "lon")``).
+
+    Returns:
+        Dataset indexed by ``"object"`` with
+        ``("displacement_lat", "displacement_lon", "distance",
+        "object_id")``. Pairs missing in one side are dropped.
+    """
+    if len(dims) != 2:
+        raise ValueError("centroid_displacement requires two physical dims.")
+    if "label" not in objects_pred.data_vars or "label" not in objects_ref.data_vars:
+        raise ValueError(
+            "Inputs must each carry a 'label' integer DataArray; got "
+            f"pred={list(objects_pred.data_vars)}, ref={list(objects_ref.data_vars)}."
+        )
+    for d in dims:
+        if d not in objects_pred["label"].dims or d not in objects_ref["label"].dims:
+            raise ValueError(
+                f"label DataArrays must carry both dims {dims!r}; got "
+                f"pred dims={objects_pred['label'].dims}, "
+                f"ref dims={objects_ref['label'].dims}."
+            )
+
+    # Force axis order (dims[0], dims[1]) so np.where indexing matches
+    # the coord lookups below regardless of how the input was authored.
+    lab_p = objects_pred["label"].transpose(*dims).values
+    lab_r = objects_ref["label"].transpose(*dims).values
+    coord_a = objects_pred.coords[dims[0]].values
+    coord_b = objects_pred.coords[dims[1]].values
+
+    def _centroids(lab: np.ndarray) -> dict[int, tuple[float, float]]:
+        out: dict[int, tuple[float, float]] = {}
+        ids = np.unique(lab)
+        ids = ids[ids > 0]
+        for i in ids:
+            sel = lab == i
+            # Average coord values within the labelled region.
+            idx_a, idx_b = np.where(sel)
+            out[int(i)] = (float(coord_a[idx_a].mean()), float(coord_b[idx_b].mean()))
+        return out
+
+    cp = _centroids(lab_p)
+    cr = _centroids(lab_r)
+    common = sorted(set(cp) & set(cr))
+
+    if not common:
+        return xr.Dataset(
+            {
+                f"displacement_{dims[0]}": (("object",), np.array([], dtype=float)),
+                f"displacement_{dims[1]}": (("object",), np.array([], dtype=float)),
+                "distance": (("object",), np.array([], dtype=float)),
+                "object_id": (("object",), np.array([], dtype=np.int64)),
+            }
+        )
+
+    da_a = np.array([cp[i][0] - cr[i][0] for i in common])
+    db_a = np.array([cp[i][1] - cr[i][1] for i in common])
+    dist = np.sqrt(da_a**2 + db_a**2)
+    return xr.Dataset(
+        {
+            f"displacement_{dims[0]}": (("object",), da_a),
+            f"displacement_{dims[1]}": (("object",), db_a),
+            "distance": (("object",), dist),
+            "object_id": (("object",), np.array(common, dtype=np.int64)),
+        }
+    )
+
+
+# ---------- Layer-1 -------------------------------------------------------
+
+
+class SSIM(Operator):
+    """Structural-similarity-index operator (scikit-image)."""
+
+    def __init__(
+        self,
+        variable: str,
+        dims: str | Sequence[str],
+        *,
+        window: int | None = None,
+    ) -> None:
+        self.variable = variable
+        self.dims = list(_normalize_dims(dims))
+        self.window = window
+
+    def _apply(self, ds_pred: xr.Dataset, ds_ref: xr.Dataset) -> xr.DataArray:
+        return ssim(
+            ds_pred,
+            ds_ref,
+            variable=self.variable,
+            dims=self.dims,
+            window=self.window,
+        )
+
+    def get_config(self) -> dict[str, Any]:
+        return {
+            "variable": self.variable,
+            "dims": list(self.dims),
+            "window": self.window,
+        }
+
+
+class GradientDifference(Operator):
+    """RMS gradient-difference operator."""
+
+    def __init__(self, variable: str, dims: str | Sequence[str]) -> None:
+        self.variable = variable
+        self.dims = list(_normalize_dims(dims))
+
+    def _apply(self, ds_pred: xr.Dataset, ds_ref: xr.Dataset) -> xr.DataArray:
+        return gradient_difference(
+            ds_pred, ds_ref, variable=self.variable, dims=self.dims
+        )
+
+    def get_config(self) -> dict[str, Any]:
+        return {"variable": self.variable, "dims": list(self.dims)}
+
+
+class PhaseShiftError(Operator):
+    """FFT cross-correlation phase-shift operator."""
+
+    def __init__(
+        self,
+        variable: str,
+        dims: str | Sequence[str],
+        *,
+        periodic: bool = False,
+    ) -> None:
+        self.variable = variable
+        self.dims = list(_normalize_dims(dims))
+        self.periodic = periodic
+
+    def _apply(self, ds_pred: xr.Dataset, ds_ref: xr.Dataset) -> xr.Dataset:
+        return phase_shift_error(
+            ds_pred,
+            ds_ref,
+            variable=self.variable,
+            dims=self.dims,
+            periodic=self.periodic,
+        )
+
+    def get_config(self) -> dict[str, Any]:
+        return {
+            "variable": self.variable,
+            "dims": list(self.dims),
+            "periodic": self.periodic,
+        }
+
+
+class CentroidDisplacement(Operator):
+    """Centroid-displacement operator on labelled-object datasets."""
+
+    def __init__(self, dims: tuple[str, str] = ("lat", "lon")) -> None:
+        self.dims = tuple(dims)
+
+    def _apply(self, objects_pred: xr.Dataset, objects_ref: xr.Dataset) -> xr.Dataset:
+        return centroid_displacement(objects_pred, objects_ref, dims=self.dims)
+
+    def get_config(self) -> dict[str, Any]:
+        return {"dims": list(self.dims)}
+
+
+__all__ = [
+    "SSIM",
+    "CentroidDisplacement",
+    "GradientDifference",
+    "PhaseShiftError",
+    "centroid_displacement",
+    "gradient_difference",
+    "phase_shift_error",
+    "ssim",
+]

--- a/src/xr_toolz/metrics/operators.py
+++ b/src/xr_toolz/metrics/operators.py
@@ -1,11 +1,17 @@
 """Layer-1 ``Operator`` wrappers for evaluation metrics.
 
 This module re-exports the operator classes from
-:mod:`xr_toolz.metrics._src.pixel` and :mod:`xr_toolz.metrics._src.spectral`
-for ergonomic ``from xr_toolz.metrics.operators import RMSE`` access.
+:mod:`xr_toolz.metrics._src.pixel` and friends for ergonomic
+``from xr_toolz.metrics.operators import RMSE`` access.
 """
 
+from xr_toolz.metrics._src.distributional import (
+    CRPS,
+    EnergyDistance,
+    Wasserstein1,
+)
 from xr_toolz.metrics._src.forecast import SkillByLeadTime
+from xr_toolz.metrics._src.masked import MaskedMetric
 from xr_toolz.metrics._src.multiscale import EvaluateByRegion
 from xr_toolz.metrics._src.pixel import (
     MAE,
@@ -16,18 +22,42 @@ from xr_toolz.metrics._src.pixel import (
     Correlation,
     R2Score,
 )
+from xr_toolz.metrics._src.probabilistic import (
+    EnsembleCoverage,
+    RankHistogram,
+    ReliabilityCurve,
+    SpreadSkillRatio,
+)
 from xr_toolz.metrics._src.spectral import PSDScore
+from xr_toolz.metrics._src.structural import (
+    SSIM,
+    CentroidDisplacement,
+    GradientDifference,
+    PhaseShiftError,
+)
 
 
 __all__ = [
+    "CRPS",
     "MAE",
     "MSE",
     "NRMSE",
     "RMSE",
+    "SSIM",
     "Bias",
+    "CentroidDisplacement",
     "Correlation",
+    "EnergyDistance",
+    "EnsembleCoverage",
     "EvaluateByRegion",
+    "GradientDifference",
+    "MaskedMetric",
     "PSDScore",
+    "PhaseShiftError",
     "R2Score",
+    "RankHistogram",
+    "ReliabilityCurve",
     "SkillByLeadTime",
+    "SpreadSkillRatio",
+    "Wasserstein1",
 ]

--- a/tests/test_metrics_imports.py
+++ b/tests/test_metrics_imports.py
@@ -110,6 +110,75 @@ def test_metrics_spectral_submodule_imports():
     _ = (PSDScore, find_intercept_1D, psd_error, resolved_scale)
 
 
+def test_metrics_structural_submodule_imports():
+    from xr_toolz.metrics.structural import (
+        SSIM,
+        CentroidDisplacement,
+        GradientDifference,
+        PhaseShiftError,
+        centroid_displacement,
+        gradient_difference,
+        phase_shift_error,
+        ssim,
+    )
+
+    assert callable(ssim)
+    _ = (
+        SSIM,
+        CentroidDisplacement,
+        GradientDifference,
+        PhaseShiftError,
+        centroid_displacement,
+        gradient_difference,
+        phase_shift_error,
+    )
+
+
+def test_metrics_probabilistic_submodule_imports():
+    from xr_toolz.metrics.probabilistic import (
+        EnsembleCoverage,
+        RankHistogram,
+        ReliabilityCurve,
+        SpreadSkillRatio,
+        ensemble_coverage,
+        rank_histogram,
+        reliability_curve,
+        spread_skill_ratio,
+    )
+
+    assert callable(spread_skill_ratio)
+    _ = (
+        EnsembleCoverage,
+        RankHistogram,
+        ReliabilityCurve,
+        SpreadSkillRatio,
+        ensemble_coverage,
+        rank_histogram,
+        reliability_curve,
+    )
+
+
+def test_metrics_distributional_submodule_imports():
+    from xr_toolz.metrics.distributional import (
+        CRPS,
+        EnergyDistance,
+        Wasserstein1,
+        crps_ensemble,
+        energy_distance,
+        wasserstein_1,
+    )
+
+    assert callable(crps_ensemble)
+    _ = (CRPS, EnergyDistance, Wasserstein1, energy_distance, wasserstein_1)
+
+
+def test_metrics_masked_submodule_imports():
+    from xr_toolz.metrics.masked import MaskedMetric, masked_metric
+
+    assert callable(masked_metric)
+    _ = (MaskedMetric,)
+
+
 def test_metrics_operators_submodule_imports():
     from xr_toolz.metrics.operators import (
         MAE,
@@ -129,10 +198,6 @@ def test_metrics_operators_submodule_imports():
 @pytest.mark.parametrize(
     "submodule",
     [
-        "structural",
-        "probabilistic",
-        "distributional",
-        "masked",
         "physical",
         "lagrangian",
     ],

--- a/tests/test_metrics_v2_data_representation.py
+++ b/tests/test_metrics_v2_data_representation.py
@@ -1,0 +1,388 @@
+"""Tests for V2 (Data Representation Metrics).
+
+Covers:
+- V2.1 structural: SSIM, GradientDifference, PhaseShiftError, CentroidDisplacement
+- V2.2 probabilistic: SpreadSkillRatio, RankHistogram, EnsembleCoverage,
+  ReliabilityCurve
+- V2.3 distributional: CRPS, EnergyDistance, Wasserstein1
+- V2.4 masked: MaskedMetric
+"""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from xr_toolz.metrics import (
+    CRPS,
+    RMSE,
+    SSIM,
+    CentroidDisplacement,
+    EnergyDistance,
+    EnsembleCoverage,
+    GradientDifference,
+    MaskedMetric,
+    PhaseShiftError,
+    RankHistogram,
+    ReliabilityCurve,
+    SpreadSkillRatio,
+    Wasserstein1,
+    masked_metric,
+    phase_shift_error,
+)
+
+
+# =========================================================================
+# V2.4 — Masked
+# =========================================================================
+
+
+def test_masked_metric_matches_manual_where() -> None:
+    rng = np.random.default_rng(0)
+    pred = rng.standard_normal((4, 5))
+    ref = rng.standard_normal((4, 5))
+    coords = {"lat": np.arange(4), "lon": np.arange(5)}
+    ds_p = xr.Dataset({"x": (("lat", "lon"), pred)}, coords=coords)
+    ds_r = xr.Dataset({"x": (("lat", "lon"), ref)}, coords=coords)
+    mask = xr.DataArray(
+        np.array([[True] * 3 + [False] * 2] * 4),
+        dims=("lat", "lon"),
+        coords=coords,
+    )
+    inner = RMSE("x", ("lat", "lon"))
+    op = MaskedMetric(inner, mask=mask)
+    out = op(ds_p, ds_r)
+    expected = inner(ds_p.where(mask), ds_r.where(mask))
+    np.testing.assert_allclose(out.values, expected.values)
+
+
+def test_masked_metric_per_call_mask_overrides() -> None:
+    rng = np.random.default_rng(1)
+    pred = rng.standard_normal((6,))
+    ref = rng.standard_normal((6,))
+    ds_p = xr.Dataset({"x": (("t",), pred)})
+    ds_r = xr.Dataset({"x": (("t",), ref)})
+    op = MaskedMetric(RMSE("x", "t"))
+    mask = xr.DataArray([True, True, False, False, True, True], dims="t")
+    out = op(ds_p, ds_r, mask=mask)
+    expected = RMSE("x", "t")(ds_p.where(mask), ds_r.where(mask))
+    np.testing.assert_allclose(out.values, expected.values)
+
+
+def test_masked_metric_no_mask_raises() -> None:
+    op = MaskedMetric(RMSE("x", "t"))
+    ds = xr.Dataset({"x": (("t",), np.zeros(3))})
+    with pytest.raises(ValueError, match="requires a mask"):
+        op(ds, ds)
+
+
+def test_masked_metric_get_config_json_safe() -> None:
+    op = MaskedMetric(RMSE("x", "t"))
+    cfg = op.get_config()
+    assert cfg["metric"]["class"] == "RMSE"
+    assert cfg["mask"] is None
+    assert json.loads(json.dumps(cfg)) == cfg
+
+
+def test_masked_metric_layer0_function() -> None:
+    rng = np.random.default_rng(2)
+    ds_p = xr.Dataset({"x": (("t",), rng.standard_normal(8))})
+    ds_r = xr.Dataset({"x": (("t",), rng.standard_normal(8))})
+    mask = xr.DataArray([True] * 4 + [False] * 4, dims="t")
+    out = masked_metric(ds_p, ds_r, metric=RMSE("x", "t"), mask=mask)
+    expected = RMSE("x", "t")(ds_p.where(mask), ds_r.where(mask))
+    np.testing.assert_allclose(out.values, expected.values)
+
+
+# =========================================================================
+# V2.3 — Distributional
+# =========================================================================
+
+
+@pytest.fixture
+def ensemble_pair() -> tuple[xr.Dataset, xr.Dataset]:
+    rng = np.random.default_rng(42)
+    truth = rng.standard_normal((10,))
+    ens = truth[None, :] + rng.standard_normal((20, 10))  # 20 members
+    ds_e = xr.Dataset(
+        {"x": (("member", "t"), ens)},
+        coords={"member": np.arange(20), "t": np.arange(10)},
+    )
+    ds_r = xr.Dataset({"x": (("t",), truth)}, coords={"t": np.arange(10)})
+    return ds_e, ds_r
+
+
+def test_crps_against_xskillscore(ensemble_pair) -> None:
+    import xskillscore as xs
+
+    ds_e, ds_r = ensemble_pair
+    op = CRPS("x")
+    out = op(ds_e, ds_r)
+    expected = xs.crps_ensemble(ds_r["x"], ds_e["x"], member_dim="member", dim=[])
+    np.testing.assert_allclose(out.values, expected.values)
+
+
+def test_energy_distance_identical_samples_zero() -> None:
+    rng = np.random.default_rng(3)
+    samples = rng.standard_normal((50, 4))
+    ds_a = xr.Dataset({"x": (("member", "t"), samples)})
+    ds_b = xr.Dataset({"x": (("member", "t"), samples.copy())})
+    out = EnergyDistance("x")(ds_a, ds_b)
+    np.testing.assert_allclose(out.values, 0.0, atol=1e-10)
+
+
+def test_energy_distance_separated_distributions() -> None:
+    rng = np.random.default_rng(4)
+    a = rng.standard_normal((500, 1))
+    b = rng.standard_normal((500, 1)) + 5.0
+    ds_a = xr.Dataset({"x": (("member", "t"), a)})
+    ds_b = xr.Dataset({"x": (("member", "t"), b)})
+    out = EnergyDistance("x")(ds_a, ds_b)
+    # Well-separated: energy distance grows with the gap.
+    assert float(out.values.item()) > 1.0
+
+
+def test_wasserstein_1_identical_samples_zero() -> None:
+    rng = np.random.default_rng(5)
+    samples = rng.standard_normal((50, 3))
+    ds = xr.Dataset({"x": (("member", "t"), samples)})
+    out = Wasserstein1("x")(ds, ds)
+    np.testing.assert_allclose(out.values, 0.0, atol=1e-10)
+
+
+def test_wasserstein_1_recovers_shift() -> None:
+    rng = np.random.default_rng(6)
+    a = rng.standard_normal((1000, 1))
+    b = a + 3.0
+    ds_a = xr.Dataset({"x": (("member", "t"), a)})
+    ds_b = xr.Dataset({"x": (("member", "t"), b)})
+    out = Wasserstein1("x")(ds_a, ds_b)
+    np.testing.assert_allclose(out.values, 3.0, atol=0.1)
+
+
+def test_distributional_get_config_json() -> None:
+    cfg = CRPS("x", ensemble_dim="ens", dims=("t",)).get_config()
+    assert cfg == {"variable": "x", "ensemble_dim": "ens", "dims": ["t"]}
+    assert json.loads(json.dumps(cfg)) == cfg
+
+
+# =========================================================================
+# V2.2 — Probabilistic
+# =========================================================================
+
+
+def test_spread_skill_ratio_calibrated_ensemble() -> None:
+    """Calibrated ensemble: truth and members drawn from the same dist.
+
+    Population spread/skill = sqrt(N/(N+1)).
+    """
+    rng = np.random.default_rng(7)
+    n_t = 5000
+    n_m = 30
+    truth = rng.standard_normal(n_t)
+    members = rng.standard_normal((n_m, n_t))
+    ds_e = xr.Dataset(
+        {"x": (("member", "t"), members)},
+        coords={"member": np.arange(n_m), "t": np.arange(n_t)},
+    )
+    ds_r = xr.Dataset({"x": (("t",), truth)}, coords={"t": np.arange(n_t)})
+    out = SpreadSkillRatio("x")(ds_e, ds_r)
+    expected = np.sqrt(n_m / (n_m + 1))
+    np.testing.assert_allclose(float(out.values), expected, rtol=0.05)
+
+
+def test_rank_histogram_calibrated_ensemble_uniform() -> None:
+    rng = np.random.default_rng(8)
+    n_t, n_m = 4000, 20
+    truth = rng.standard_normal(n_t)
+    ens = rng.standard_normal((n_m, n_t))
+    ds_e = xr.Dataset({"x": (("member", "t"), ens)})
+    ds_r = xr.Dataset({"x": (("t",), truth)})
+    out = RankHistogram("x")(ds_e, ds_r)
+    counts = out["rank_count"].values
+    expected = n_t / (n_m + 1)
+    # χ²-like sanity: every bin within ~30% of expected.
+    assert (np.abs(counts - expected) / expected < 0.3).all()
+
+
+def test_ensemble_coverage_calibrated() -> None:
+    rng = np.random.default_rng(9)
+    n_t, n_m = 5000, 50
+    truth = rng.standard_normal(n_t)
+    ens = rng.standard_normal((n_m, n_t))
+    ds_e = xr.Dataset({"x": (("member", "t"), ens)})
+    ds_r = xr.Dataset({"x": (("t",), truth)})
+    out = EnsembleCoverage("x", q=(0.05, 0.95))(ds_e, ds_r)
+    np.testing.assert_allclose(float(out.values), 0.9, atol=0.05)
+
+
+def test_reliability_curve_perfectly_calibrated() -> None:
+    rng = np.random.default_rng(10)
+    n = 20000
+    p = rng.uniform(size=n)
+    o = (rng.uniform(size=n) < p).astype(float)
+    ds_p = xr.Dataset({"x": (("i",), p)})
+    ds_o = xr.Dataset({"x": (("i",), o)})
+    out = ReliabilityCurve("x")(ds_p, ds_o)
+    fc = out["forecast_probability"].values
+    obf = out["observed_frequency"].values
+    # Observed frequency tracks forecast probability bin-by-bin.
+    np.testing.assert_allclose(obf, fc, atol=0.03)
+
+
+def test_probabilistic_missing_member_dim_raises() -> None:
+    ds_e = xr.Dataset({"x": (("t",), np.zeros(5))})
+    ds_r = xr.Dataset({"x": (("t",), np.zeros(5))})
+    with pytest.raises(ValueError, match="ensemble dim"):
+        SpreadSkillRatio("x")(ds_e, ds_r)
+
+
+def test_ensemble_coverage_invalid_q() -> None:
+    rng = np.random.default_rng(11)
+    ds_e = xr.Dataset({"x": (("member", "t"), rng.standard_normal((5, 3)))})
+    ds_r = xr.Dataset({"x": (("t",), np.zeros(3))})
+    with pytest.raises(ValueError, match="q must be"):
+        EnsembleCoverage("x", q=(0.95, 0.05))(ds_e, ds_r)
+
+
+# =========================================================================
+# V2.1 — Structural
+# =========================================================================
+
+
+def test_gradient_difference_constant_field_zero() -> None:
+    """Constant fields have zero gradient — gradient difference is 0."""
+    n = 8
+    coords = {"lat": np.arange(n), "lon": np.arange(n)}
+    ds_p = xr.Dataset({"x": (("lat", "lon"), np.full((n, n), 3.0))}, coords=coords)
+    ds_r = xr.Dataset({"x": (("lat", "lon"), np.full((n, n), 7.0))}, coords=coords)
+    out = GradientDifference("x", ("lat", "lon"))(ds_p, ds_r)
+    np.testing.assert_allclose(float(out.values), 0.0, atol=1e-10)
+
+
+def test_gradient_difference_step_proportional() -> None:
+    n = 16
+    coords = {"lat": np.arange(n), "lon": np.arange(n)}
+    flat = np.zeros((n, n))
+    step = np.zeros((n, n))
+    step[:, n // 2 :] = 1.0
+    ds_p = xr.Dataset({"x": (("lat", "lon"), flat)}, coords=coords)
+    ds_r = xr.Dataset({"x": (("lat", "lon"), step)}, coords=coords)
+    out_step = float(GradientDifference("x", ("lat", "lon"))(ds_p, ds_r).values)
+    ds_r2 = xr.Dataset({"x": (("lat", "lon"), 2.0 * step)}, coords=coords)
+    out_step2 = float(GradientDifference("x", ("lat", "lon"))(ds_p, ds_r2).values)
+    np.testing.assert_allclose(out_step2, 2.0 * out_step, rtol=1e-6)
+
+
+def test_phase_shift_error_recovers_1d_shift() -> None:
+    n = 64
+    x = np.arange(n)
+    sig = np.sin(2 * np.pi * x / 16)
+    shift = 5
+    sig_shifted = np.roll(sig, shift)
+    ds_p = xr.Dataset({"x": (("t",), sig_shifted)}, coords={"t": x})
+    ds_r = xr.Dataset({"x": (("t",), sig)}, coords={"t": x})
+    out = PhaseShiftError("x", "t", periodic=True)(ds_p, ds_r)
+    assert int(out["shift_t"].values) == shift
+    np.testing.assert_allclose(float(out["residual_rmse"].values), 0.0, atol=1e-10)
+
+
+def test_phase_shift_error_2d_periodic() -> None:
+    """Use a single Gaussian blob — non-periodic feature → unique correlation peak."""
+    n = 32
+    yy, xx = np.meshgrid(np.arange(n), np.arange(n), indexing="ij")
+    blob = np.exp(-((xx - n // 2) ** 2 + (yy - n // 2) ** 2) / 8.0)
+    shifted = np.roll(blob, shift=(3, -4), axis=(0, 1))
+    coords = {"lat": np.arange(n), "lon": np.arange(n)}
+    ds_p = xr.Dataset({"x": (("lat", "lon"), shifted)}, coords=coords)
+    ds_r = xr.Dataset({"x": (("lat", "lon"), blob)}, coords=coords)
+    out = phase_shift_error(
+        ds_p, ds_r, variable="x", dims=("lat", "lon"), periodic=False
+    )
+    assert int(out["shift_lat"].values) == 3
+    assert int(out["shift_lon"].values) == -4
+
+
+def test_centroid_displacement_paired_blobs() -> None:
+    n = 20
+    coords = {"lat": np.arange(n, dtype=float), "lon": np.arange(n, dtype=float)}
+    lab_p = np.zeros((n, n), dtype=np.int64)
+    lab_r = np.zeros((n, n), dtype=np.int64)
+    # Object 1: 3x3 block at (5,5) in pred, (5,7) in ref → lon shift = -2
+    lab_p[5:8, 5:8] = 1
+    lab_r[5:8, 7:10] = 1
+    # Object 2: only in pred — should be dropped.
+    lab_p[15:17, 15:17] = 2
+    op_p = xr.Dataset({"label": (("lat", "lon"), lab_p)}, coords=coords)
+    op_r = xr.Dataset({"label": (("lat", "lon"), lab_r)}, coords=coords)
+    out = CentroidDisplacement(("lat", "lon"))(op_p, op_r)
+    assert out.sizes["object"] == 1
+    assert int(out["object_id"].values[0]) == 1
+    np.testing.assert_allclose(float(out["displacement_lon"].values[0]), -2.0)
+    np.testing.assert_allclose(float(out["displacement_lat"].values[0]), 0.0)
+
+
+def test_centroid_displacement_no_common_objects() -> None:
+    n = 10
+    coords = {"lat": np.arange(n, dtype=float), "lon": np.arange(n, dtype=float)}
+    lab_p = np.zeros((n, n), dtype=np.int64)
+    lab_r = np.zeros((n, n), dtype=np.int64)
+    lab_p[1, 1] = 1
+    lab_r[5, 5] = 2
+    op_p = xr.Dataset({"label": (("lat", "lon"), lab_p)}, coords=coords)
+    op_r = xr.Dataset({"label": (("lat", "lon"), lab_r)}, coords=coords)
+    out = CentroidDisplacement(("lat", "lon"))(op_p, op_r)
+    assert out.sizes["object"] == 0
+
+
+def test_ssim_identical_inputs_one() -> None:
+    rng = np.random.default_rng(12)
+    img = rng.standard_normal((32, 32))
+    coords = {"lat": np.arange(32), "lon": np.arange(32)}
+    ds = xr.Dataset({"x": (("lat", "lon"), img)}, coords=coords)
+    out = SSIM("x", ("lat", "lon"))(ds, ds)
+    np.testing.assert_allclose(float(out.values), 1.0, atol=1e-10)
+
+
+def test_ssim_uncorrelated_noise_low() -> None:
+    rng = np.random.default_rng(13)
+    coords = {"lat": np.arange(32), "lon": np.arange(32)}
+    ds_p = xr.Dataset(
+        {"x": (("lat", "lon"), rng.standard_normal((32, 32)))}, coords=coords
+    )
+    ds_r = xr.Dataset(
+        {"x": (("lat", "lon"), rng.standard_normal((32, 32)))}, coords=coords
+    )
+    out = SSIM("x", ("lat", "lon"))(ds_p, ds_r)
+    assert abs(float(out.values)) < 0.3
+
+
+def test_structural_get_config_json_safe() -> None:
+    cfg = SSIM("x", ("lat", "lon"), window=7).get_config()
+    assert json.loads(json.dumps(cfg)) == cfg
+    cfg2 = PhaseShiftError("x", ("lat", "lon"), periodic=True).get_config()
+    assert json.loads(json.dumps(cfg2)) == cfg2
+
+
+# =========================================================================
+# Composition (V2.4 inside Graph)
+# =========================================================================
+
+
+def test_masked_metric_inside_graph() -> None:
+    from xr_toolz.core import Graph, Input
+
+    rng = np.random.default_rng(14)
+    ds_p = xr.Dataset({"x": (("t",), rng.standard_normal(8))})
+    ds_r = xr.Dataset({"x": (("t",), rng.standard_normal(8))})
+    mask = xr.DataArray([True] * 4 + [False] * 4, dims="t")
+    p = Input("p")
+    r = Input("r")
+    out = MaskedMetric(RMSE("x", "t"), mask=mask)(p, r)
+    g = Graph(inputs={"p": p, "r": r}, outputs={"y": out})
+    res = g(p=ds_p, r=ds_r)
+    expected = RMSE("x", "t")(ds_p.where(mask), ds_r.where(mask))
+    np.testing.assert_allclose(res["y"].values, expected.values)

--- a/uv.lock
+++ b/uv.lock
@@ -776,6 +776,19 @@ wheels = [
 ]
 
 [[package]]
+name = "imageio"
+version = "2.37.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pillow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/84/93bcd1300216ea50811cee96873b84a1bebf8d0489ffaf7f2a3756bab866/imageio-2.37.3.tar.gz", hash = "sha256:bbb37efbfc4c400fcd534b367b91fcd66d5da639aaa138034431a1c5e0a41451", size = 389673, upload-time = "2026-03-09T11:31:12.573Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/fa/391e437a34e55095173dca5f24070d89cbc233ff85bf1c29c93248c6588d/imageio-2.37.3-py3-none-any.whl", hash = "sha256:46f5bb8522cd421c0f5ae104d8268f569d856b29eb1a13b92829d1970f32c9f0", size = 317646, upload-time = "2026-03-09T11:31:10.771Z" },
+]
+
+[[package]]
 name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1097,6 +1110,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/41/c5f71f9f00aabcc71fee8b7475e3f64747282580c2fe748961ba29b18385/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:f6764a4ccab3078db14a632420930f6186058750df066b8ea2a7106df91d3203", size = 138036, upload-time = "2026-03-09T13:15:36.894Z" },
     { url = "https://files.pythonhosted.org/packages/fa/06/7399a607f434119c6e1fdc8ec89a8d51ccccadf3341dee4ead6bd14caaf5/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c31c13da98624f957b0fb1b5bae5383b2333c2c3f6793d9825dd5ce79b525cb7", size = 194295, upload-time = "2026-03-09T13:15:38.22Z" },
     { url = "https://files.pythonhosted.org/packages/b5/91/53255615acd2a1eaca307ede3c90eb550bae9c94581f8c00081b6b1c8f44/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-win_amd64.whl", hash = "sha256:1f1489f769582498610e015a8ef2d36f28f505ab3096d0e16b4858a9ec214f57", size = 75987, upload-time = "2026-03-09T13:15:39.65Z" },
+]
+
+[[package]]
+name = "lazy-loader"
+version = "0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/ac/21a1f8aa3777f5658576777ea76bfb124b702c520bbe90edf4ae9915eafa/lazy_loader-0.5.tar.gz", hash = "sha256:717f9179a0dbed357012ddad50a5ad3d5e4d9a0b8712680d4e687f5e6e6ed9b3", size = 15294, upload-time = "2026-03-06T15:45:09.054Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/a1/8d812e53a5da1687abb10445275d41a8b13adb781bbf7196ddbcf8d88505/lazy_loader-0.5-py3-none-any.whl", hash = "sha256:ab0ea149e9c554d4ffeeb21105ac60bed7f3b4fd69b1d2360a4add51b170b005", size = 8044, upload-time = "2026-03-06T15:45:07.668Z" },
 ]
 
 [[package]]
@@ -1559,6 +1584,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
+]
+
+[[package]]
+name = "networkx"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
 ]
 
 [[package]]
@@ -2616,6 +2650,64 @@ wheels = [
 ]
 
 [[package]]
+name = "scikit-image"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "imageio" },
+    { name = "lazy-loader" },
+    { name = "networkx" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "scipy" },
+    { name = "tifffile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/b4/2528bb43c67d48053a7a649a9666432dc307d66ba02e3a6d5c40f46655df/scikit_image-0.26.0.tar.gz", hash = "sha256:f5f970ab04efad85c24714321fcc91613fcb64ef2a892a13167df2f3e59199fa", size = 22729739, upload-time = "2025-12-20T17:12:21.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/e8/e13757982264b33a1621628f86b587e9a73a13f5256dad49b19ba7dc9083/scikit_image-0.26.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d454b93a6fa770ac5ae2d33570f8e7a321bb80d29511ce4b6b78058ebe176e8c", size = 12376452, upload-time = "2025-12-20T17:10:52.796Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/be/f8dd17d0510f9911f9f17ba301f7455328bf13dae416560126d428de9568/scikit_image-0.26.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3409e89d66eff5734cd2b672d1c48d2759360057e714e1d92a11df82c87cba37", size = 12061567, upload-time = "2025-12-20T17:10:55.207Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/2b/c70120a6880579fb42b91567ad79feb4772f7be72e8d52fec403a3dde0c6/scikit_image-0.26.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4c717490cec9e276afb0438dd165b7c3072d6c416709cc0f9f5a4c1070d23a44", size = 13084214, upload-time = "2025-12-20T17:10:57.468Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/a2/70401a107d6d7466d64b466927e6b96fcefa99d57494b972608e2f8be50f/scikit_image-0.26.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7df650e79031634ac90b11e64a9eedaf5a5e06fcd09bcd03a34be01745744466", size = 13561683, upload-time = "2025-12-20T17:10:59.49Z" },
+    { url = "https://files.pythonhosted.org/packages/13/a5/48bdfd92794c5002d664e0910a349d0a1504671ef5ad358150f21643c79a/scikit_image-0.26.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:cefd85033e66d4ea35b525bb0937d7f42d4cdcfed2d1888e1570d5ce450d3932", size = 14112147, upload-time = "2025-12-20T17:11:02.083Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/b5/ac71694da92f5def5953ca99f18a10fe98eac2dd0a34079389b70b4d0394/scikit_image-0.26.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3f5bf622d7c0435884e1e141ebbe4b2804e16b2dd23ae4c6183e2ea99233be70", size = 14661625, upload-time = "2025-12-20T17:11:04.528Z" },
+    { url = "https://files.pythonhosted.org/packages/23/4d/a3cc1e96f080e253dad2251bfae7587cf2b7912bcd76fd43fd366ff35a87/scikit_image-0.26.0-cp312-cp312-win_amd64.whl", hash = "sha256:abed017474593cd3056ae0fe948d07d0747b27a085e92df5474f4955dd65aec0", size = 11911059, upload-time = "2025-12-20T17:11:06.61Z" },
+    { url = "https://files.pythonhosted.org/packages/35/8a/d1b8055f584acc937478abf4550d122936f420352422a1a625eef2c605d8/scikit_image-0.26.0-cp312-cp312-win_arm64.whl", hash = "sha256:4d57e39ef67a95d26860c8caf9b14b8fb130f83b34c6656a77f191fa6d1d04d8", size = 11348740, upload-time = "2025-12-20T17:11:09.118Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/48/02357ffb2cca35640f33f2cfe054a4d6d5d7a229b88880a64f1e45c11f4e/scikit_image-0.26.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a2e852eccf41d2d322b8e60144e124802873a92b8d43a6f96331aa42888491c7", size = 12346329, upload-time = "2025-12-20T17:11:11.599Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b9/b792c577cea2c1e94cda83b135a656924fc57c428e8a6d302cd69aac1b60/scikit_image-0.26.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:98329aab3bc87db352b9887f64ce8cdb8e75f7c2daa19927f2e121b797b678d5", size = 12031726, upload-time = "2025-12-20T17:11:13.871Z" },
+    { url = "https://files.pythonhosted.org/packages/07/a9/9564250dfd65cb20404a611016db52afc6268b2b371cd19c7538ea47580f/scikit_image-0.26.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:915bb3ba66455cf8adac00dc8fdf18a4cd29656aec7ddd38cb4dda90289a6f21", size = 13094910, upload-time = "2025-12-20T17:11:16.2Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/b8/0d8eeb5a9fd7d34ba84f8a55753a0a3e2b5b51b2a5a0ade648a8db4a62f7/scikit_image-0.26.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b36ab5e778bf50af5ff386c3ac508027dc3aaeccf2161bdf96bde6848f44d21b", size = 13660939, upload-time = "2025-12-20T17:11:18.464Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/d6/91d8973584d4793d4c1a847d388e34ef1218d835eeddecfc9108d735b467/scikit_image-0.26.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:09bad6a5d5949c7896c8347424c4cca899f1d11668030e5548813ab9c2865dcb", size = 14138938, upload-time = "2025-12-20T17:11:20.919Z" },
+    { url = "https://files.pythonhosted.org/packages/39/9a/7e15d8dc10d6bbf212195fb39bdeb7f226c46dd53f9c63c312e111e2e175/scikit_image-0.26.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:aeb14db1ed09ad4bee4ceb9e635547a8d5f3549be67fc6c768c7f923e027e6cd", size = 14752243, upload-time = "2025-12-20T17:11:23.347Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/58/2b11b933097bc427e42b4a8b15f7de8f24f2bac1fd2779d2aea1431b2c31/scikit_image-0.26.0-cp313-cp313-win_amd64.whl", hash = "sha256:ac529eb9dbd5954f9aaa2e3fe9a3fd9661bfe24e134c688587d811a0233127f1", size = 11906770, upload-time = "2025-12-20T17:11:25.297Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/ec/96941474a18a04b69b6f6562a5bd79bd68049fa3728d3b350976eccb8b93/scikit_image-0.26.0-cp313-cp313-win_arm64.whl", hash = "sha256:a2d211bc355f59725efdcae699b93b30348a19416cc9e017f7b2fb599faf7219", size = 11342506, upload-time = "2025-12-20T17:11:27.399Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e5/c1a9962b0cf1952f42d32b4a2e48eed520320dbc4d2ff0b981c6fa508b6b/scikit_image-0.26.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:9eefb4adad066da408a7601c4c24b07af3b472d90e08c3e7483d4e9e829d8c49", size = 12663278, upload-time = "2025-12-20T17:11:29.358Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/97/c1a276a59ce8e4e24482d65c1a3940d69c6b3873279193b7ebd04e5ee56b/scikit_image-0.26.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:6caec76e16c970c528d15d1c757363334d5cb3069f9cea93d2bead31820511f3", size = 12405142, upload-time = "2025-12-20T17:11:31.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/4a/f1cbd1357caef6c7993f7efd514d6e53d8fd6f7fe01c4714d51614c53289/scikit_image-0.26.0-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a07200fe09b9d99fcdab959859fe0f7db8df6333d6204344425d476850ce3604", size = 12942086, upload-time = "2025-12-20T17:11:33.683Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/6f/74d9fb87c5655bd64cf00b0c44dc3d6206d9002e5f6ba1c9aeb13236f6bf/scikit_image-0.26.0-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:92242351bccf391fc5df2d1529d15470019496d2498d615beb68da85fe7fdf37", size = 13265667, upload-time = "2025-12-20T17:11:36.11Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/73/faddc2413ae98d863f6fa2e3e14da4467dd38e788e1c23346cf1a2b06b97/scikit_image-0.26.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:52c496f75a7e45844d951557f13c08c81487c6a1da2e3c9c8a39fcde958e02cc", size = 14001966, upload-time = "2025-12-20T17:11:38.55Z" },
+    { url = "https://files.pythonhosted.org/packages/02/94/9f46966fa042b5d57c8cd641045372b4e0df0047dd400e77ea9952674110/scikit_image-0.26.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:20ef4a155e2e78b8ab973998e04d8a361d49d719e65412405f4dadd9155a61d9", size = 14359526, upload-time = "2025-12-20T17:11:41.087Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/b4/2840fe38f10057f40b1c9f8fb98a187a370936bf144a4ac23452c5ef1baf/scikit_image-0.26.0-cp313-cp313t-win_amd64.whl", hash = "sha256:c9087cf7d0e7f33ab5c46d2068d86d785e70b05400a891f73a13400f1e1faf6a", size = 12287629, upload-time = "2025-12-20T17:11:43.11Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ba/73b6ca70796e71f83ab222690e35a79612f0117e5aaf167151b7d46f5f2c/scikit_image-0.26.0-cp313-cp313t-win_arm64.whl", hash = "sha256:27d58bc8b2acd351f972c6508c1b557cfed80299826080a4d803dd29c51b707e", size = 11647755, upload-time = "2025-12-20T17:11:45.279Z" },
+    { url = "https://files.pythonhosted.org/packages/51/44/6b744f92b37ae2833fd423cce8f806d2368859ec325a699dc30389e090b9/scikit_image-0.26.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:63af3d3a26125f796f01052052f86806da5b5e54c6abef152edb752683075a9c", size = 12365810, upload-time = "2025-12-20T17:11:47.357Z" },
+    { url = "https://files.pythonhosted.org/packages/40/f5/83590d9355191f86ac663420fec741b82cc547a4afe7c4c1d986bf46e4db/scikit_image-0.26.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ce00600cd70d4562ed59f80523e18cdcc1fae0e10676498a01f73c255774aefd", size = 12075717, upload-time = "2025-12-20T17:11:49.483Z" },
+    { url = "https://files.pythonhosted.org/packages/72/48/253e7cf5aee6190459fe136c614e2cbccc562deceb4af96e0863f1b8ee29/scikit_image-0.26.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6381edf972b32e4f54085449afde64365a57316637496c1325a736987083e2ab", size = 13161520, upload-time = "2025-12-20T17:11:51.58Z" },
+    { url = "https://files.pythonhosted.org/packages/73/c3/cec6a3cbaadfdcc02bd6ff02f3abfe09eaa7f4d4e0a525a1e3a3f4bce49c/scikit_image-0.26.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c6624a76c6085218248154cc7e1500e6b488edcd9499004dd0d35040607d7505", size = 13684340, upload-time = "2025-12-20T17:11:53.708Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/0d/39a776f675d24164b3a267aa0db9f677a4cb20127660d8bf4fd7fef66817/scikit_image-0.26.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f775f0e420faac9c2aa6757135f4eb468fb7b70e0b67fa77a5e79be3c30ee331", size = 14203839, upload-time = "2025-12-20T17:11:55.89Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/25/2514df226bbcedfe9b2caafa1ba7bc87231a0c339066981b182b08340e06/scikit_image-0.26.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede4d6d255cc5da9faeb2f9ba7fedbc990abbc652db429f40a16b22e770bb578", size = 14770021, upload-time = "2025-12-20T17:11:58.014Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/5b/0671dc91c0c79340c3fe202f0549c7d3681eb7640fe34ab68a5f090a7c7f/scikit_image-0.26.0-cp314-cp314-win_amd64.whl", hash = "sha256:0660b83968c15293fd9135e8d860053ee19500d52bf55ca4fb09de595a1af650", size = 12023490, upload-time = "2025-12-20T17:12:00.013Z" },
+    { url = "https://files.pythonhosted.org/packages/65/08/7c4cb59f91721f3de07719085212a0b3962e3e3f2d1818cbac4eeb1ea53e/scikit_image-0.26.0-cp314-cp314-win_arm64.whl", hash = "sha256:b8d14d3181c21c11170477a42542c1addc7072a90b986675a71266ad17abc37f", size = 11473782, upload-time = "2025-12-20T17:12:01.983Z" },
+    { url = "https://files.pythonhosted.org/packages/49/41/65c4258137acef3d73cb561ac55512eacd7b30bb4f4a11474cad526bc5db/scikit_image-0.26.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:cde0bbd57e6795eba83cb10f71a677f7239271121dc950bc060482834a668ad1", size = 12686060, upload-time = "2025-12-20T17:12:03.886Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/32/76971f8727b87f1420a962406388a50e26667c31756126444baf6668f559/scikit_image-0.26.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:163e9afb5b879562b9aeda0dd45208a35316f26cc7a3aed54fd601604e5cf46f", size = 12422628, upload-time = "2025-12-20T17:12:05.921Z" },
+    { url = "https://files.pythonhosted.org/packages/37/0d/996febd39f757c40ee7b01cdb861867327e5c8e5f595a634e8201462d958/scikit_image-0.26.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:724f79fd9b6cb6f4a37864fe09f81f9f5d5b9646b6868109e1b100d1a7019e59", size = 12962369, upload-time = "2025-12-20T17:12:07.912Z" },
+    { url = "https://files.pythonhosted.org/packages/48/b4/612d354f946c9600e7dea012723c11d47e8d455384e530f6daaaeb9bf62c/scikit_image-0.26.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3268f13310e6857508bd87202620df996199a016a1d281b309441d227c822394", size = 13272431, upload-time = "2025-12-20T17:12:10.255Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/6e/26c00b466e06055a086de2c6e2145fe189ccdc9a1d11ccc7de020f2591ad/scikit_image-0.26.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fac96a1f9b06cd771cbbb3cd96c5332f36d4efd839b1d8b053f79e5887acde62", size = 14016362, upload-time = "2025-12-20T17:12:12.793Z" },
+    { url = "https://files.pythonhosted.org/packages/47/88/00a90402e1775634043c2a0af8a3c76ad450866d9fa444efcc43b553ba2d/scikit_image-0.26.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2c1e7bd342f43e7a97e571b3f03ba4c1293ea1a35c3f13f41efdc8a81c1dc8f2", size = 14364151, upload-time = "2025-12-20T17:12:14.909Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ca/918d8d306bd43beacff3b835c6d96fac0ae64c0857092f068b88db531a7c/scikit_image-0.26.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b702c3bb115e1dcf4abf5297429b5c90f2189655888cbed14921f3d26f81d3a4", size = 12413484, upload-time = "2025-12-20T17:12:17.046Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/cd/4da01329b5a8d47ff7ec3c99a2b02465a8017b186027590dc7425cee0b56/scikit_image-0.26.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0608aa4a9ec39e0843de10d60edb2785a30c1c47819b67866dd223ebd149acaf", size = 11769501, upload-time = "2025-12-20T17:12:19.339Z" },
+]
+
+[[package]]
 name = "scikit-learn"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2855,6 +2947,18 @@ wheels = [
 ]
 
 [[package]]
+name = "tifffile"
+version = "2026.4.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d7/4a/e687f5957fead200faad58dbf9c9431a2bbb118040e96f5fb8a55f7ebc50/tifffile-2026.4.11.tar.gz", hash = "sha256:17758ff0c0d4db385792a083ad3ca51fcb0f4d942642f4d8f8bc1287fdcf17bc", size = 394956, upload-time = "2026-04-12T01:57:28.793Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/9f/74f110b4271ded519c7add4341cbabc824de26817ff1c345b3109df9e99c/tifffile-2026.4.11-py3-none-any.whl", hash = "sha256:9b94ffeddb39e97601af646345e8808f885773de01b299e480ed6d3a41509ec9", size = 248227, upload-time = "2026-04-12T01:57:26.969Z" },
+]
+
+[[package]]
 name = "tinycss2"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3084,6 +3188,7 @@ dependencies = [
     { name = "pyproj" },
     { name = "regionmask" },
     { name = "rioxarray" },
+    { name = "scikit-image" },
     { name = "scikit-learn" },
     { name = "scipy" },
     { name = "xarray" },
@@ -3155,6 +3260,7 @@ requires-dist = [
     { name = "pywavelets", marker = "extra == 'wavelets'", specifier = ">=1.4" },
     { name = "regionmask", specifier = ">=0.12" },
     { name = "rioxarray", specifier = ">=0.15" },
+    { name = "scikit-image", specifier = ">=0.22" },
     { name = "scikit-learn", specifier = ">=1.4" },
     { name = "scipy", specifier = ">=1.12" },
     { name = "xarray", specifier = ">=2024.2" },


### PR DESCRIPTION
## Summary
Lands all four V2 sub-issues in one PR — fourteen new operators across the four sub-modules:

- **V2.1 structural** (#44): `SSIM`, `GradientDifference`, `PhaseShiftError`, `CentroidDisplacement`
- **V2.2 probabilistic** (#45): `SpreadSkillRatio`, `RankHistogram`, `EnsembleCoverage`, `ReliabilityCurve`
- **V2.3 distributional** (#46): `CRPS`, `EnergyDistance`, `Wasserstein1`
- **V2.4 masked** (#47): `MaskedMetric`

Each operator follows the established two-tier pattern (Layer-0 free function + Layer-1 Operator with `get_config()`). Member-dim convention is pinned to `"member"` (configurable). V2.5 demo notebook will land in a follow-up.

## Dependency changes
`scikit-image` and `xskillscore` are now full runtime dependencies (per user request — no lazy-import dance, no optional extras).

## Test plan
- [x] `uv run pytest tests/test_metrics_v2_data_representation.py` — 27 tests pass
- [x] V2.1: SSIM identity → 1, uncorrelated noise → low; GradientDifference constant → 0, step → linear; PhaseShiftError recovers known 1-D + 2-D shifts (Gaussian-blob fixture for 2-D to avoid periodic ambiguity); CentroidDisplacement on synthetic blobs
- [x] V2.2: SpreadSkillRatio on calibrated ensemble (truth + members from same N(0,1)) ≈ √(N/(N+1)); RankHistogram approximately uniform; EnsembleCoverage(0.05, 0.95) ≈ 0.9; ReliabilityCurve identity for calibrated probability forecast
- [x] V2.3: CRPS matches `xskillscore.crps_ensemble`; energy distance and Wasserstein-1 zero on identical samples; Wasserstein-1 recovers a +3.0 location shift; energy distance grows with distribution gap
- [x] V2.4: MaskedMetric matches manual `where + metric`; per-call mask override; composes inside `Graph`
- [x] Full suite: 719 passed, 1 skipped
- [x] `uv run --group lint ruff check .` / `ruff format --check .` clean
- [x] `uv run --group typecheck ty check src/xr_toolz` — 41 diagnostics, same as `main` baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)