### PR TITLE
feat(interpolate): smooth submodule (F3.3)

### DIFF
--- a/src/xr_toolz/interpolate/__init__.py
+++ b/src/xr_toolz/interpolate/__init__.py
@@ -9,9 +9,11 @@ source/target structure under :mod:`._src`:
 - :mod:`._src.binning` — ``Grid``, ``Period``, ``SpaceTimeGrid``, ``bin_2d``,
   ``histogram_2d``
 - :mod:`._src.points_to_grid` — ``points_to_grid``
-- :mod:`._src.grid_to_points`, :mod:`._src.coord_remap`, :mod:`._src.smooth`,
+- :mod:`._src.smooth` — ``moving_average``, ``gaussian_smooth``,
+  ``lowpass_filter``
+- :mod:`._src.grid_to_points`, :mod:`._src.coord_remap`,
   :mod:`._src.downscale` — placeholder submodules for upcoming work
-  (D12, issues #34/#35/#36)
+  (D12, issues #34/#36)
 
 Layer-1 ``Operator`` wrappers live in :mod:`xr_toolz.interpolate.operators`.
 """
@@ -33,6 +35,11 @@ from xr_toolz.interpolate._src.gap_fill import (
 from xr_toolz.interpolate._src.grid_to_grid import coarsen, refine
 from xr_toolz.interpolate._src.points_to_grid import points_to_grid
 from xr_toolz.interpolate._src.resample import resample_time
+from xr_toolz.interpolate._src.smooth import (
+    gaussian_smooth,
+    lowpass_filter,
+    moving_average,
+)
 
 
 __all__ = [
@@ -44,7 +51,10 @@ __all__ = [
     "fillnan_rbf",
     "fillnan_spatial",
     "fillnan_temporal",
+    "gaussian_smooth",
     "histogram_2d",
+    "lowpass_filter",
+    "moving_average",
     "points_to_grid",
     "refine",
     "resample_time",

--- a/src/xr_toolz/interpolate/_src/array_smooth.py
+++ b/src/xr_toolz/interpolate/_src/array_smooth.py
@@ -11,10 +11,27 @@ F3.3 pilot.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
 from scipy.ndimage import gaussian_filter1d
 from scipy.signal import butter, sosfiltfilt
+
+
+_BUTTER_BTYPES: frozenset[str] = frozenset(
+    {"low", "high", "lowpass", "highpass", "bandpass", "bandstop"}
+)
+
+
+def _as_floating(arr: ArrayLike) -> np.ndarray:
+    """Cast ``arr`` to a floating dtype while preserving complex inputs."""
+    a = np.asarray(arr)
+    if np.issubdtype(a.dtype, np.complexfloating):
+        return a if a.dtype == np.complex128 else a.astype(np.complex128)
+    if np.issubdtype(a.dtype, np.floating):
+        return a
+    return a.astype(np.float64)
 
 
 def moving_average(
@@ -30,11 +47,11 @@ def moving_average(
     Parameters
     ----------
     arr
-        Input array (any shape).
+        Input array (any shape). Complex inputs are smoothed component-wise.
     axis
         Axis to smooth along.
     window
-        Window length (number of samples).
+        Window length (number of samples). Must be a positive integer.
     center
         If True, the window is centered on the output sample; otherwise
         trailing.
@@ -47,12 +64,16 @@ def moving_average(
     NDArray
         Smoothed array, same shape as the input.
     """
+    if not isinstance(window, (int, np.integer)) or isinstance(window, bool):
+        raise TypeError(f"window must be an integer, got {type(window).__name__}")
     if window < 1:
         raise ValueError(f"window must be >= 1, got {window}")
+    if min_periods is not None and min_periods < 0:
+        raise ValueError(f"min_periods must be >= 0, got {min_periods}")
     if min_periods is None:
         min_periods = window
 
-    a = np.asarray(arr, dtype=float)
+    a = _as_floating(arr)
     moved = np.moveaxis(a, axis, -1)
     if center:
         pad_left = (window - 1) // 2
@@ -83,11 +104,13 @@ def gaussian_smooth(
     """Gaussian convolution along ``axis`` with standard deviation ``sigma``.
 
     Delegates to :func:`scipy.ndimage.gaussian_filter1d`. NaN inputs
-    propagate.
+    propagate. Complex inputs are filtered component-wise.
     """
     if sigma <= 0:
         raise ValueError(f"sigma must be > 0, got {sigma}")
-    a = np.asarray(arr, dtype=float)
+    if truncate <= 0:
+        raise ValueError(f"truncate must be > 0, got {truncate}")
+    a = _as_floating(arr)
     return gaussian_filter1d(
         a, sigma=sigma, axis=axis, truncate=truncate, mode="reflect"
     )
@@ -97,22 +120,75 @@ def lowpass_filter(
     arr: ArrayLike,
     *,
     axis: int = -1,
-    cutoff: float,
+    cutoff: float | Sequence[float],
     order: int = 4,
     btype: str = "low",
 ) -> NDArray[np.floating]:
     """Zero-phase Butterworth filter along ``axis``.
 
-    ``cutoff`` is the normalized critical frequency (fraction of the
-    Nyquist rate); values must lie in ``(0, 1)``. ``btype`` is forwarded
-    to :func:`scipy.signal.butter` (``"low"``, ``"high"``, ``"band"``,
-    ``"bandstop"``).
+    Parameters
+    ----------
+    cutoff
+        Normalized critical frequency (fraction of the Nyquist rate). For
+        ``btype`` in ``{"low", "high"}`` (or aliases), ``cutoff`` is a
+        scalar in ``(0, 1)``. For ``btype`` in ``{"bandpass", "bandstop"}``,
+        ``cutoff`` is a length-2 sequence ``(low, high)`` with both
+        entries in ``(0, 1)``.
+    order
+        Filter order (positive integer).
+    btype
+        Filter type — one of ``{"low", "high", "lowpass", "highpass",
+        "bandpass", "bandstop"}``, forwarded to :func:`scipy.signal.butter`.
 
+    Notes
+    -----
     The filter is applied with :func:`scipy.signal.sosfiltfilt` for zero
-    phase and SOS-form numerical stability.
+    phase and SOS-form numerical stability. Complex inputs are filtered
+    component-wise.
     """
-    a = np.asarray(arr, dtype=float)
-    sos = butter(order, cutoff, btype=btype, output="sos")
+    if btype not in _BUTTER_BTYPES:
+        raise ValueError(
+            f"btype must be one of {sorted(_BUTTER_BTYPES)}, got {btype!r}"
+        )
+    if not isinstance(order, (int, np.integer)) or isinstance(order, bool):
+        raise TypeError(f"order must be an integer, got {type(order).__name__}")
+    if order < 1:
+        raise ValueError(f"order must be >= 1, got {order}")
+
+    is_band = btype in {"bandpass", "bandstop"}
+    if is_band:
+        if np.isscalar(cutoff):
+            raise ValueError(
+                f"btype={btype!r} requires a length-2 cutoff (low, high); "
+                f"got scalar {cutoff}"
+            )
+        cutoff_arr = np.asarray(cutoff, dtype=float)
+        if cutoff_arr.shape != (2,):
+            raise ValueError(
+                f"btype={btype!r} requires a length-2 cutoff; "
+                f"got shape {cutoff_arr.shape}"
+            )
+        if not np.all((cutoff_arr > 0.0) & (cutoff_arr < 1.0)):
+            raise ValueError(
+                f"cutoff entries must lie in (0, 1); got {cutoff_arr.tolist()}"
+            )
+        if cutoff_arr[0] >= cutoff_arr[1]:
+            raise ValueError(
+                f"cutoff[0] must be < cutoff[1]; got {cutoff_arr.tolist()}"
+            )
+        sos_cutoff: float | np.ndarray = cutoff_arr
+    else:
+        if not np.isscalar(cutoff):
+            raise ValueError(
+                f"btype={btype!r} requires a scalar cutoff; got {cutoff!r}"
+            )
+        c = float(cutoff)  # type: ignore[arg-type]
+        if not (0.0 < c < 1.0):
+            raise ValueError(f"cutoff must lie in (0, 1); got {c}")
+        sos_cutoff = c
+
+    a = _as_floating(arr)
+    sos = butter(order, sos_cutoff, btype=btype, output="sos")
     return sosfiltfilt(sos, a, axis=axis)
 
 

--- a/src/xr_toolz/interpolate/_src/array_smooth.py
+++ b/src/xr_toolz/interpolate/_src/array_smooth.py
@@ -1,0 +1,123 @@
+"""Tier A — array kernels for value-preserving smoothers (D11, D12).
+
+Per design decision D11, every arithmetic submodule grows a duck-array
+``axis=`` entry point. These kernels operate on raw :class:`numpy.ndarray`
+inputs with an explicit ``axis``, returning an array of the same shape
+(no reduction).
+
+Backend: numpy + scipy. JAX / CuPy variants are out of scope for the
+F3.3 pilot.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import ArrayLike, NDArray
+from scipy.ndimage import gaussian_filter1d
+from scipy.signal import butter, sosfiltfilt
+
+
+def moving_average(
+    arr: ArrayLike,
+    *,
+    axis: int = -1,
+    window: int,
+    center: bool = True,
+    min_periods: int | None = None,
+) -> NDArray[np.floating]:
+    """Sliding-window mean along ``axis``. NaN-skipping.
+
+    Parameters
+    ----------
+    arr
+        Input array (any shape).
+    axis
+        Axis to smooth along.
+    window
+        Window length (number of samples).
+    center
+        If True, the window is centered on the output sample; otherwise
+        trailing.
+    min_periods
+        Minimum number of non-NaN samples required inside the window
+        for the output to be non-NaN. Defaults to ``window``.
+
+    Returns
+    -------
+    NDArray
+        Smoothed array, same shape as the input.
+    """
+    if window < 1:
+        raise ValueError(f"window must be >= 1, got {window}")
+    if min_periods is None:
+        min_periods = window
+
+    a = np.asarray(arr, dtype=float)
+    moved = np.moveaxis(a, axis, -1)
+    if center:
+        pad_left = (window - 1) // 2
+        pad_right = window - 1 - pad_left
+    else:
+        pad_left = window - 1
+        pad_right = 0
+
+    pad_widths = [(0, 0)] * moved.ndim
+    pad_widths[-1] = (pad_left, pad_right)
+    padded = np.pad(moved, pad_widths, mode="constant", constant_values=np.nan)
+    windows = np.lib.stride_tricks.sliding_window_view(padded, window, axis=-1)
+
+    valid = (~np.isnan(windows)).sum(axis=-1)
+    with np.errstate(invalid="ignore"):
+        means = np.nanmean(windows, axis=-1)
+    out = np.where(valid >= min_periods, means, np.nan)
+    return np.moveaxis(out, -1, axis)
+
+
+def gaussian_smooth(
+    arr: ArrayLike,
+    *,
+    axis: int = -1,
+    sigma: float,
+    truncate: float = 4.0,
+) -> NDArray[np.floating]:
+    """Gaussian convolution along ``axis`` with standard deviation ``sigma``.
+
+    Delegates to :func:`scipy.ndimage.gaussian_filter1d`. NaN inputs
+    propagate.
+    """
+    if sigma <= 0:
+        raise ValueError(f"sigma must be > 0, got {sigma}")
+    a = np.asarray(arr, dtype=float)
+    return gaussian_filter1d(
+        a, sigma=sigma, axis=axis, truncate=truncate, mode="reflect"
+    )
+
+
+def lowpass_filter(
+    arr: ArrayLike,
+    *,
+    axis: int = -1,
+    cutoff: float,
+    order: int = 4,
+    btype: str = "low",
+) -> NDArray[np.floating]:
+    """Zero-phase Butterworth filter along ``axis``.
+
+    ``cutoff`` is the normalized critical frequency (fraction of the
+    Nyquist rate); values must lie in ``(0, 1)``. ``btype`` is forwarded
+    to :func:`scipy.signal.butter` (``"low"``, ``"high"``, ``"band"``,
+    ``"bandstop"``).
+
+    The filter is applied with :func:`scipy.signal.sosfiltfilt` for zero
+    phase and SOS-form numerical stability.
+    """
+    a = np.asarray(arr, dtype=float)
+    sos = butter(order, cutoff, btype=btype, output="sos")
+    return sosfiltfilt(sos, a, axis=axis)
+
+
+__all__ = [
+    "gaussian_smooth",
+    "lowpass_filter",
+    "moving_average",
+]

--- a/src/xr_toolz/interpolate/_src/smooth.py
+++ b/src/xr_toolz/interpolate/_src/smooth.py
@@ -35,11 +35,11 @@ def _apply_along_dim(
     out_vars: dict[str, xr.DataArray] = {}
     for name, da in ds.data_vars.items():
         if dim not in da.dims or not np.issubdtype(da.dtype, np.number):
-            out_vars[name] = da
+            out_vars[str(name)] = da
             continue
         axis = da.get_axis_num(dim)
         smoothed = fn(da.values, axis=axis)
-        out_vars[name] = xr.DataArray(
+        out_vars[str(name)] = xr.DataArray(
             smoothed,
             dims=da.dims,
             coords=da.coords,
@@ -94,14 +94,16 @@ def lowpass_filter(
     ds: xr.Dataset,
     *,
     dim: str,
-    cutoff: float,
+    cutoff: float | tuple[float, float] | list[float] | np.ndarray,
     order: int = 4,
     btype: str = "low",
 ) -> xr.Dataset:
     """Zero-phase Butterworth filter along ``dim``.
 
     ``cutoff`` is the normalized critical frequency (fraction of the
-    Nyquist rate). See :func:`xr_toolz.interpolate.array.lowpass_filter`.
+    Nyquist rate). For ``btype`` in ``{"bandpass", "bandstop"}`` pass a
+    length-2 ``(low, high)`` sequence. See
+    :func:`xr_toolz.interpolate.array.lowpass_filter`.
     """
 
     def _fn(arr: np.ndarray, *, axis: int) -> np.ndarray:

--- a/src/xr_toolz/interpolate/_src/smooth.py
+++ b/src/xr_toolz/interpolate/_src/smooth.py
@@ -1,10 +1,119 @@
-"""Value-preserving smoothers (placeholder).
+"""Tier B — value-preserving smoothers on xarray Datasets (D12, F3.3).
 
-Future home for ``MovingAverage``, ``GaussianSmooth``, ``LowpassFilter``,
-``KalmanSmoother``. See D12 and issue #35.
+Functions take an :class:`xr.Dataset`, a dimension name, and smoother
+parameters; they return a Dataset with the same shape and coords, every
+numeric data variable smoothed along ``dim``. Variables that don't
+carry ``dim`` (or are non-numeric) pass through untouched.
+
+Per D12 the smoothers are deterministic and parameter-free —
+``KalmanSmoother`` is out of scope here and lives under future
+``assimilate.smooth``.
+
+Tier A array kernels live at :mod:`xr_toolz.interpolate._src.array_smooth`.
 """
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from typing import Any
 
-__all__: list[str] = []
+import numpy as np
+import xarray as xr
+
+from xr_toolz.interpolate._src import array_smooth as _array
+
+
+def _apply_along_dim(
+    ds: xr.Dataset,
+    dim: str,
+    fn: Callable[..., Any],
+) -> xr.Dataset:
+    """Apply a Tier A kernel to every numeric data variable that carries ``dim``."""
+    if dim not in ds.dims:
+        raise ValueError(f"dim {dim!r} not in Dataset dims {tuple(ds.dims)}")
+
+    out_vars: dict[str, xr.DataArray] = {}
+    for name, da in ds.data_vars.items():
+        if dim not in da.dims or not np.issubdtype(da.dtype, np.number):
+            out_vars[name] = da
+            continue
+        axis = da.get_axis_num(dim)
+        smoothed = fn(da.values, axis=axis)
+        out_vars[name] = xr.DataArray(
+            smoothed,
+            dims=da.dims,
+            coords=da.coords,
+            attrs=dict(da.attrs),
+            name=da.name,
+        )
+    return xr.Dataset(out_vars, coords=ds.coords, attrs=dict(ds.attrs))
+
+
+def moving_average(
+    ds: xr.Dataset,
+    *,
+    dim: str,
+    window: int,
+    center: bool = True,
+    min_periods: int | None = None,
+) -> xr.Dataset:
+    """Sliding-window mean along ``dim``.
+
+    See :func:`xr_toolz.interpolate.array.moving_average` for the Tier A
+    kernel and parameter semantics.
+    """
+
+    def _fn(arr: np.ndarray, *, axis: int) -> np.ndarray:
+        return _array.moving_average(
+            arr,
+            axis=axis,
+            window=window,
+            center=center,
+            min_periods=min_periods,
+        )
+
+    return _apply_along_dim(ds, dim, _fn)
+
+
+def gaussian_smooth(
+    ds: xr.Dataset,
+    *,
+    dim: str,
+    sigma: float,
+    truncate: float = 4.0,
+) -> xr.Dataset:
+    """Gaussian smoothing along ``dim`` with standard deviation ``sigma``."""
+
+    def _fn(arr: np.ndarray, *, axis: int) -> np.ndarray:
+        return _array.gaussian_smooth(arr, axis=axis, sigma=sigma, truncate=truncate)
+
+    return _apply_along_dim(ds, dim, _fn)
+
+
+def lowpass_filter(
+    ds: xr.Dataset,
+    *,
+    dim: str,
+    cutoff: float,
+    order: int = 4,
+    btype: str = "low",
+) -> xr.Dataset:
+    """Zero-phase Butterworth filter along ``dim``.
+
+    ``cutoff`` is the normalized critical frequency (fraction of the
+    Nyquist rate). See :func:`xr_toolz.interpolate.array.lowpass_filter`.
+    """
+
+    def _fn(arr: np.ndarray, *, axis: int) -> np.ndarray:
+        return _array.lowpass_filter(
+            arr, axis=axis, cutoff=cutoff, order=order, btype=btype
+        )
+
+    return _apply_along_dim(ds, dim, _fn)
+
+
+__all__ = [
+    "gaussian_smooth",
+    "lowpass_filter",
+    "moving_average",
+]

--- a/src/xr_toolz/interpolate/array.py
+++ b/src/xr_toolz/interpolate/array.py
@@ -1,0 +1,27 @@
+"""Tier A — array-tier entry points for :mod:`xr_toolz.interpolate`.
+
+Per design decision D11, every arithmetic submodule grows a duck-array
+``axis=`` entry point under ``<module>/array.py``. This module re-exports
+the smoother kernels (``moving_average``, ``gaussian_smooth``,
+``lowpass_filter``) that take :class:`numpy.ndarray` (or any duck array
+convertible via :func:`numpy.asarray`) and an ``axis`` argument,
+returning an array of the same shape.
+
+These are the kernels Tier B (xarray, ``dim=``) and Tier C
+(``Operator``) delegate to.
+"""
+
+from __future__ import annotations
+
+from xr_toolz.interpolate._src.array_smooth import (
+    gaussian_smooth,
+    lowpass_filter,
+    moving_average,
+)
+
+
+__all__ = [
+    "gaussian_smooth",
+    "lowpass_filter",
+    "moving_average",
+]

--- a/src/xr_toolz/interpolate/operators.py
+++ b/src/xr_toolz/interpolate/operators.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 
 from typing import Any
 
+import numpy as np
+
 from xr_toolz.core import Operator
 from xr_toolz.interpolate._src import (
     binning as _binning,
@@ -248,10 +250,18 @@ class MovingAverage(Operator):
         center: bool = True,
         min_periods: int | None = None,
     ):
+        if not isinstance(window, int) or isinstance(window, bool):
+            raise TypeError(f"window must be an int, got {type(window).__name__}")
         if window < 1:
             raise ValueError(f"window must be >= 1, got {window}")
+        if min_periods is not None and (
+            not isinstance(min_periods, int) or min_periods < 0
+        ):
+            raise ValueError(
+                f"min_periods must be a non-negative int or None, got {min_periods!r}"
+            )
         self.dim = dim
-        self.window = int(window)
+        self.window = window
         self.center = bool(center)
         self.min_periods = min_periods
 
@@ -293,19 +303,33 @@ class GaussianSmooth(Operator):
 
 
 class LowpassFilter(Operator):
-    """Wrap :func:`xr_toolz.interpolate._src.smooth.lowpass_filter`."""
+    """Wrap :func:`xr_toolz.interpolate._src.smooth.lowpass_filter`.
+
+    For ``btype`` in ``{"low", "high", "lowpass", "highpass"}`` ``cutoff``
+    is a scalar in ``(0, 1)``. For ``btype`` in
+    ``{"bandpass", "bandstop"}`` it is a length-2 sequence. Validation
+    is delegated to the Tier A kernel.
+    """
 
     def __init__(
         self,
         dim: str,
-        cutoff: float,
+        cutoff: Any,
         *,
         order: int = 4,
         btype: str = "low",
     ):
+        if not isinstance(order, int) or isinstance(order, bool):
+            raise TypeError(f"order must be an int, got {type(order).__name__}")
         self.dim = dim
-        self.cutoff = float(cutoff)
-        self.order = int(order)
+        if np.isscalar(cutoff):
+            self.cutoff: Any = float(cutoff)
+        else:
+            pair = tuple(float(v) for v in cutoff)
+            if len(pair) != 2:
+                raise ValueError(f"cutoff sequence must have length 2, got {len(pair)}")
+            self.cutoff = pair
+        self.order = order
         self.btype = btype
 
     def _apply(self, ds):
@@ -320,7 +344,9 @@ class LowpassFilter(Operator):
     def get_config(self) -> dict[str, Any]:
         return {
             "dim": self.dim,
-            "cutoff": self.cutoff,
+            "cutoff": (
+                list(self.cutoff) if isinstance(self.cutoff, tuple) else self.cutoff
+            ),
             "order": self.order,
             "btype": self.btype,
         }

--- a/src/xr_toolz/interpolate/operators.py
+++ b/src/xr_toolz/interpolate/operators.py
@@ -18,6 +18,7 @@ from xr_toolz.interpolate._src import (
     grid_to_grid as _grid_to_grid,
     points_to_grid as _points_to_grid,
     resample as _resample,
+    smooth as _smooth,
 )
 
 
@@ -233,13 +234,108 @@ class PointsToGrid(Operator):
         return {"grid": "<Grid>", "statistic": self.statistic}
 
 
+# ---------- smoothers ------------------------------------------------------
+
+
+class MovingAverage(Operator):
+    """Wrap :func:`xr_toolz.interpolate._src.smooth.moving_average`."""
+
+    def __init__(
+        self,
+        dim: str,
+        window: int,
+        *,
+        center: bool = True,
+        min_periods: int | None = None,
+    ):
+        if window < 1:
+            raise ValueError(f"window must be >= 1, got {window}")
+        self.dim = dim
+        self.window = int(window)
+        self.center = bool(center)
+        self.min_periods = min_periods
+
+    def _apply(self, ds):
+        return _smooth.moving_average(
+            ds,
+            dim=self.dim,
+            window=self.window,
+            center=self.center,
+            min_periods=self.min_periods,
+        )
+
+    def get_config(self) -> dict[str, Any]:
+        return {
+            "dim": self.dim,
+            "window": self.window,
+            "center": self.center,
+            "min_periods": self.min_periods,
+        }
+
+
+class GaussianSmooth(Operator):
+    """Wrap :func:`xr_toolz.interpolate._src.smooth.gaussian_smooth`."""
+
+    def __init__(self, dim: str, sigma: float, *, truncate: float = 4.0):
+        if sigma <= 0:
+            raise ValueError(f"sigma must be > 0, got {sigma}")
+        self.dim = dim
+        self.sigma = float(sigma)
+        self.truncate = float(truncate)
+
+    def _apply(self, ds):
+        return _smooth.gaussian_smooth(
+            ds, dim=self.dim, sigma=self.sigma, truncate=self.truncate
+        )
+
+    def get_config(self) -> dict[str, Any]:
+        return {"dim": self.dim, "sigma": self.sigma, "truncate": self.truncate}
+
+
+class LowpassFilter(Operator):
+    """Wrap :func:`xr_toolz.interpolate._src.smooth.lowpass_filter`."""
+
+    def __init__(
+        self,
+        dim: str,
+        cutoff: float,
+        *,
+        order: int = 4,
+        btype: str = "low",
+    ):
+        self.dim = dim
+        self.cutoff = float(cutoff)
+        self.order = int(order)
+        self.btype = btype
+
+    def _apply(self, ds):
+        return _smooth.lowpass_filter(
+            ds,
+            dim=self.dim,
+            cutoff=self.cutoff,
+            order=self.order,
+            btype=self.btype,
+        )
+
+    def get_config(self) -> dict[str, Any]:
+        return {
+            "dim": self.dim,
+            "cutoff": self.cutoff,
+            "order": self.order,
+            "btype": self.btype,
+        }
+
+
 __all__ = [
     "Bin2D",
     "Coarsen",
     "FillNaNRBF",
     "FillNaNSpatial",
     "FillNaNTemporal",
+    "GaussianSmooth",
     "Histogram2D",
+    "LowpassFilter",
+    "MovingAverage",
     "PointsToGrid",
     "Refine",
     "ResampleTime",

--- a/tests/test_interpolate_imports.py
+++ b/tests/test_interpolate_imports.py
@@ -88,6 +88,6 @@ def test_legacy_geo_operator_names_are_gone() -> None:
 
 
 def test_placeholder_submodules_importable() -> None:
-    for sub in ("coord_remap", "smooth", "downscale", "grid_to_points"):
+    for sub in ("coord_remap", "downscale", "grid_to_points"):
         mod = importlib.import_module(f"xr_toolz.interpolate._src.{sub}")
         assert mod.__all__ == []

--- a/tests/test_interpolate_smooth.py
+++ b/tests/test_interpolate_smooth.py
@@ -190,3 +190,61 @@ def test_tier_c_get_config_is_serializable():
         "order": 6,
         "btype": "high",
     }
+
+
+# ---------------------------------------------------------------------------
+# Validation + dtype preservation (review feedback)
+# ---------------------------------------------------------------------------
+
+
+def test_array_smoothers_preserve_complex_dtype():
+    """Complex inputs must not be silently coerced to float."""
+    n = 64
+    t = np.arange(n)
+    z = np.exp(1j * 2 * np.pi * t / n)
+    assert np.iscomplexobj(ia.gaussian_smooth(z, axis=-1, sigma=1.0))
+    assert np.iscomplexobj(ia.lowpass_filter(z, axis=-1, cutoff=0.1))
+
+
+def test_array_lowpass_band_requires_pair_cutoff():
+    rng = np.random.default_rng(0)
+    x = rng.standard_normal(256)
+    out = ia.lowpass_filter(x, axis=-1, cutoff=(0.05, 0.4), btype="bandpass")
+    assert out.shape == x.shape
+    with pytest.raises(ValueError):
+        ia.lowpass_filter(x, axis=-1, cutoff=0.1, btype="bandpass")
+    with pytest.raises(ValueError):
+        ia.lowpass_filter(x, axis=-1, cutoff=(0.4, 0.05), btype="bandpass")
+
+
+def test_array_lowpass_unknown_btype_raises():
+    with pytest.raises(ValueError):
+        ia.lowpass_filter(np.zeros(16), axis=-1, cutoff=0.2, btype="bogus")
+
+
+def test_array_lowpass_invalid_cutoff_raises():
+    with pytest.raises(ValueError):
+        ia.lowpass_filter(np.zeros(16), axis=-1, cutoff=1.5)
+    with pytest.raises(ValueError):
+        ia.lowpass_filter(np.zeros(16), axis=-1, cutoff=0.0)
+
+
+def test_array_moving_average_rejects_non_integer_window():
+    with pytest.raises(TypeError):
+        ia.moving_average(np.zeros(8), axis=-1, window=1.9)  # type: ignore[arg-type]
+
+
+def test_tier_c_moving_average_rejects_non_integer_window():
+    with pytest.raises(TypeError):
+        MovingAverage("time", window=1.9)  # type: ignore[arg-type]
+
+
+def test_tier_c_lowpass_band_filter_passes_band():
+    n = 1024
+    t = np.arange(n)
+    # Period 16 → 0.0625 cycles/sample → 0.125 in normalized (Nyquist=1) units.
+    band_signal = np.sin(2 * np.pi * t / 16)
+    ds = xr.Dataset({"x": (("time",), band_signal)}, coords={"time": t})
+    op = LowpassFilter("time", cutoff=(0.08, 0.20), order=4, btype="bandpass")
+    out = op(ds)
+    assert out["x"].values[100:-100].std() > 0.9 * band_signal.std()

--- a/tests/test_interpolate_smooth.py
+++ b/tests/test_interpolate_smooth.py
@@ -1,0 +1,192 @@
+"""Tests for ``xr_toolz.interpolate`` smoothers (F3.3, D12)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from xr_toolz.interpolate import (
+    array as ia,
+    gaussian_smooth,
+    lowpass_filter,
+    moving_average,
+)
+from xr_toolz.interpolate.operators import (
+    GaussianSmooth,
+    LowpassFilter,
+    MovingAverage,
+)
+
+
+# ---------------------------------------------------------------------------
+# Tier A — moving_average
+# ---------------------------------------------------------------------------
+
+
+def test_array_moving_average_constant_input_unchanged():
+    x = np.full(20, 3.5)
+    out = ia.moving_average(x, axis=-1, window=5, min_periods=1)
+    np.testing.assert_allclose(out, 3.5)
+
+
+def test_array_moving_average_default_min_periods_nans_edges():
+    """With default ``min_periods=window`` the edges lack a full window."""
+    x = np.full(20, 3.5)
+    out = ia.moving_average(x, axis=-1, window=5)  # default min_periods=window
+    # Centered window of 5 leaves 2 NaN at each end.
+    assert np.all(np.isnan(out[:2]))
+    assert np.all(np.isnan(out[-2:]))
+    np.testing.assert_allclose(out[2:-2], 3.5)
+
+
+def test_array_moving_average_centered_window_matches_manual():
+    x = np.arange(10, dtype=float)
+    out = ia.moving_average(x, axis=-1, window=3, center=True)
+    # Interior: simple mean of (x[i-1], x[i], x[i+1]).
+    np.testing.assert_allclose(out[1:-1], np.arange(1, 9, dtype=float))
+
+
+def test_array_moving_average_min_periods_propagates_nan():
+    x = np.arange(10, dtype=float)
+    out = ia.moving_average(x, axis=-1, window=4, center=False, min_periods=4)
+    # First three outputs lack a full window → NaN.
+    assert np.all(np.isnan(out[:3]))
+    assert not np.any(np.isnan(out[3:]))
+
+
+def test_array_moving_average_invalid_window_raises():
+    with pytest.raises(ValueError):
+        ia.moving_average(np.zeros(5), axis=-1, window=0)
+
+
+# ---------------------------------------------------------------------------
+# Tier A — gaussian_smooth
+# ---------------------------------------------------------------------------
+
+
+def test_array_gaussian_preserves_constant():
+    x = np.full(50, 2.0)
+    np.testing.assert_allclose(ia.gaussian_smooth(x, axis=-1, sigma=2.0), 2.0)
+
+
+def test_array_gaussian_attenuates_high_freq():
+    n = 256
+    t = np.arange(n)
+    fast = np.sin(2 * np.pi * t / 4)  # period-4 sinusoid
+    smooth = ia.gaussian_smooth(fast, axis=-1, sigma=4.0)
+    # Sigma=4 over period-4 should aggressively attenuate.
+    assert smooth.std() < 0.1 * fast.std()
+
+
+def test_array_gaussian_invalid_sigma_raises():
+    with pytest.raises(ValueError):
+        ia.gaussian_smooth(np.zeros(5), axis=-1, sigma=0.0)
+
+
+# ---------------------------------------------------------------------------
+# Tier A — lowpass_filter
+# ---------------------------------------------------------------------------
+
+
+def test_array_lowpass_attenuates_above_cutoff():
+    """Pass-band sinusoid survives; stop-band sinusoid is attenuated."""
+    n = 1024
+    t = np.arange(n)
+    pass_band = np.sin(2 * np.pi * t / 64)  # period 64 → freq 1/64 ≈ 0.016 (< cutoff)
+    stop_band = np.sin(2 * np.pi * t / 4)  # period 4 → freq 0.25 (> cutoff)
+
+    cutoff = 0.05  # fraction of Nyquist (Nyquist=1)
+    pass_out = ia.lowpass_filter(pass_band, axis=-1, cutoff=cutoff, order=4)
+    stop_out = ia.lowpass_filter(stop_band, axis=-1, cutoff=cutoff, order=4)
+
+    # Trim edge transients before measuring amplitude.
+    assert pass_out[100:-100].std() > 0.9 * pass_band.std()
+    assert stop_out[100:-100].std() < 0.05 * stop_band.std()
+
+
+# ---------------------------------------------------------------------------
+# Tier B — Dataset wrappers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def ds_signal():
+    n = 128
+    t = np.arange(n)
+    x = np.sin(2 * np.pi * t / 8) + 0.5 * np.sin(2 * np.pi * t / 2)
+    return xr.Dataset({"x": (("time",), x)}, coords={"time": t})
+
+
+def test_tier_b_moving_average_preserves_shape(ds_signal):
+    out = moving_average(ds_signal, dim="time", window=5)
+    assert out["x"].shape == ds_signal["x"].shape
+    assert out["x"].dims == ("time",)
+
+
+def test_tier_b_gaussian_smooth_matches_tier_a(ds_signal):
+    out = gaussian_smooth(ds_signal, dim="time", sigma=3.0)
+    expected = ia.gaussian_smooth(ds_signal["x"].values, axis=-1, sigma=3.0)
+    np.testing.assert_allclose(out["x"].values, expected)
+
+
+def test_tier_b_lowpass_filter_matches_tier_a(ds_signal):
+    out = lowpass_filter(ds_signal, dim="time", cutoff=0.1, order=4)
+    expected = ia.lowpass_filter(ds_signal["x"].values, axis=-1, cutoff=0.1, order=4)
+    np.testing.assert_allclose(out["x"].values, expected)
+
+
+def test_tier_b_passes_through_non_dim_variables():
+    ds = xr.Dataset(
+        {
+            "x": (("time",), np.arange(10, dtype=float)),
+            "static": ((), 7.0),
+        },
+        coords={"time": np.arange(10)},
+    )
+    out = moving_average(ds, dim="time", window=3)
+    assert float(out["static"]) == 7.0
+
+
+def test_tier_b_unknown_dim_raises(ds_signal):
+    with pytest.raises(ValueError):
+        moving_average(ds_signal, dim="bogus", window=3)
+
+
+# ---------------------------------------------------------------------------
+# Tier C — Operator wrappers
+# ---------------------------------------------------------------------------
+
+
+def test_tier_c_moving_average_matches_tier_b(ds_signal):
+    op = MovingAverage("time", window=5)
+    np.testing.assert_allclose(
+        op(ds_signal)["x"].values,
+        moving_average(ds_signal, dim="time", window=5)["x"].values,
+    )
+
+
+def test_tier_c_gaussian_smooth_matches_tier_b(ds_signal):
+    op = GaussianSmooth("time", sigma=2.5)
+    np.testing.assert_allclose(
+        op(ds_signal)["x"].values,
+        gaussian_smooth(ds_signal, dim="time", sigma=2.5)["x"].values,
+    )
+
+
+def test_tier_c_lowpass_filter_matches_tier_b(ds_signal):
+    op = LowpassFilter("time", cutoff=0.1)
+    np.testing.assert_allclose(
+        op(ds_signal)["x"].values,
+        lowpass_filter(ds_signal, dim="time", cutoff=0.1)["x"].values,
+    )
+
+
+def test_tier_c_get_config_is_serializable():
+    cfg = LowpassFilter("time", cutoff=0.2, order=6, btype="high").get_config()
+    assert cfg == {
+        "dim": "time",
+        "cutoff": 0.2,
+        "order": 6,
+        "btype": "high",
+    }

--- a/tests/test_tier_contract.py
+++ b/tests/test_tier_contract.py
@@ -177,3 +177,69 @@ def test_calc_array_gradient_returns_per_axis() -> None:
     assert len(components) == 2
     for comp in components:
         assert comp.shape == x.shape
+
+
+# ---------------------------------------------------------------------------
+# interpolate (smoothers — F3.3)
+# ---------------------------------------------------------------------------
+
+
+_SMOOTH_NAMES: tuple[str, ...] = ("moving_average", "gaussian_smooth", "lowpass_filter")
+
+
+@pytest.mark.parametrize("name", _SMOOTH_NAMES)
+def test_interpolate_array_namespace_exports(name: str) -> None:
+    """Tier A is reachable via ``xr_toolz.interpolate.array``."""
+    from xr_toolz.interpolate import array as ia
+
+    assert hasattr(ia, name), f"xr_toolz.interpolate.array.{name} missing"
+    assert callable(getattr(ia, name))
+
+
+def test_interpolate_smooth_tier_b_matches_tier_a() -> None:
+    """Tier B (Dataset, ``dim=``) numerically matches Tier A (``axis=``)."""
+    from xr_toolz.interpolate import array as ia
+    from xr_toolz.interpolate._src import smooth as tier_b
+
+    rng = np.random.default_rng(0)
+    x = rng.standard_normal((3, 64))
+    ds = xr.Dataset({"x": (("a", "time"), x)})
+
+    b_ma = tier_b.moving_average(ds, dim="time", window=5)["x"].values
+    a_ma = ia.moving_average(x, axis=-1, window=5)
+    np.testing.assert_allclose(a_ma, b_ma)
+
+    b_g = tier_b.gaussian_smooth(ds, dim="time", sigma=2.0)["x"].values
+    a_g = ia.gaussian_smooth(x, axis=-1, sigma=2.0)
+    np.testing.assert_allclose(a_g, b_g)
+
+    b_lp = tier_b.lowpass_filter(ds, dim="time", cutoff=0.1)["x"].values
+    a_lp = ia.lowpass_filter(x, axis=-1, cutoff=0.1)
+    np.testing.assert_allclose(a_lp, b_lp)
+
+
+def test_interpolate_smooth_tier_c_matches_tier_b() -> None:
+    """Tier C ``Operator`` output equals Tier B function output."""
+    from xr_toolz.interpolate._src import smooth as tier_b
+    from xr_toolz.interpolate.operators import (
+        GaussianSmooth,
+        LowpassFilter,
+        MovingAverage,
+    )
+
+    rng = np.random.default_rng(1)
+    x = rng.standard_normal((3, 64))
+    ds = xr.Dataset({"x": (("a", "time"), x)})
+
+    np.testing.assert_allclose(
+        MovingAverage("time", window=5)(ds)["x"].values,
+        tier_b.moving_average(ds, dim="time", window=5)["x"].values,
+    )
+    np.testing.assert_allclose(
+        GaussianSmooth("time", sigma=2.0)(ds)["x"].values,
+        tier_b.gaussian_smooth(ds, dim="time", sigma=2.0)["x"].values,
+    )
+    np.testing.assert_allclose(
+        LowpassFilter("time", cutoff=0.1)(ds)["x"].values,
+        tier_b.lowpass_filter(ds, dim="time", cutoff=0.1)["x"].values,
+    )


### PR DESCRIPTION
## Summary
- Adds \`xr_toolz.interpolate.smooth\` with \`MovingAverage\`, \`GaussianSmooth\`, \`LowpassFilter\` per D12.
- Three-tier (D11): Tier A array kernels (\`interpolate/_src/array_smooth.py\` + \`interpolate/array.py\`), Tier B Dataset wrappers, Tier C \`Operator\`s.
- \`KalmanSmoother\` deferred to future \`assimilate.smooth\` per F3.5 resolution of D12 Q3.

## Notes
- \`MovingAverage\` follows xarray/pandas convention: \`min_periods\` defaults to \`window\` (boundary samples NaN). Pass \`min_periods=1\` for full coverage.
- \`LowpassFilter\` uses zero-phase \`scipy.signal.sosfiltfilt\` over a Butterworth SOS for numerical stability. \`cutoff\` is normalized (fraction of Nyquist).
- \`GaussianSmooth\` delegates to \`scipy.ndimage.gaussian_filter1d\` with \`mode=\"reflect\"\`.

Closes #35.

## Test plan
- [x] \`pytest tests/test_interpolate_smooth.py tests/test_tier_contract.py\` (50 passed)
- [x] \`ruff check .\` / \`ruff format --check .\` clean
- [x] No new \`ty\` diagnostics on the smooth code

🤖 Generated with [Claude Code](https://claude.com/claude-code)