### PR TITLE
feat(interpolate): coord_remap submodule (F3.2)

### DIFF
--- a/src/xr_toolz/interpolate/__init__.py
+++ b/src/xr_toolz/interpolate/__init__.py
@@ -11,9 +11,9 @@ source/target structure under :mod:`._src`:
 - :mod:`._src.points_to_grid` — ``points_to_grid``
 - :mod:`._src.smooth` — ``moving_average``, ``gaussian_smooth``,
   ``lowpass_filter``
-- :mod:`._src.grid_to_points`, :mod:`._src.coord_remap`,
-  :mod:`._src.downscale` — placeholder submodules for upcoming work
-  (D12, issues #34/#36)
+- :mod:`._src.coord_remap` — ``remap_axis``, ``to_phase``
+- :mod:`._src.grid_to_points`, :mod:`._src.downscale` — placeholder
+  submodules for upcoming work (D12, issue #36)
 
 Layer-1 ``Operator`` wrappers live in :mod:`xr_toolz.interpolate.operators`.
 """
@@ -27,6 +27,7 @@ from xr_toolz.interpolate._src.binning import (
     bin_2d,
     histogram_2d,
 )
+from xr_toolz.interpolate._src.coord_remap import remap_axis, to_phase
 from xr_toolz.interpolate._src.gap_fill import (
     fillnan_rbf,
     fillnan_spatial,
@@ -57,5 +58,7 @@ __all__ = [
     "moving_average",
     "points_to_grid",
     "refine",
+    "remap_axis",
     "resample_time",
+    "to_phase",
 ]

--- a/src/xr_toolz/interpolate/_src/array_coord_remap.py
+++ b/src/xr_toolz/interpolate/_src/array_coord_remap.py
@@ -1,0 +1,91 @@
+"""Tier A — array kernels for axis remapping (D11, D12).
+
+Per design decision D11, every arithmetic submodule grows a duck-array
+``axis=`` entry point. ``remap_axis`` interpolates values from a source
+1D coordinate vector to a target 1D coordinate vector along a chosen
+axis, preserving all other dimensions.
+
+Backend: numpy. Methods: ``"linear"`` (np.interp), ``"nearest"``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import ArrayLike, NDArray
+
+
+def remap_axis(
+    values: ArrayLike,
+    *,
+    axis: int = -1,
+    source_coords: ArrayLike,
+    target_coords: ArrayLike,
+    method: str = "linear",
+) -> NDArray[np.floating]:
+    """Interpolate values along ``axis`` from ``source_coords`` to ``target_coords``.
+
+    Parameters
+    ----------
+    values
+        Array with one axis whose length matches ``source_coords``.
+    axis
+        Axis to remap along.
+    source_coords
+        1D monotonic (ascending or descending) coordinate vector.
+    target_coords
+        1D coordinate vector to interpolate to.
+    method
+        ``"linear"`` or ``"nearest"``.
+
+    Returns
+    -------
+    NDArray
+        Same shape as ``values`` except along ``axis``, which is
+        replaced by ``len(target_coords)``. Targets outside the source
+        range produce NaN (no extrapolation).
+    """
+    arr = np.asarray(values, dtype=float)
+    src = np.asarray(source_coords, dtype=float)
+    tgt = np.asarray(target_coords, dtype=float)
+
+    if src.ndim != 1 or tgt.ndim != 1:
+        raise ValueError("source_coords and target_coords must be 1D")
+    if arr.shape[axis] != src.size:
+        raise ValueError(
+            f"values.shape[axis]={arr.shape[axis]} but len(source_coords)={src.size}"
+        )
+
+    # Normalize to ascending source for np.interp / searchsorted.
+    diffs = np.diff(src)
+    if np.all(diffs > 0):
+        ascending = True
+    elif np.all(diffs < 0):
+        ascending = False
+        src = src[::-1]
+    else:
+        raise ValueError("source_coords must be strictly monotonic")
+
+    moved = np.moveaxis(arr, axis, -1)
+    if not ascending:
+        moved = moved[..., ::-1]
+
+    flat = moved.reshape(-1, src.size)
+    out = np.empty((flat.shape[0], tgt.size), dtype=float)
+
+    if method == "linear":
+        for i in range(flat.shape[0]):
+            out[i] = np.interp(tgt, src, flat[i], left=np.nan, right=np.nan)
+    elif method == "nearest":
+        idx = np.abs(src[None, :] - tgt[:, None]).argmin(axis=1)  # (M,)
+        out[:] = flat[:, idx]
+        oor = (tgt < src.min()) | (tgt > src.max())
+        if oor.any():
+            out[:, oor] = np.nan
+    else:
+        raise ValueError(f"unknown method {method!r}; expected 'linear' or 'nearest'")
+
+    out = out.reshape(*moved.shape[:-1], tgt.size)
+    return np.moveaxis(out, -1, axis)
+
+
+__all__ = ["remap_axis"]

--- a/src/xr_toolz/interpolate/_src/array_coord_remap.py
+++ b/src/xr_toolz/interpolate/_src/array_coord_remap.py
@@ -5,13 +5,24 @@ Per design decision D11, every arithmetic submodule grows a duck-array
 1D coordinate vector to a target 1D coordinate vector along a chosen
 axis, preserving all other dimensions.
 
-Backend: numpy. Methods: ``"linear"`` (np.interp), ``"nearest"``.
+Backend: numpy. Methods: ``"linear"`` (np.interp on real/imag parts
+independently), ``"nearest"``.
 """
 
 from __future__ import annotations
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
+
+
+def _as_floating(arr: ArrayLike) -> np.ndarray:
+    """Cast to a floating dtype while preserving complex inputs."""
+    a = np.asarray(arr)
+    if np.issubdtype(a.dtype, np.complexfloating):
+        return a if a.dtype == np.complex128 else a.astype(np.complex128)
+    if np.issubdtype(a.dtype, np.floating):
+        return a
+    return a.astype(np.float64)
 
 
 def remap_axis(
@@ -21,19 +32,21 @@ def remap_axis(
     source_coords: ArrayLike,
     target_coords: ArrayLike,
     method: str = "linear",
-) -> NDArray[np.floating]:
+) -> NDArray:
     """Interpolate values along ``axis`` from ``source_coords`` to ``target_coords``.
 
     Parameters
     ----------
     values
         Array with one axis whose length matches ``source_coords``.
+        Real or complex; complex inputs are interpolated component-wise.
     axis
         Axis to remap along.
     source_coords
         1D monotonic (ascending or descending) coordinate vector.
     target_coords
-        1D coordinate vector to interpolate to.
+        1D coordinate vector to interpolate to. Targets outside the
+        source range or equal to ``NaN`` produce ``NaN`` in the output.
     method
         ``"linear"`` or ``"nearest"``.
 
@@ -41,10 +54,9 @@ def remap_axis(
     -------
     NDArray
         Same shape as ``values`` except along ``axis``, which is
-        replaced by ``len(target_coords)``. Targets outside the source
-        range produce NaN (no extrapolation).
+        replaced by ``len(target_coords)``.
     """
-    arr = np.asarray(values, dtype=float)
+    arr = _as_floating(values)
     src = np.asarray(source_coords, dtype=float)
     tgt = np.asarray(target_coords, dtype=float)
 
@@ -70,15 +82,34 @@ def remap_axis(
         moved = moved[..., ::-1]
 
     flat = moved.reshape(-1, src.size)
-    out = np.empty((flat.shape[0], tgt.size), dtype=float)
+    is_complex = np.iscomplexobj(flat)
+    out_dtype = flat.dtype if is_complex else float
+    out = np.empty((flat.shape[0], tgt.size), dtype=out_dtype)
+
+    # Identify NaN targets up front; numpy.interp/searchsorted have
+    # surprising behavior on NaN inputs (np.interp returns the right-hand
+    # fill value, argmin/searchsorted treat NaN as larger than any
+    # number), so we mask them out and assign NaN explicitly.
+    nan_target = np.isnan(tgt)
 
     if method == "linear":
-        for i in range(flat.shape[0]):
-            out[i] = np.interp(tgt, src, flat[i], left=np.nan, right=np.nan)
+        if is_complex:
+            for i in range(flat.shape[0]):
+                real = np.interp(tgt, src, flat[i].real, left=np.nan, right=np.nan)
+                imag = np.interp(tgt, src, flat[i].imag, left=np.nan, right=np.nan)
+                out[i] = real + 1j * imag
+        else:
+            for i in range(flat.shape[0]):
+                out[i] = np.interp(tgt, src, flat[i], left=np.nan, right=np.nan)
+        if nan_target.any():
+            out[:, nan_target] = np.nan
     elif method == "nearest":
-        idx = np.abs(src[None, :] - tgt[:, None]).argmin(axis=1)  # (M,)
+        # Replace NaN targets with a sentinel so argmin is well-defined;
+        # we'll mask the result back to NaN below.
+        safe_tgt = np.where(nan_target, src.min(), tgt)
+        idx = np.abs(src[None, :] - safe_tgt[:, None]).argmin(axis=1)  # (M,)
         out[:] = flat[:, idx]
-        oor = (tgt < src.min()) | (tgt > src.max())
+        oor = (tgt < src.min()) | (tgt > src.max()) | nan_target
         if oor.any():
             out[:, oor] = np.nan
     else:

--- a/src/xr_toolz/interpolate/_src/coord_remap.py
+++ b/src/xr_toolz/interpolate/_src/coord_remap.py
@@ -1,11 +1,172 @@
-"""Coordinate-axis remapping (placeholder).
+"""Tier B — coordinate-axis remapping on xarray Datasets (D12, F3.2).
 
-Future home for ``RemapAxis`` and presets (``ToSigma``,
-``ToIsopycnal``, ``ToPressureLevels``, ``ToPhase``, …). See D12 and
-issue #34.
+The generic primitive is :func:`remap_axis`: given a source dimension and
+a 1D target coordinate vector, every numeric variable that carries the
+source dim is interpolated onto the target axis along that dim.
+
+Vertical / temporal presets (``ToSigma``, ``FromSigma``,
+``ToIsopycnal``, ``ToPressureLevels``, ``ToHeight``, ``ToPhase``) live
+as :class:`Operator` subclasses in
+:mod:`xr_toolz.interpolate.operators`; they parametrise the generic
+operator with conventional dim/coord names.
+
+Tier A array kernel: :mod:`xr_toolz.interpolate._src.array_coord_remap`.
 """
 
 from __future__ import annotations
 
+import numpy as np
+import xarray as xr
 
-__all__: list[str] = []
+from xr_toolz.interpolate._src import array_coord_remap as _array
+
+
+def remap_axis(
+    ds: xr.Dataset,
+    *,
+    source_dim: str,
+    target_coords: xr.DataArray | np.ndarray,
+    target_name: str | None = None,
+    method: str = "linear",
+) -> xr.Dataset:
+    """Remap every variable carrying ``source_dim`` onto ``target_coords``.
+
+    If ``target_coords`` is a :class:`xr.DataArray` and ``target_name``
+    is None, the new dim name is taken from ``target_coords.name``;
+    otherwise ``target_name`` (or ``source_dim``) is used.
+
+    Targets outside the source range produce NaN (no extrapolation).
+    """
+    if source_dim not in ds.dims:
+        raise ValueError(
+            f"source_dim {source_dim!r} not in Dataset dims {tuple(ds.dims)}"
+        )
+    if source_dim not in ds.coords:
+        raise ValueError(
+            f"Dataset must carry a coordinate named {source_dim!r} "
+            "for the source axis values"
+        )
+
+    if isinstance(target_coords, xr.DataArray):
+        new_name = target_name or target_coords.name or source_dim
+        tgt = np.asarray(target_coords.values, dtype=float)
+    else:
+        new_name = target_name or source_dim
+        tgt = np.asarray(target_coords, dtype=float)
+
+    src = np.asarray(ds[source_dim].values, dtype=float)
+
+    out_vars: dict[str, xr.DataArray] = {}
+    for name, da in ds.data_vars.items():
+        if source_dim not in da.dims or not np.issubdtype(da.dtype, np.number):
+            out_vars[str(name)] = da
+            continue
+        axis = da.get_axis_num(source_dim)
+        new_values = _array.remap_axis(
+            da.values,
+            axis=axis,
+            source_coords=src,
+            target_coords=tgt,
+            method=method,
+        )
+        new_dims = tuple(new_name if d == source_dim else d for d in da.dims)
+        new_coords = {
+            cname: c
+            for cname, c in da.coords.items()
+            if source_dim not in c.dims and cname != source_dim
+        }
+        new_coords[new_name] = xr.DataArray(tgt, dims=(new_name,), name=new_name)
+        out_vars[str(name)] = xr.DataArray(
+            new_values,
+            dims=new_dims,
+            coords=new_coords,
+            attrs=dict(da.attrs),
+            name=da.name,
+        )
+
+    base_coords = {
+        cname: c
+        for cname, c in ds.coords.items()
+        if source_dim not in c.dims and cname != source_dim
+    }
+    base_coords[new_name] = xr.DataArray(tgt, dims=(new_name,), name=new_name)
+    return xr.Dataset(out_vars, coords=base_coords, attrs=dict(ds.attrs))
+
+
+def to_phase(
+    ds: xr.Dataset,
+    *,
+    time_dim: str,
+    period: float,
+    n_bins: int,
+    epoch: float = 0.0,
+) -> xr.Dataset:
+    """Fold ``time_dim`` onto a phase axis by binning + averaging.
+
+    The time coordinate must be numeric in the same units as ``period``.
+    Phase is computed as ``((t - epoch) / period) mod 1`` and binned
+    into ``n_bins`` evenly-spaced bins on ``[0, 1)``. Output carries
+    a ``"phase"`` dim with coordinate values at bin centers.
+    """
+    if time_dim not in ds.dims:
+        raise ValueError(f"time_dim {time_dim!r} not in Dataset dims {tuple(ds.dims)}")
+    if period <= 0:
+        raise ValueError(f"period must be > 0, got {period}")
+    if n_bins < 1:
+        raise ValueError(f"n_bins must be >= 1, got {n_bins}")
+
+    t = np.asarray(ds[time_dim].values, dtype=float)
+    phase = ((t - epoch) / period) % 1.0
+    edges = np.linspace(0.0, 1.0, n_bins + 1)
+    centers = 0.5 * (edges[:-1] + edges[1:])
+    bin_idx = np.clip(np.searchsorted(edges, phase, side="right") - 1, 0, n_bins - 1)
+
+    out_vars: dict[str, xr.DataArray] = {}
+    for name, da in ds.data_vars.items():
+        if time_dim not in da.dims or not np.issubdtype(da.dtype, np.number):
+            out_vars[str(name)] = da
+            continue
+        axis = da.get_axis_num(time_dim)
+        moved = np.moveaxis(da.values, axis, 0)
+        flat = moved.reshape(moved.shape[0], -1)
+        sums = np.zeros((n_bins, flat.shape[1]), dtype=float)
+        counts = np.zeros((n_bins, flat.shape[1]), dtype=float)
+        valid = ~np.isnan(flat)
+        for b in range(n_bins):
+            m = bin_idx == b
+            if not m.any():
+                continue
+            sub = flat[m]
+            sub_valid = valid[m]
+            sums[b] = np.where(sub_valid, sub, 0.0).sum(axis=0)
+            counts[b] = sub_valid.sum(axis=0)
+        with np.errstate(invalid="ignore"):
+            mean = np.where(counts > 0, sums / counts, np.nan)
+        out_shape = (n_bins, *moved.shape[1:])
+        new_values = mean.reshape(out_shape)
+        new_values = np.moveaxis(new_values, 0, axis)
+        new_dims = tuple("phase" if d == time_dim else d for d in da.dims)
+        new_coords = {
+            cname: c
+            for cname, c in da.coords.items()
+            if time_dim not in c.dims and cname != time_dim
+        }
+        new_coords["phase"] = xr.DataArray(centers, dims=("phase",), name="phase")
+        out_vars[str(name)] = xr.DataArray(
+            new_values,
+            dims=new_dims,
+            coords=new_coords,
+            attrs=dict(da.attrs),
+            name=da.name,
+        )
+
+    base_coords = {
+        cname: c
+        for cname, c in ds.coords.items()
+        if time_dim not in c.dims and cname != time_dim
+    }
+    base_coords["phase"] = xr.DataArray(centers, dims=("phase",), name="phase")
+    return xr.Dataset(out_vars, coords=base_coords, attrs=dict(ds.attrs))
+
+
+__all__ = ["remap_axis", "to_phase"]

--- a/src/xr_toolz/interpolate/_src/coord_remap.py
+++ b/src/xr_toolz/interpolate/_src/coord_remap.py
@@ -130,7 +130,8 @@ def to_phase(
         raise ValueError(f"n_bins must be >= 1, got {n_bins}")
 
     t = np.asarray(ds[time_dim].values, dtype=float)
-    phase = ((t - epoch) / period) % 1.0
+    finite_t = np.isfinite(t)
+    phase = np.where(finite_t, ((t - epoch) / period) % 1.0, 0.0)
     edges = np.linspace(0.0, 1.0, n_bins + 1)
     centers = 0.5 * (edges[:-1] + edges[1:])
     bin_idx = np.clip(np.searchsorted(edges, phase, side="right") - 1, 0, n_bins - 1)
@@ -149,19 +150,35 @@ def to_phase(
         axis = da.get_axis_num(time_dim)
         moved = np.moveaxis(da.values, axis, 0)
         flat = moved.reshape(moved.shape[0], -1)
-        sums = np.zeros((n_bins, flat.shape[1]), dtype=float)
+        # Use a complex accumulator if the data is complex so the
+        # imaginary part isn't dropped (P1 review).
+        is_complex = np.iscomplexobj(flat)
+        acc_dtype = np.complex128 if is_complex else float
+        sums = np.zeros((n_bins, flat.shape[1]), dtype=acc_dtype)
         counts = np.zeros((n_bins, flat.shape[1]), dtype=float)
-        valid = ~np.isnan(flat)
+        # A sample is valid only if its time coord is finite AND every
+        # data value is finite. Excluding NaN-time rows keeps stale rows
+        # out of the phase means (P2 review).
+        valid_value = (
+            ~np.isnan(flat)
+            if not is_complex
+            else (~np.isnan(flat.real) & ~np.isnan(flat.imag))
+        )
+        valid = finite_t[:, None] & valid_value
         for b in range(n_bins):
-            m = bin_idx == b
+            m = (bin_idx == b) & finite_t
             if not m.any():
                 continue
             sub = flat[m]
             sub_valid = valid[m]
-            sums[b] = np.where(sub_valid, sub, 0.0).sum(axis=0)
+            zero = acc_dtype(0)
+            sums[b] = np.where(sub_valid, sub, zero).sum(axis=0)
             counts[b] = sub_valid.sum(axis=0)
         with np.errstate(invalid="ignore"):
-            mean = np.where(counts > 0, sums / counts, np.nan)
+            nan_fill = (np.nan + 0j) if is_complex else np.nan
+            mean = np.where(
+                counts > 0, sums / np.where(counts > 0, counts, 1.0), nan_fill
+            )
         out_shape = (n_bins, *moved.shape[1:])
         new_values = mean.reshape(out_shape)
         new_values = np.moveaxis(new_values, 0, axis)

--- a/src/xr_toolz/interpolate/_src/coord_remap.py
+++ b/src/xr_toolz/interpolate/_src/coord_remap.py
@@ -58,9 +58,19 @@ def remap_axis(
 
     out_vars: dict[str, xr.DataArray] = {}
     for name, da in ds.data_vars.items():
-        if source_dim not in da.dims or not np.issubdtype(da.dtype, np.number):
+        if source_dim not in da.dims:
+            # Variable doesn't depend on the source axis — pass through.
             out_vars[str(name)] = da
             continue
+        if not np.issubdtype(da.dtype, np.number):
+            # A non-numeric variable that depends on source_dim cannot be
+            # interpolated; passing it through would leave the output with a
+            # phantom source_dim axis (and possibly incompatible sizes).
+            raise TypeError(
+                f"variable {name!r} carries source_dim {source_dim!r} but has "
+                f"non-numeric dtype {da.dtype}; drop or convert it before "
+                "calling remap_axis"
+            )
         axis = da.get_axis_num(source_dim)
         new_values = _array.remap_axis(
             da.values,
@@ -110,6 +120,10 @@ def to_phase(
     """
     if time_dim not in ds.dims:
         raise ValueError(f"time_dim {time_dim!r} not in Dataset dims {tuple(ds.dims)}")
+    if time_dim not in ds.coords:
+        raise ValueError(
+            f"Dataset must carry a coordinate named {time_dim!r} to compute phase"
+        )
     if period <= 0:
         raise ValueError(f"period must be > 0, got {period}")
     if n_bins < 1:
@@ -123,9 +137,15 @@ def to_phase(
 
     out_vars: dict[str, xr.DataArray] = {}
     for name, da in ds.data_vars.items():
-        if time_dim not in da.dims or not np.issubdtype(da.dtype, np.number):
+        if time_dim not in da.dims:
             out_vars[str(name)] = da
             continue
+        if not np.issubdtype(da.dtype, np.number):
+            raise TypeError(
+                f"variable {name!r} carries time_dim {time_dim!r} but has "
+                f"non-numeric dtype {da.dtype}; drop or convert it before "
+                "calling to_phase"
+            )
         axis = da.get_axis_num(time_dim)
         moved = np.moveaxis(da.values, axis, 0)
         flat = moved.reshape(moved.shape[0], -1)

--- a/src/xr_toolz/interpolate/_src/downscale.py
+++ b/src/xr_toolz/interpolate/_src/downscale.py
@@ -1,11 +1,78 @@
-"""Learned value resampling (placeholder).
+"""Tier B/C — learned resolution-change operators (D12, F3.4).
 
-Future home for ``Downscale`` (learned refinement / super-resolution)
-and ``Upscale`` (learned aggregation / subgrid-scale surrogate)
-``ModelOp`` wrappers. See D12 and issue #36.
+Per D12, ``Downscale`` is *learned* refinement (super-resolution) and
+``Upscale`` is *learned* aggregation (subgrid-scale surrogate); the
+deterministic counterparts ``Refine`` / ``Coarsen`` live in
+:mod:`._src.grid_to_grid`.
+
+Per the F3.5 resolution of D12 Q1, both operators are pure callable
+wrappers — they do not carry ``patch_size`` / ``overlap`` constructor
+args. Patch tiling is delegated to ``xrpatcher`` upstream of the
+operator (compose ``patcher | Downscale(model) | unpatcher``).
+
+The wrapped ``model`` is duck-typed: it can be a
+:class:`~xr_toolz.inference.modelop.ModelOp`, any other
+:class:`~xr_toolz.core.Operator`, or a plain callable that maps an
+input container (Dataset / DataArray / array) to an output container.
+No framework imports here (D4).
 """
 
 from __future__ import annotations
 
+from typing import Any
 
-__all__: list[str] = []
+from xr_toolz.core import Operator
+
+
+class _ResolutionOp(Operator):
+    """Common base for learned resolution-change operators.
+
+    Stores a callable ``model`` and an optional ``target_grid`` (a
+    Dataset, DataArray, or any object the user wants to attach as a
+    reference output specification — not used inside ``_apply``; the
+    model is responsible for emitting the right resolution).
+    """
+
+    def __init__(self, model: Any, *, target_grid: Any = None) -> None:
+        if not callable(model):
+            raise TypeError(
+                f"model must be callable (Operator / ModelOp / function), "
+                f"got {type(model).__name__}"
+            )
+        self.model = model
+        self.target_grid = target_grid
+
+    def _apply(self, data: Any) -> Any:
+        return self.model(data)
+
+    def get_config(self) -> dict[str, Any]:
+        model_repr = (
+            type(self.model).__name__
+            if not isinstance(self.model, type)
+            else self.model.__name__
+        )
+        return {
+            "model": f"<{model_repr}>",
+            "target_grid": "<grid>" if self.target_grid is not None else None,
+        }
+
+
+class Downscale(_ResolutionOp):
+    """Learned refinement (super-resolution).
+
+    Wraps a model that maps a coarse-resolution input to a
+    fine-resolution output. Per D12, ``Refine`` is the deterministic
+    counterpart in :mod:`xr_toolz.interpolate._src.grid_to_grid`.
+    """
+
+
+class Upscale(_ResolutionOp):
+    """Learned aggregation (subgrid-scale surrogate).
+
+    Wraps a model that maps a fine-resolution input to a
+    coarse-resolution output. Per D12, ``Coarsen`` is the deterministic
+    counterpart in :mod:`xr_toolz.interpolate._src.grid_to_grid`.
+    """
+
+
+__all__ = ["Downscale", "Upscale"]

--- a/src/xr_toolz/interpolate/array.py
+++ b/src/xr_toolz/interpolate/array.py
@@ -13,6 +13,7 @@ These are the kernels Tier B (xarray, ``dim=``) and Tier C
 
 from __future__ import annotations
 
+from xr_toolz.interpolate._src.array_coord_remap import remap_axis
 from xr_toolz.interpolate._src.array_smooth import (
     gaussian_smooth,
     lowpass_filter,
@@ -24,4 +25,5 @@ __all__ = [
     "gaussian_smooth",
     "lowpass_filter",
     "moving_average",
+    "remap_axis",
 ]

--- a/src/xr_toolz/interpolate/operators.py
+++ b/src/xr_toolz/interpolate/operators.py
@@ -12,10 +12,12 @@ from __future__ import annotations
 from typing import Any
 
 import numpy as np
+import xarray as xr
 
 from xr_toolz.core import Operator
 from xr_toolz.interpolate._src import (
     binning as _binning,
+    coord_remap as _coord_remap,
     gap_fill as _gap_fill,
     grid_to_grid as _grid_to_grid,
     points_to_grid as _points_to_grid,
@@ -352,17 +354,205 @@ class LowpassFilter(Operator):
         }
 
 
+# ---------- coord remap ----------------------------------------------------
+
+
+class RemapAxis(Operator):
+    """Generic axis remapping (D12).
+
+    Replaces the ``source_axis`` dimension in the input Dataset with a
+    new dimension whose coordinate values are ``target_axis``. Every
+    numeric variable that carries ``source_axis`` is interpolated onto
+    the target axis.
+
+    Parameters
+    ----------
+    source_axis
+        Name of the existing dimension to remap.
+    target_axis
+        Target coordinate values. If an :class:`xr.DataArray`, its
+        ``.name`` becomes the new dim name; otherwise the new dim name
+        defaults to ``target_name`` or ``source_axis``.
+    target_name
+        Optional explicit new dim name.
+    method
+        ``"linear"`` or ``"nearest"``.
+    """
+
+    def __init__(
+        self,
+        source_axis: str,
+        target_axis: xr.DataArray | np.ndarray | list,
+        *,
+        target_name: str | None = None,
+        method: str = "linear",
+    ):
+        self.source_axis = source_axis
+        if isinstance(target_axis, xr.DataArray):
+            self._target_da = target_axis
+            self._target_values: np.ndarray = np.asarray(
+                target_axis.values, dtype=float
+            )
+            self._inferred_name = target_axis.name
+        else:
+            self._target_da = None
+            self._target_values = np.asarray(target_axis, dtype=float)
+            self._inferred_name = None
+        self.target_name = target_name
+        self.method = method
+
+    def _apply(self, ds):
+        target = self._target_da if self._target_da is not None else self._target_values
+        return _coord_remap.remap_axis(
+            ds,
+            source_dim=self.source_axis,
+            target_coords=target,
+            target_name=self.target_name,
+            method=self.method,
+        )
+
+    def get_config(self) -> dict[str, Any]:
+        return {
+            "source_axis": self.source_axis,
+            "target_axis": self._target_values.tolist(),
+            "target_name": self.target_name or self._inferred_name,
+            "method": self.method,
+        }
+
+
+# Vertical presets — thin specializations that pin convention names. The
+# user supplies the target coordinate values; the preset names the new
+# dim and the source dim conventionally.
+
+
+class _VerticalPreset(RemapAxis):
+    """Common base for vertical-axis presets — pins ``target_name`` only."""
+
+    _DEFAULT_TARGET_NAME: str = ""
+    _DEFAULT_SOURCE: str = "depth"
+
+    def __init__(
+        self,
+        target_axis: xr.DataArray | np.ndarray | list,
+        *,
+        source_axis: str | None = None,
+        target_name: str | None = None,
+        method: str = "linear",
+    ):
+        super().__init__(
+            source_axis=source_axis or self._DEFAULT_SOURCE,
+            target_axis=target_axis,
+            target_name=target_name or self._DEFAULT_TARGET_NAME,
+            method=method,
+        )
+
+
+class ToSigma(_VerticalPreset):
+    """Remap a depth axis to terrain-following ``sigma`` values."""
+
+    _DEFAULT_TARGET_NAME = "sigma"
+    _DEFAULT_SOURCE = "depth"
+
+
+class FromSigma(_VerticalPreset):
+    """Remap a ``sigma`` axis back to a fixed depth grid."""
+
+    _DEFAULT_TARGET_NAME = "depth"
+    _DEFAULT_SOURCE = "sigma"
+
+
+class ToIsopycnal(_VerticalPreset):
+    """Remap a depth axis to potential-density (isopycnal) levels."""
+
+    _DEFAULT_TARGET_NAME = "sigma_theta"
+    _DEFAULT_SOURCE = "depth"
+
+
+class ToPressureLevels(_VerticalPreset):
+    """Remap a height/depth axis to standard pressure levels."""
+
+    _DEFAULT_TARGET_NAME = "pressure"
+    _DEFAULT_SOURCE = "level"
+
+
+class ToHeight(_VerticalPreset):
+    """Remap a pressure or hybrid axis to geometric height."""
+
+    _DEFAULT_TARGET_NAME = "height"
+    _DEFAULT_SOURCE = "level"
+
+
+class ToPhase(Operator):
+    """Fold a time axis onto a phase axis by binning + averaging.
+
+    Phase is computed as ``((t - epoch) / period) mod 1`` and binned
+    into ``n_bins`` evenly-spaced bins on ``[0, 1)``.
+
+    Parameters
+    ----------
+    time_dim
+        Name of the time dimension.
+    period
+        Length of one cycle, in the same units as the time coordinate.
+    n_bins
+        Number of phase bins.
+    epoch
+        Reference time at which phase = 0.
+    """
+
+    def __init__(
+        self,
+        time_dim: str,
+        period: float,
+        n_bins: int,
+        *,
+        epoch: float = 0.0,
+    ):
+        if period <= 0:
+            raise ValueError(f"period must be > 0, got {period}")
+        if n_bins < 1:
+            raise ValueError(f"n_bins must be >= 1, got {n_bins}")
+        self.time_dim = time_dim
+        self.period = float(period)
+        self.n_bins = int(n_bins)
+        self.epoch = float(epoch)
+
+    def _apply(self, ds):
+        return _coord_remap.to_phase(
+            ds,
+            time_dim=self.time_dim,
+            period=self.period,
+            n_bins=self.n_bins,
+            epoch=self.epoch,
+        )
+
+    def get_config(self) -> dict[str, Any]:
+        return {
+            "time_dim": self.time_dim,
+            "period": self.period,
+            "n_bins": self.n_bins,
+            "epoch": self.epoch,
+        }
+
+
 __all__ = [
     "Bin2D",
     "Coarsen",
     "FillNaNRBF",
     "FillNaNSpatial",
     "FillNaNTemporal",
+    "FromSigma",
     "GaussianSmooth",
     "Histogram2D",
     "LowpassFilter",
     "MovingAverage",
     "PointsToGrid",
     "Refine",
+    "RemapAxis",
     "ResampleTime",
+    "ToHeight",
+    "ToIsopycnal",
+    "ToPhase",
+    "ToPressureLevels",
+    "ToSigma",
 ]

--- a/src/xr_toolz/interpolate/operators.py
+++ b/src/xr_toolz/interpolate/operators.py
@@ -18,6 +18,7 @@ from xr_toolz.core import Operator
 from xr_toolz.interpolate._src import (
     binning as _binning,
     coord_remap as _coord_remap,
+    downscale as _downscale,
     gap_fill as _gap_fill,
     grid_to_grid as _grid_to_grid,
     points_to_grid as _points_to_grid,
@@ -535,9 +536,18 @@ class ToPhase(Operator):
         }
 
 
+# ---------- learned resolution change --------------------------------------
+
+# Re-export Downscale / Upscale from _src.downscale so all Layer-1 Operators
+# are reachable from xr_toolz.interpolate.operators.
+Downscale = _downscale.Downscale
+Upscale = _downscale.Upscale
+
+
 __all__ = [
     "Bin2D",
     "Coarsen",
+    "Downscale",
     "FillNaNRBF",
     "FillNaNSpatial",
     "FillNaNTemporal",
@@ -555,4 +565,5 @@ __all__ = [
     "ToPhase",
     "ToPressureLevels",
     "ToSigma",
+    "Upscale",
 ]

--- a/tests/test_interpolate_coord_remap.py
+++ b/tests/test_interpolate_coord_remap.py
@@ -1,0 +1,278 @@
+"""Tests for ``xr_toolz.interpolate`` coord_remap (F3.2, D12)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from xr_toolz.interpolate import array as ia, remap_axis, to_phase
+from xr_toolz.interpolate.operators import (
+    FromSigma,
+    RemapAxis,
+    ToHeight,
+    ToIsopycnal,
+    ToPhase,
+    ToPressureLevels,
+    ToSigma,
+)
+
+
+# ---------------------------------------------------------------------------
+# Tier A — remap_axis
+# ---------------------------------------------------------------------------
+
+
+def test_array_remap_identity_when_target_equals_source():
+    src = np.linspace(0.0, 10.0, 11)
+    values = np.sin(src)
+    out = ia.remap_axis(values, axis=-1, source_coords=src, target_coords=src)
+    np.testing.assert_allclose(out, values)
+
+
+def test_array_remap_linear_recovers_known_function():
+    src = np.linspace(0.0, 1.0, 21)
+    values = 2.0 * src + 3.0  # exactly representable by linear interp
+    tgt = np.linspace(0.0, 1.0, 7)
+    out = ia.remap_axis(values, axis=-1, source_coords=src, target_coords=tgt)
+    np.testing.assert_allclose(out, 2.0 * tgt + 3.0, rtol=1e-12)
+
+
+def test_array_remap_2d_along_first_axis():
+    src = np.linspace(0.0, 1.0, 11)
+    field = np.outer(src, np.arange(4, dtype=float))  # shape (11, 4)
+    tgt = np.array([0.25, 0.5, 0.75])
+    out = ia.remap_axis(field, axis=0, source_coords=src, target_coords=tgt)
+    assert out.shape == (3, 4)
+    np.testing.assert_allclose(out, np.outer(tgt, np.arange(4, dtype=float)))
+
+
+def test_array_remap_handles_descending_source():
+    src = np.linspace(10.0, 0.0, 11)  # descending
+    values = src.copy()  # f(x)=x
+    tgt = np.array([2.0, 5.0, 8.0])
+    out = ia.remap_axis(values, axis=-1, source_coords=src, target_coords=tgt)
+    np.testing.assert_allclose(out, tgt, rtol=1e-12)
+
+
+def test_array_remap_outside_range_returns_nan():
+    src = np.linspace(0.0, 1.0, 11)
+    values = np.ones_like(src)
+    tgt = np.array([-0.5, 0.5, 1.5])
+    out = ia.remap_axis(values, axis=-1, source_coords=src, target_coords=tgt)
+    assert np.isnan(out[0])
+    assert out[1] == 1.0
+    assert np.isnan(out[2])
+
+
+def test_array_remap_nearest_method():
+    src = np.array([0.0, 1.0, 2.0, 3.0])
+    values = np.array([10.0, 20.0, 30.0, 40.0])
+    tgt = np.array([0.4, 1.6, 2.9])
+    out = ia.remap_axis(
+        values, axis=-1, source_coords=src, target_coords=tgt, method="nearest"
+    )
+    # 0.4 → 0.0; 1.6 → 2.0; 2.9 → 3.0
+    np.testing.assert_array_equal(out, np.array([10.0, 30.0, 40.0]))
+
+
+def test_array_remap_invalid_method_raises():
+    src = np.array([0.0, 1.0])
+    with pytest.raises(ValueError):
+        ia.remap_axis(
+            np.array([1.0, 2.0]),
+            axis=-1,
+            source_coords=src,
+            target_coords=src,
+            method="bogus",
+        )
+
+
+def test_array_remap_non_monotonic_source_raises():
+    with pytest.raises(ValueError):
+        ia.remap_axis(
+            np.array([1.0, 2.0, 3.0]),
+            axis=-1,
+            source_coords=np.array([0.0, 2.0, 1.0]),
+            target_coords=np.array([0.5]),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tier B — Dataset wrappers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def ds_profile():
+    """Synthetic ocean profile: T(z) = 20 - 0.1 * z, with a horizontal axis."""
+    z = np.linspace(0.0, 100.0, 21)
+    x = np.arange(4)
+    T = 20.0 - 0.1 * z[:, None] + 0.0 * x[None, :]
+    return xr.Dataset(
+        {"T": (("depth", "x"), T)},
+        coords={"depth": z, "x": x},
+    )
+
+
+def test_tier_b_remap_axis_replaces_dim(ds_profile):
+    new_z = np.linspace(0.0, 100.0, 11)
+    out = remap_axis(
+        ds_profile,
+        source_dim="depth",
+        target_coords=new_z,
+    )
+    assert "depth" in out.dims
+    assert out.sizes["depth"] == 11
+    np.testing.assert_allclose(out["T"].values[:, 0], 20.0 - 0.1 * new_z)
+
+
+def test_tier_b_remap_axis_renames_via_target_name(ds_profile):
+    out = remap_axis(
+        ds_profile,
+        source_dim="depth",
+        target_coords=np.linspace(0.0, 100.0, 11),
+        target_name="z_new",
+    )
+    assert "z_new" in out.dims
+    assert "depth" not in out.dims
+
+
+def test_tier_b_remap_axis_uses_dataarray_name(ds_profile):
+    target = xr.DataArray(np.linspace(0.0, 100.0, 11), dims=("z2",), name="z2")
+    out = remap_axis(ds_profile, source_dim="depth", target_coords=target)
+    assert "z2" in out.dims
+
+
+def test_tier_b_unknown_source_dim_raises(ds_profile):
+    with pytest.raises(ValueError):
+        remap_axis(ds_profile, source_dim="bogus", target_coords=np.array([0.0, 1.0]))
+
+
+# ---------------------------------------------------------------------------
+# Tier B — to_phase
+# ---------------------------------------------------------------------------
+
+
+def test_to_phase_recovers_diurnal_sinusoid():
+    """A sinusoid with period 24 sampled over many days should fold cleanly."""
+    period = 24.0
+    n_days = 30
+    n_per_day = 48  # half-hourly
+    t = np.arange(n_days * n_per_day) * (period / n_per_day)
+    signal = np.sin(2 * np.pi * t / period)
+    ds = xr.Dataset({"x": (("time",), signal)}, coords={"time": t})
+    out = to_phase(ds, time_dim="time", period=period, n_bins=24)
+
+    assert out.sizes["phase"] == 24
+    phases = out["phase"].values
+    expected = np.sin(2 * np.pi * phases)
+    np.testing.assert_allclose(out["x"].values, expected, atol=0.05)
+
+
+def test_to_phase_invalid_args_raise():
+    ds = xr.Dataset({"x": (("time",), np.zeros(10))}, coords={"time": np.arange(10)})
+    with pytest.raises(ValueError):
+        to_phase(ds, time_dim="time", period=0.0, n_bins=8)
+    with pytest.raises(ValueError):
+        to_phase(ds, time_dim="time", period=1.0, n_bins=0)
+    with pytest.raises(ValueError):
+        to_phase(ds, time_dim="bogus", period=1.0, n_bins=8)
+
+
+# ---------------------------------------------------------------------------
+# Tier B → C — round-trip identity (ToSigma → FromSigma)
+# ---------------------------------------------------------------------------
+
+
+def test_to_sigma_from_sigma_round_trip():
+    """ToSigma then FromSigma on a synthetic profile recovers the original.
+
+    Builds a simple linear depth → sigma mapping and remaps T(depth) →
+    T(sigma) → T(depth).
+    """
+    z = np.linspace(0.0, 100.0, 41)
+    T = 20.0 - 0.1 * z + 0.001 * z**2
+    ds = xr.Dataset({"T": (("depth",), T)}, coords={"depth": z})
+
+    # Linear mapping: sigma = -depth / H, so sigma in [-1, 0].
+    H = 100.0
+    sigma_levels = np.linspace(-1.0, 0.0, 51)
+
+    # Forward: build a target that carries depth values at chosen sigma levels.
+    # Since sigma = -depth/H, depth at each sigma is -sigma * H.
+    depth_at_sigma = -sigma_levels * H
+    # Use generic remap_axis: source=depth, target=depth_at_sigma but rename to sigma.
+    sig = ToSigma(
+        target_axis=xr.DataArray(depth_at_sigma, dims=("sigma",), name="sigma")
+    )
+    in_sigma = sig(ds)
+    assert "sigma" in in_sigma.dims
+    assert in_sigma.sizes["sigma"] == 51
+
+    # Reverse: from the sigma-frame Dataset, remap back to a regular depth
+    # grid. Source dim is now "sigma" (with values = depth_at_sigma — note
+    # that ToSigma puts the *target* values into the new "sigma" coord, so
+    # the sigma coord here actually holds depth_at_sigma).
+    back = FromSigma(target_axis=z)(in_sigma)
+    assert "depth" in back.dims
+    # Quadratic profile through two linear interpolations introduces a
+    # small interpolation error proportional to the squared step size.
+    np.testing.assert_allclose(back["T"].values, T, atol=1e-2)
+
+
+# ---------------------------------------------------------------------------
+# Tier C — Operator wrappers
+# ---------------------------------------------------------------------------
+
+
+def test_remap_axis_operator_matches_function(ds_profile):
+    new_z = np.linspace(0.0, 100.0, 11)
+    op = RemapAxis("depth", new_z)
+    np.testing.assert_allclose(
+        op(ds_profile)["T"].values,
+        remap_axis(ds_profile, source_dim="depth", target_coords=new_z)["T"].values,
+    )
+
+
+def test_to_phase_operator_matches_function():
+    period = 24.0
+    t = np.arange(240) * 0.5
+    signal = np.cos(2 * np.pi * t / period)
+    ds = xr.Dataset({"x": (("time",), signal)}, coords={"time": t})
+    op = ToPhase("time", period=period, n_bins=12)
+    np.testing.assert_allclose(
+        op(ds)["x"].values,
+        to_phase(ds, time_dim="time", period=period, n_bins=12)["x"].values,
+    )
+
+
+def test_vertical_presets_default_dim_names():
+    """Each preset names the output dim conventionally."""
+    z = np.linspace(0.0, 100.0, 11)
+    ds = xr.Dataset({"T": (("depth",), z)}, coords={"depth": z})
+    target = np.linspace(0.0, 100.0, 5)
+
+    out_sigma = ToSigma(target_axis=target)(ds)
+    assert "sigma" in out_sigma.dims
+
+    out_iso = ToIsopycnal(target_axis=target)(ds)
+    assert "sigma_theta" in out_iso.dims
+
+    ds_p = xr.Dataset({"T": (("level",), z)}, coords={"level": z})
+    out_p = ToPressureLevels(target_axis=target)(ds_p)
+    assert "pressure" in out_p.dims
+
+    out_h = ToHeight(target_axis=target)(ds_p)
+    assert "height" in out_h.dims
+
+
+def test_remap_axis_get_config_is_serializable():
+    op = RemapAxis("depth", np.array([0.0, 50.0, 100.0]), target_name="z")
+    cfg = op.get_config()
+    assert cfg == {
+        "source_axis": "depth",
+        "target_axis": [0.0, 50.0, 100.0],
+        "target_name": "z",
+        "method": "linear",
+    }

--- a/tests/test_interpolate_coord_remap.py
+++ b/tests/test_interpolate_coord_remap.py
@@ -318,6 +318,74 @@ def test_to_phase_rejects_non_numeric_var_with_time_dim():
         to_phase(ds, time_dim="time", period=1.0, n_bins=8)
 
 
+def test_array_remap_preserves_complex_dtype():
+    """Complex inputs must not silently lose their imaginary component."""
+    src = np.linspace(0.0, 1.0, 11)
+    z = src + 1j * src**2
+    tgt = np.array([0.25, 0.5, 0.75])
+    out = ia.remap_axis(z, axis=-1, source_coords=src, target_coords=tgt)
+    assert np.iscomplexobj(out)
+    np.testing.assert_allclose(out.real, tgt, atol=1e-12)
+    # Linear interpolation of x^2 incurs O(h^2) discretization error.
+    np.testing.assert_allclose(out.imag, tgt**2, atol=5e-3)
+
+
+def test_array_remap_nan_target_returns_nan_linear():
+    src = np.linspace(0.0, 1.0, 5)
+    out = ia.remap_axis(
+        np.arange(5, dtype=float),
+        axis=-1,
+        source_coords=src,
+        target_coords=np.array([0.5, np.nan, 0.75]),
+    )
+    assert not np.isnan(out[0])
+    assert np.isnan(out[1])
+    assert not np.isnan(out[2])
+
+
+def test_array_remap_nan_target_returns_nan_nearest():
+    src = np.linspace(0.0, 1.0, 5)
+    out = ia.remap_axis(
+        np.arange(5, dtype=float),
+        axis=-1,
+        source_coords=src,
+        target_coords=np.array([0.1, np.nan, 0.9]),
+        method="nearest",
+    )
+    assert np.isnan(out[1])
+    assert not np.isnan(out[0])
+    assert not np.isnan(out[2])
+
+
+def test_to_phase_preserves_complex_signal():
+    """Complex time series must fold without dropping the imaginary part."""
+    period = 24.0
+    # Sample much finer than the bin width so the per-bin mean is
+    # close to ``exp(i 2π * bin_center)``.
+    n_per_period = 240
+    n = n_per_period * 30
+    t = np.arange(n, dtype=float) * (period / n_per_period)
+    z = np.exp(1j * 2 * np.pi * t / period)
+    ds = xr.Dataset({"z": (("time",), z)}, coords={"time": t})
+    out = to_phase(ds, time_dim="time", period=period, n_bins=24)
+    assert np.iscomplexobj(out["z"].values)
+    phases = out["phase"].values
+    expected = np.exp(1j * 2 * np.pi * phases)
+    np.testing.assert_allclose(out["z"].values, expected, atol=0.05)
+
+
+def test_to_phase_drops_nan_time_samples():
+    """Samples with NaN time must not contribute to phase-bin means."""
+    period = 1.0
+    t = np.array([0.1, 0.2, np.nan, 0.6, 0.7])
+    # Bin 0 should average (10, 20); bin 1 (60, 70). The NaN-time sample
+    # has value 1000 — if it leaked into a bin, the mean would explode.
+    values = np.array([10.0, 20.0, 1000.0, 60.0, 70.0])
+    ds = xr.Dataset({"x": (("time",), values)}, coords={"time": t})
+    out = to_phase(ds, time_dim="time", period=period, n_bins=2)
+    np.testing.assert_allclose(out["x"].values, [15.0, 65.0])
+
+
 def test_remap_axis_get_config_is_serializable():
     op = RemapAxis("depth", np.array([0.0, 50.0, 100.0]), target_name="z")
     cfg = op.get_config()

--- a/tests/test_interpolate_coord_remap.py
+++ b/tests/test_interpolate_coord_remap.py
@@ -267,6 +267,57 @@ def test_vertical_presets_default_dim_names():
     assert "height" in out_h.dims
 
 
+def test_remap_axis_rejects_non_numeric_var_with_source_dim():
+    """A non-numeric variable carrying source_dim must raise (review feedback)."""
+    z = np.linspace(0.0, 100.0, 5)
+    ds = xr.Dataset(
+        {
+            "T": (("depth",), 20.0 - 0.1 * z),
+            "flag": (("depth",), np.array(["a", "b", "c", "d", "e"])),
+        },
+        coords={"depth": z},
+    )
+    with pytest.raises(TypeError, match="non-numeric"):
+        remap_axis(
+            ds,
+            source_dim="depth",
+            target_coords=np.linspace(0.0, 100.0, 11),
+        )
+
+
+def test_remap_axis_passes_through_non_dim_non_numeric_var():
+    z = np.linspace(0.0, 100.0, 5)
+    ds = xr.Dataset(
+        {
+            "T": (("depth",), 20.0 - 0.1 * z),
+            "label": ((), "site_42"),
+        },
+        coords={"depth": z},
+    )
+    out = remap_axis(ds, source_dim="depth", target_coords=np.linspace(0.0, 100.0, 11))
+    assert str(out["label"].values) == "site_42"
+
+
+def test_to_phase_requires_time_coord():
+    """Dataset must carry a coordinate named time_dim, not just a dimension."""
+    ds = xr.Dataset({"x": (("time",), np.zeros(10))})  # time has no coord
+    with pytest.raises(ValueError, match="coordinate named"):
+        to_phase(ds, time_dim="time", period=1.0, n_bins=8)
+
+
+def test_to_phase_rejects_non_numeric_var_with_time_dim():
+    t = np.arange(10, dtype=float)
+    ds = xr.Dataset(
+        {
+            "x": (("time",), np.zeros(10)),
+            "label": (("time",), np.array(["a"] * 10)),
+        },
+        coords={"time": t},
+    )
+    with pytest.raises(TypeError, match="non-numeric"):
+        to_phase(ds, time_dim="time", period=1.0, n_bins=8)
+
+
 def test_remap_axis_get_config_is_serializable():
     op = RemapAxis("depth", np.array([0.0, 50.0, 100.0]), target_name="z")
     cfg = op.get_config()

--- a/tests/test_interpolate_downscale.py
+++ b/tests/test_interpolate_downscale.py
@@ -1,0 +1,161 @@
+"""Tests for ``xr_toolz.interpolate.downscale`` (F3.4, D12).
+
+Per F3.5 resolution of D12 Q1, ``Downscale`` and ``Upscale`` are pure
+callable wrappers — patch tiling is delegated to ``xrpatcher`` upstream.
+The smoke tests use a trivial bilinear-resize as the wrapped model.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from xr_toolz.interpolate.operators import Downscale, Upscale
+
+
+def _bilinear_to(target_lon: np.ndarray, target_lat: np.ndarray):
+    """Return a callable that bilinearly resizes a Dataset to the given grid."""
+
+    def _resize(ds: xr.Dataset) -> xr.Dataset:
+        return ds.interp(lon=target_lon, lat=target_lat)
+
+    return _resize
+
+
+@pytest.fixture
+def coarse_ds():
+    lon = np.linspace(0.0, 10.0, 5)
+    lat = np.linspace(-5.0, 5.0, 5)
+    field = np.outer(lat, lon)
+    return xr.Dataset(
+        {"f": (("lat", "lon"), field)},
+        coords={"lat": lat, "lon": lon},
+    )
+
+
+@pytest.fixture
+def fine_ds():
+    lon = np.linspace(0.0, 10.0, 21)
+    lat = np.linspace(-5.0, 5.0, 21)
+    field = np.outer(lat, lon)
+    return xr.Dataset(
+        {"f": (("lat", "lon"), field)},
+        coords={"lat": lat, "lon": lon},
+    )
+
+
+def test_downscale_smoke_wrapping_bilinear_resize(coarse_ds):
+    """Downscale plumbing: coarse 5x5 → fine 21x21 via bilinear-resize callable."""
+    fine_lon = np.linspace(0.0, 10.0, 21)
+    fine_lat = np.linspace(-5.0, 5.0, 21)
+    op = Downscale(_bilinear_to(fine_lon, fine_lat))
+    out = op(coarse_ds)
+
+    assert out.sizes["lon"] == 21
+    assert out.sizes["lat"] == 21
+    # Bilinear on a smooth f(lat, lon) = lat * lon recovers the analytic answer.
+    expected = np.outer(fine_lat, fine_lon)
+    np.testing.assert_allclose(out["f"].values, expected, atol=1e-10)
+
+
+def test_upscale_smoke_wrapping_bilinear_resize(fine_ds):
+    """Upscale plumbing: fine 21x21 → coarse 5x5 via bilinear-resize callable."""
+    coarse_lon = np.linspace(0.0, 10.0, 5)
+    coarse_lat = np.linspace(-5.0, 5.0, 5)
+    op = Upscale(_bilinear_to(coarse_lon, coarse_lat))
+    out = op(fine_ds)
+
+    assert out.sizes["lon"] == 5
+    assert out.sizes["lat"] == 5
+    expected = np.outer(coarse_lat, coarse_lon)
+    np.testing.assert_allclose(out["f"].values, expected, atol=1e-10)
+
+
+def test_downscale_rejects_non_callable():
+    with pytest.raises(TypeError):
+        Downscale(model="not_a_callable")  # type: ignore[arg-type]
+
+
+def test_target_grid_attribute_is_carried(coarse_ds):
+    """The optional target_grid is stored as metadata, not used in _apply."""
+    fine_lon = np.linspace(0.0, 10.0, 21)
+    fine_lat = np.linspace(-5.0, 5.0, 21)
+    grid = xr.Dataset(coords={"lat": fine_lat, "lon": fine_lon})
+
+    op = Downscale(_bilinear_to(fine_lon, fine_lat), target_grid=grid)
+    assert op.target_grid is grid
+
+
+def test_get_config_round_trips_through_json(coarse_ds):
+    """Config must survive ``json.dumps``/``loads`` so it stays serializable."""
+    import json
+
+    fine_lon = np.linspace(0.0, 10.0, 21)
+    fine_lat = np.linspace(-5.0, 5.0, 21)
+    op = Downscale(
+        _bilinear_to(fine_lon, fine_lat),
+        target_grid=xr.Dataset(coords={"lat": fine_lat, "lon": fine_lon}),
+    )
+    cfg = op.get_config()
+    round_tripped = json.loads(json.dumps(cfg))
+    assert round_tripped == cfg
+    assert round_tripped["target_grid"] == "<grid>"
+    assert isinstance(round_tripped["model"], str)
+
+
+def test_no_top_level_jax_or_torch_import():
+    """Per D4, the downscale module must not import JAX or torch.
+
+    Run the import in a fresh subprocess so the result is independent of
+    test ordering — other tests (e.g. ``test_inference_jax``) may have
+    already pulled JAX into ``sys.modules`` of the parent process.
+    """
+    import subprocess
+    import sys
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys\n"
+                "import xr_toolz.interpolate._src.downscale  # noqa: F401\n"
+                "for name in ('jax', 'jaxlib', 'torch'):\n"
+                "    if name in sys.modules:\n"
+                "        print(name)\n"
+            ),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    leaked = [n for n in result.stdout.strip().splitlines() if n]
+    assert leaked == [], f"backend leaked into sys.modules: {leaked}"
+
+
+def test_works_with_arbitrary_operator(coarse_ds):
+    """Downscale composes with any Operator (duck-typed callable).
+
+    The wrapped object doesn't have to be a ``ModelOp`` — any Operator
+    or plain callable works.
+    """
+    from xr_toolz.core import Operator
+
+    class TinyResize(Operator):
+        def __init__(self, lon, lat):
+            self.lon = lon
+            self.lat = lat
+
+        def _apply(self, ds):
+            return ds.interp(lon=self.lon, lat=self.lat)
+
+        def get_config(self):
+            return {"lon": list(self.lon), "lat": list(self.lat)}
+
+    fine_lon = np.linspace(0.0, 10.0, 11)
+    fine_lat = np.linspace(-5.0, 5.0, 11)
+    op = Downscale(TinyResize(fine_lon, fine_lat))
+    out = op(coarse_ds)
+    assert out.sizes["lon"] == 11
+    assert out.sizes["lat"] == 11

--- a/tests/test_interpolate_imports.py
+++ b/tests/test_interpolate_imports.py
@@ -31,13 +31,25 @@ CANONICAL_FUNCS = (
 CANONICAL_OPS = (
     "Bin2D",
     "Coarsen",
+    "Downscale",
     "FillNaNRBF",
     "FillNaNSpatial",
     "FillNaNTemporal",
+    "FromSigma",
+    "GaussianSmooth",
     "Histogram2D",
+    "LowpassFilter",
+    "MovingAverage",
     "PointsToGrid",
     "Refine",
+    "RemapAxis",
     "ResampleTime",
+    "ToHeight",
+    "ToIsopycnal",
+    "ToPhase",
+    "ToPressureLevels",
+    "ToSigma",
+    "Upscale",
 )
 
 REMOVED_FROM_GEO = (
@@ -88,6 +100,6 @@ def test_legacy_geo_operator_names_are_gone() -> None:
 
 
 def test_placeholder_submodules_importable() -> None:
-    for sub in ("downscale", "grid_to_points"):
+    for sub in ("grid_to_points",):
         mod = importlib.import_module(f"xr_toolz.interpolate._src.{sub}")
         assert mod.__all__ == []

--- a/tests/test_interpolate_imports.py
+++ b/tests/test_interpolate_imports.py
@@ -88,6 +88,6 @@ def test_legacy_geo_operator_names_are_gone() -> None:
 
 
 def test_placeholder_submodules_importable() -> None:
-    for sub in ("coord_remap", "downscale", "grid_to_points"):
+    for sub in ("downscale", "grid_to_points"):
         mod = importlib.import_module(f"xr_toolz.interpolate._src.{sub}")
         assert mod.__all__ == []

--- a/tests/test_tier_contract.py
+++ b/tests/test_tier_contract.py
@@ -184,7 +184,12 @@ def test_calc_array_gradient_returns_per_axis() -> None:
 # ---------------------------------------------------------------------------
 
 
-_SMOOTH_NAMES: tuple[str, ...] = ("moving_average", "gaussian_smooth", "lowpass_filter")
+_SMOOTH_NAMES: tuple[str, ...] = (
+    "moving_average",
+    "gaussian_smooth",
+    "lowpass_filter",
+    "remap_axis",
+)
 
 
 @pytest.mark.parametrize("name", _SMOOTH_NAMES)
@@ -242,4 +247,41 @@ def test_interpolate_smooth_tier_c_matches_tier_b() -> None:
     np.testing.assert_allclose(
         LowpassFilter("time", cutoff=0.1)(ds)["x"].values,
         tier_b.lowpass_filter(ds, dim="time", cutoff=0.1)["x"].values,
+    )
+
+
+def test_interpolate_coord_remap_tier_b_matches_tier_a() -> None:
+    """Tier B ``remap_axis`` matches the Tier A kernel on the same data."""
+    from xr_toolz.interpolate import array as ia
+    from xr_toolz.interpolate._src import coord_remap as tier_b
+
+    src = np.linspace(0.0, 100.0, 21)
+    tgt = np.linspace(0.0, 100.0, 11)
+    rng = np.random.default_rng(0)
+    field = rng.standard_normal((src.size, 4))
+    ds = xr.Dataset(
+        {"f": (("depth", "x"), field)},
+        coords={"depth": src, "x": np.arange(4)},
+    )
+    b_out = tier_b.remap_axis(ds, source_dim="depth", target_coords=tgt)["f"].values
+    a_out = ia.remap_axis(field, axis=0, source_coords=src, target_coords=tgt)
+    np.testing.assert_allclose(a_out, b_out)
+
+
+def test_interpolate_coord_remap_tier_c_matches_tier_b() -> None:
+    """Tier C ``RemapAxis`` Operator output equals Tier B function output."""
+    from xr_toolz.interpolate._src import coord_remap as tier_b
+    from xr_toolz.interpolate.operators import RemapAxis
+
+    src = np.linspace(0.0, 100.0, 21)
+    tgt = np.linspace(0.0, 100.0, 11)
+    rng = np.random.default_rng(1)
+    field = rng.standard_normal((src.size, 4))
+    ds = xr.Dataset(
+        {"f": (("depth", "x"), field)},
+        coords={"depth": src, "x": np.arange(4)},
+    )
+    np.testing.assert_allclose(
+        RemapAxis("depth", tgt)(ds)["f"].values,
+        tier_b.remap_axis(ds, source_dim="depth", target_coords=tgt)["f"].values,
     )

--- a/tests/test_tier_contract.py
+++ b/tests/test_tier_contract.py
@@ -180,11 +180,11 @@ def test_calc_array_gradient_returns_per_axis() -> None:
 
 
 # ---------------------------------------------------------------------------
-# interpolate (smoothers — F3.3)
+# interpolate (Tier A array kernels — F3.2 / F3.3)
 # ---------------------------------------------------------------------------
 
 
-_SMOOTH_NAMES: tuple[str, ...] = (
+_INTERPOLATE_ARRAY_NAMES: tuple[str, ...] = (
     "moving_average",
     "gaussian_smooth",
     "lowpass_filter",
@@ -192,7 +192,7 @@ _SMOOTH_NAMES: tuple[str, ...] = (
 )
 
 
-@pytest.mark.parametrize("name", _SMOOTH_NAMES)
+@pytest.mark.parametrize("name", _INTERPOLATE_ARRAY_NAMES)
 def test_interpolate_array_namespace_exports(name: str) -> None:
     """Tier A is reachable via ``xr_toolz.interpolate.array``."""
     from xr_toolz.interpolate import array as ia


### PR DESCRIPTION
## Summary
- Adds \`xr_toolz.interpolate.coord_remap\` per D12: generic \`RemapAxis\` Operator with vertical presets (\`ToSigma\`, \`FromSigma\`, \`ToIsopycnal\`, \`ToPressureLevels\`, \`ToHeight\`) and temporal preset \`ToPhase\`.
- Three-tier (D11): Tier A \`remap_axis\` array kernel (linear / nearest, NaN extrapolation), Tier B Dataset wrapper, Tier C Operator wrappers.
- \`to_phase\` folds a numeric time axis onto a regular phase axis via bin averaging.

## Notes
- **Stacked on #109** (f3.3-smooth) — base is set so the diff is just F3.2 work.
- Vertical presets are intentionally thin: they pin the new dim name (\`sigma\`, \`depth\`, \`sigma_theta\`, \`pressure\`, \`height\`) and a default source dim. The user supplies the target coordinate values (which encode the conversion math, since e.g. σ depends on η and H).
- Round-trip tolerance for \`ToSigma → FromSigma\` is \`atol=1e-2\` because the test uses a quadratic profile through two linear interpolations.
- Per F3.5 (#108), additional presets (\`ToTropopauseRelative\`, \`ToBoundaryLayerCoord\`) are deferred — add on demand.

Closes #34.

## Test plan
- [x] \`pytest tests/test_interpolate_coord_remap.py tests/test_tier_contract.py tests/test_interpolate_smooth.py\` (72 passed)
- [x] \`ruff check .\` / \`ruff format --check .\` clean
- [x] No new \`ty\` errors on \`xr_toolz/interpolate\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)