### PR TITLE
feat(interpolate): downscale submodule (F3.4)

### DIFF
--- a/src/xr_toolz/interpolate/_src/downscale.py
+++ b/src/xr_toolz/interpolate/_src/downscale.py
@@ -1,11 +1,78 @@
-"""Learned value resampling (placeholder).
+"""Tier B/C — learned resolution-change operators (D12, F3.4).
 
-Future home for ``Downscale`` (learned refinement / super-resolution)
-and ``Upscale`` (learned aggregation / subgrid-scale surrogate)
-``ModelOp`` wrappers. See D12 and issue #36.
+Per D12, ``Downscale`` is *learned* refinement (super-resolution) and
+``Upscale`` is *learned* aggregation (subgrid-scale surrogate); the
+deterministic counterparts ``Refine`` / ``Coarsen`` live in
+:mod:`._src.grid_to_grid`.
+
+Per the F3.5 resolution of D12 Q1, both operators are pure callable
+wrappers — they do not carry ``patch_size`` / ``overlap`` constructor
+args. Patch tiling is delegated to ``xrpatcher`` upstream of the
+operator (compose ``patcher | Downscale(model) | unpatcher``).
+
+The wrapped ``model`` is duck-typed: it can be a
+:class:`~xr_toolz.inference.modelop.ModelOp`, any other
+:class:`~xr_toolz.core.Operator`, or a plain callable that maps an
+input container (Dataset / DataArray / array) to an output container.
+No framework imports here (D4).
 """
 
 from __future__ import annotations
 
+from typing import Any
 
-__all__: list[str] = []
+from xr_toolz.core import Operator
+
+
+class _ResolutionOp(Operator):
+    """Common base for learned resolution-change operators.
+
+    Stores a callable ``model`` and an optional ``target_grid`` (a
+    Dataset, DataArray, or any object the user wants to attach as a
+    reference output specification — not used inside ``_apply``; the
+    model is responsible for emitting the right resolution).
+    """
+
+    def __init__(self, model: Any, *, target_grid: Any = None) -> None:
+        if not callable(model):
+            raise TypeError(
+                f"model must be callable (Operator / ModelOp / function), "
+                f"got {type(model).__name__}"
+            )
+        self.model = model
+        self.target_grid = target_grid
+
+    def _apply(self, data: Any) -> Any:
+        return self.model(data)
+
+    def get_config(self) -> dict[str, Any]:
+        model_repr = (
+            type(self.model).__name__
+            if not isinstance(self.model, type)
+            else self.model.__name__
+        )
+        return {
+            "model": f"<{model_repr}>",
+            "target_grid": "<grid>" if self.target_grid is not None else None,
+        }
+
+
+class Downscale(_ResolutionOp):
+    """Learned refinement (super-resolution).
+
+    Wraps a model that maps a coarse-resolution input to a
+    fine-resolution output. Per D12, ``Refine`` is the deterministic
+    counterpart in :mod:`xr_toolz.interpolate._src.grid_to_grid`.
+    """
+
+
+class Upscale(_ResolutionOp):
+    """Learned aggregation (subgrid-scale surrogate).
+
+    Wraps a model that maps a fine-resolution input to a
+    coarse-resolution output. Per D12, ``Coarsen`` is the deterministic
+    counterpart in :mod:`xr_toolz.interpolate._src.grid_to_grid`.
+    """
+
+
+__all__ = ["Downscale", "Upscale"]

--- a/src/xr_toolz/interpolate/operators.py
+++ b/src/xr_toolz/interpolate/operators.py
@@ -18,6 +18,7 @@ from xr_toolz.core import Operator
 from xr_toolz.interpolate._src import (
     binning as _binning,
     coord_remap as _coord_remap,
+    downscale as _downscale,
     gap_fill as _gap_fill,
     grid_to_grid as _grid_to_grid,
     points_to_grid as _points_to_grid,
@@ -535,9 +536,18 @@ class ToPhase(Operator):
         }
 
 
+# ---------- learned resolution change --------------------------------------
+
+# Re-export Downscale / Upscale from _src.downscale so all Layer-1 Operators
+# are reachable from xr_toolz.interpolate.operators.
+Downscale = _downscale.Downscale
+Upscale = _downscale.Upscale
+
+
 __all__ = [
     "Bin2D",
     "Coarsen",
+    "Downscale",
     "FillNaNRBF",
     "FillNaNSpatial",
     "FillNaNTemporal",
@@ -555,4 +565,5 @@ __all__ = [
     "ToPhase",
     "ToPressureLevels",
     "ToSigma",
+    "Upscale",
 ]

--- a/tests/test_interpolate_downscale.py
+++ b/tests/test_interpolate_downscale.py
@@ -87,7 +87,10 @@ def test_target_grid_attribute_is_carried(coarse_ds):
     assert op.target_grid is grid
 
 
-def test_get_config_is_serializable(coarse_ds):
+def test_get_config_round_trips_through_json(coarse_ds):
+    """Config must survive ``json.dumps``/``loads`` so it stays serializable."""
+    import json
+
     fine_lon = np.linspace(0.0, 10.0, 21)
     fine_lat = np.linspace(-5.0, 5.0, 21)
     op = Downscale(
@@ -95,24 +98,48 @@ def test_get_config_is_serializable(coarse_ds):
         target_grid=xr.Dataset(coords={"lat": fine_lat, "lon": fine_lon}),
     )
     cfg = op.get_config()
-    assert set(cfg) == {"model", "target_grid"}
-    assert isinstance(cfg["model"], str)
-    assert cfg["target_grid"] == "<grid>"
+    round_tripped = json.loads(json.dumps(cfg))
+    assert round_tripped == cfg
+    assert round_tripped["target_grid"] == "<grid>"
+    assert isinstance(round_tripped["model"], str)
 
 
 def test_no_top_level_jax_or_torch_import():
-    """Per D4, the downscale module must not import JAX or torch."""
+    """Per D4, the downscale module must not import JAX or torch.
+
+    Run the import in a fresh subprocess so the result is independent of
+    test ordering — other tests (e.g. ``test_inference_jax``) may have
+    already pulled JAX into ``sys.modules`` of the parent process.
+    """
+    import subprocess
     import sys
 
-    # Simply importing our module should not pull in jax/torch transitively.
-    from xr_toolz.interpolate._src import downscale  # noqa: F401
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys\n"
+                "import xr_toolz.interpolate._src.downscale  # noqa: F401\n"
+                "for name in ('jax', 'jaxlib', 'torch'):\n"
+                "    if name in sys.modules:\n"
+                "        print(name)\n"
+            ),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    leaked = [n for n in result.stdout.strip().splitlines() if n]
+    assert leaked == [], f"backend leaked into sys.modules: {leaked}"
 
-    assert "jax" not in sys.modules
-    assert "torch" not in sys.modules
 
+def test_works_with_arbitrary_operator(coarse_ds):
+    """Downscale composes with any Operator (duck-typed callable).
 
-def test_works_with_modelop_subclass(coarse_ds):
-    """Downscale composes with any Operator (duck-typed callable)."""
+    The wrapped object doesn't have to be a ``ModelOp`` — any Operator
+    or plain callable works.
+    """
     from xr_toolz.core import Operator
 
     class TinyResize(Operator):

--- a/tests/test_interpolate_downscale.py
+++ b/tests/test_interpolate_downscale.py
@@ -1,0 +1,134 @@
+"""Tests for ``xr_toolz.interpolate.downscale`` (F3.4, D12).
+
+Per F3.5 resolution of D12 Q1, ``Downscale`` and ``Upscale`` are pure
+callable wrappers — patch tiling is delegated to ``xrpatcher`` upstream.
+The smoke tests use a trivial bilinear-resize as the wrapped model.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from xr_toolz.interpolate.operators import Downscale, Upscale
+
+
+def _bilinear_to(target_lon: np.ndarray, target_lat: np.ndarray):
+    """Return a callable that bilinearly resizes a Dataset to the given grid."""
+
+    def _resize(ds: xr.Dataset) -> xr.Dataset:
+        return ds.interp(lon=target_lon, lat=target_lat)
+
+    return _resize
+
+
+@pytest.fixture
+def coarse_ds():
+    lon = np.linspace(0.0, 10.0, 5)
+    lat = np.linspace(-5.0, 5.0, 5)
+    field = np.outer(lat, lon)
+    return xr.Dataset(
+        {"f": (("lat", "lon"), field)},
+        coords={"lat": lat, "lon": lon},
+    )
+
+
+@pytest.fixture
+def fine_ds():
+    lon = np.linspace(0.0, 10.0, 21)
+    lat = np.linspace(-5.0, 5.0, 21)
+    field = np.outer(lat, lon)
+    return xr.Dataset(
+        {"f": (("lat", "lon"), field)},
+        coords={"lat": lat, "lon": lon},
+    )
+
+
+def test_downscale_smoke_wrapping_bilinear_resize(coarse_ds):
+    """Downscale plumbing: coarse 5x5 → fine 21x21 via bilinear-resize callable."""
+    fine_lon = np.linspace(0.0, 10.0, 21)
+    fine_lat = np.linspace(-5.0, 5.0, 21)
+    op = Downscale(_bilinear_to(fine_lon, fine_lat))
+    out = op(coarse_ds)
+
+    assert out.sizes["lon"] == 21
+    assert out.sizes["lat"] == 21
+    # Bilinear on a smooth f(lat, lon) = lat * lon recovers the analytic answer.
+    expected = np.outer(fine_lat, fine_lon)
+    np.testing.assert_allclose(out["f"].values, expected, atol=1e-10)
+
+
+def test_upscale_smoke_wrapping_bilinear_resize(fine_ds):
+    """Upscale plumbing: fine 21x21 → coarse 5x5 via bilinear-resize callable."""
+    coarse_lon = np.linspace(0.0, 10.0, 5)
+    coarse_lat = np.linspace(-5.0, 5.0, 5)
+    op = Upscale(_bilinear_to(coarse_lon, coarse_lat))
+    out = op(fine_ds)
+
+    assert out.sizes["lon"] == 5
+    assert out.sizes["lat"] == 5
+    expected = np.outer(coarse_lat, coarse_lon)
+    np.testing.assert_allclose(out["f"].values, expected, atol=1e-10)
+
+
+def test_downscale_rejects_non_callable():
+    with pytest.raises(TypeError):
+        Downscale(model="not_a_callable")  # type: ignore[arg-type]
+
+
+def test_target_grid_attribute_is_carried(coarse_ds):
+    """The optional target_grid is stored as metadata, not used in _apply."""
+    fine_lon = np.linspace(0.0, 10.0, 21)
+    fine_lat = np.linspace(-5.0, 5.0, 21)
+    grid = xr.Dataset(coords={"lat": fine_lat, "lon": fine_lon})
+
+    op = Downscale(_bilinear_to(fine_lon, fine_lat), target_grid=grid)
+    assert op.target_grid is grid
+
+
+def test_get_config_is_serializable(coarse_ds):
+    fine_lon = np.linspace(0.0, 10.0, 21)
+    fine_lat = np.linspace(-5.0, 5.0, 21)
+    op = Downscale(
+        _bilinear_to(fine_lon, fine_lat),
+        target_grid=xr.Dataset(coords={"lat": fine_lat, "lon": fine_lon}),
+    )
+    cfg = op.get_config()
+    assert set(cfg) == {"model", "target_grid"}
+    assert isinstance(cfg["model"], str)
+    assert cfg["target_grid"] == "<grid>"
+
+
+def test_no_top_level_jax_or_torch_import():
+    """Per D4, the downscale module must not import JAX or torch."""
+    import sys
+
+    # Simply importing our module should not pull in jax/torch transitively.
+    from xr_toolz.interpolate._src import downscale  # noqa: F401
+
+    assert "jax" not in sys.modules
+    assert "torch" not in sys.modules
+
+
+def test_works_with_modelop_subclass(coarse_ds):
+    """Downscale composes with any Operator (duck-typed callable)."""
+    from xr_toolz.core import Operator
+
+    class TinyResize(Operator):
+        def __init__(self, lon, lat):
+            self.lon = lon
+            self.lat = lat
+
+        def _apply(self, ds):
+            return ds.interp(lon=self.lon, lat=self.lat)
+
+        def get_config(self):
+            return {"lon": list(self.lon), "lat": list(self.lat)}
+
+    fine_lon = np.linspace(0.0, 10.0, 11)
+    fine_lat = np.linspace(-5.0, 5.0, 11)
+    op = Downscale(TinyResize(fine_lon, fine_lat))
+    out = op(coarse_ds)
+    assert out.sizes["lon"] == 11
+    assert out.sizes["lat"] == 11

--- a/tests/test_interpolate_imports.py
+++ b/tests/test_interpolate_imports.py
@@ -88,6 +88,6 @@ def test_legacy_geo_operator_names_are_gone() -> None:
 
 
 def test_placeholder_submodules_importable() -> None:
-    for sub in ("downscale", "grid_to_points"):
+    for sub in ("grid_to_points",):
         mod = importlib.import_module(f"xr_toolz.interpolate._src.{sub}")
         assert mod.__all__ == []

--- a/tests/test_interpolate_imports.py
+++ b/tests/test_interpolate_imports.py
@@ -31,13 +31,25 @@ CANONICAL_FUNCS = (
 CANONICAL_OPS = (
     "Bin2D",
     "Coarsen",
+    "Downscale",
     "FillNaNRBF",
     "FillNaNSpatial",
     "FillNaNTemporal",
+    "FromSigma",
+    "GaussianSmooth",
     "Histogram2D",
+    "LowpassFilter",
+    "MovingAverage",
     "PointsToGrid",
     "Refine",
+    "RemapAxis",
     "ResampleTime",
+    "ToHeight",
+    "ToIsopycnal",
+    "ToPhase",
+    "ToPressureLevels",
+    "ToSigma",
+    "Upscale",
 )
 
 REMOVED_FROM_GEO = (


### PR DESCRIPTION
## Summary
- Adds \`xr_toolz.interpolate.downscale\` per D12: \`Downscale\` (learned refinement) and \`Upscale\` (learned aggregation) — thin \`Operator\` wrappers around any callable model.
- Per F3.5 resolution of D12 Q1: pure callable wrappers, no \`patch_size\` / \`overlap\` constructor args. Patch tiling delegated to \`xrpatcher\` upstream of the operator (compose \`patcher | Downscale(model) | unpatcher\`).
- No top-level JAX / torch imports (D4).

## Notes
- **Stacked on #110** (f3.2-coord-remap), which is stacked on #109 (f3.3-smooth).
- The wrapped \`model\` is duck-typed: \`ModelOp\`, any other \`Operator\`, or a plain callable.
- \`target_grid\` is metadata only — the model itself is responsible for emitting the right resolution.

Closes #36.

## Test plan
- [x] \`pytest tests/test_interpolate_downscale.py\` (7 passed) — bilinear-resize smoke tests in both directions, type rejection, no JAX/torch import, ModelOp/Operator interop.
- [x] \`ruff check .\` / \`ruff format --check .\` clean
- [x] No new \`ty\` errors on \`xr_toolz/interpolate\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)