### PR TITLE
fix(docs): repair api/core.md autodoc + migrate notebook imports

### DIFF
--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -1,29 +1,34 @@
 # Core — Composition Primitives
 
-Domain-agnostic primitives for building and running operator pipelines.
-Every public symbol lives at the top level of `xrtoolz` (e.g.
-`from xrtoolz import Sequential, Augment`).
+The composition primitives (`Operator`, `Sequential`, `Graph`, `Input`,
+`Node`, `Tap`) live in the carrier-agnostic
+[`pipekit`](https://github.com/jejjohnson/pipekit) framework and are
+re-exported at the top level of `xrtoolz` for convenience (e.g.
+`from xrtoolz import Sequential, Augment`). The xarray-Dataset-specific
+combinators (`Augment`, `ApplyToEach`) live in `xrtoolz.combinators`.
 
 ## Operator base class
 
-::: xrtoolz.core.operator.Operator
+::: pipekit.Operator
 
 ## Sequential pipelines
 
-::: xrtoolz.core.sequential.Sequential
+::: pipekit.Sequential
 
 ## Functional Graph API
 
-::: xrtoolz.core.graph.Input
+::: pipekit.Input
 
-::: xrtoolz.core.graph.Node
+::: pipekit.Node
 
-::: xrtoolz.core.graph.Graph
+::: pipekit.Graph
 
-## Operator combinators
+## Generic observation combinator (from pipekit)
 
-::: xrtoolz.core.combinators.Augment
+::: pipekit.Tap
 
-::: xrtoolz.core.combinators.Tap
+## xarray-specific combinators
 
-::: xrtoolz.core.combinators.ApplyToEach
+::: xrtoolz.combinators.Augment
+
+::: xrtoolz.combinators.ApplyToEach

--- a/docs/notebooks/inference_modelop_demo.ipynb
+++ b/docs/notebooks/inference_modelop_demo.ipynb
@@ -2333,7 +2333,7 @@
     }
    ],
    "source": [
-    "from xrtoolz.core import Graph, Input, Operator\n",
+    "from xrtoolz import Graph, Input, Operator\n",
     "from xrtoolz.metrics.operators import RMSE\n",
     "\n",
     "# RMSE is a two-input pixel metric over a dataset variable. Wrap each\n",

--- a/docs/notebooks/ocean_stratification_glorys.ipynb
+++ b/docs/notebooks/ocean_stratification_glorys.ipynb
@@ -627,7 +627,7 @@
     }
    ],
    "source": [
-    "from xrtoolz.core import Operator\n",
+    "from xrtoolz import Operator\n",
     "\n",
     "\n",
     "class LinearDensity(Operator):\n",

--- a/docs/notebooks/sequential_summary_demo.ipynb
+++ b/docs/notebooks/sequential_summary_demo.ipynb
@@ -97,7 +97,7 @@
     ")\n",
     "\n",
     "from xrtoolz import Sequential, Signature\n",
-    "from xrtoolz.core import Graph, Input\n",
+    "from xrtoolz import Graph, Input\n",
     "from xrtoolz.geo.operators import (\n",
     "    CalculateClimatology,\n",
     "    Reduce,\n",

--- a/docs/notebooks/validation_v1_psd_plots.ipynb
+++ b/docs/notebooks/validation_v1_psd_plots.ipynb
@@ -66,7 +66,7 @@
     "import scipy.ndimage as ndi\n",
     "import xarray as xr\n",
     "\n",
-    "from xrtoolz.core import Graph, Input, Sequential, Signature\n",
+    "from xrtoolz import Graph, Input, Sequential, Signature\n",
     "from xrtoolz.geo.operators import RemoveMean\n",
     "from xrtoolz.interpolate.operators import RegridLike\n",
     "from xrtoolz.metrics import PSDScore, psd_score\n",
@@ -286,7 +286,7 @@
    "source": [
     "from typing import Any\n",
     "\n",
-    "from xrtoolz.core import Operator\n",
+    "from xrtoolz import Operator\n",
     "\n",
     "\n",
     "class FillNaN(Operator):\n",


### PR DESCRIPTION
## Summary

The `xrtoolz.core` module was deleted in #203, but `docs/api/core.md` still autodoc'd `xrtoolz.core.operator.Operator`, breaking the [Deploy Docs](https://github.com/jejjohnson/xrtoolz/actions/runs/26298103584) workflow on `main`.

- Rewrite `docs/api/core.md` to autodoc the equivalent `pipekit.*` primitives plus the xarray-specific `xrtoolz.combinators.Augment` and `ApplyToEach`. `mkdocs build` now runs clean.
- Migrate the four tutorial notebooks (`sequential_summary_demo`, `inference_modelop_demo`, `ocean_stratification_glorys`, `validation_v1_psd_plots`) that still imported `from xrtoolz.core import …`. Switch to `from xrtoolz import …` — the symbols resolve to the exact same classes via the top-level re-export, so cached output cells stay valid (no re-execution needed).

## Test plan

- [x] `uv run --group docs mkdocs build` — clean (was failing with `mkdocstrings: xrtoolz.core.operator.Operator could not be found`).
- [x] All 4 notebooks parse as valid JSON after the in-place sed.
- [x] `from xrtoolz import Operator, Sequential, Graph, Input, Signature` → `True is True` (top-level re-exports unchanged).
- [ ] Deploy Docs workflow turns green once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)