### PR TITLE
feat(core): xarray-aware Operator with DataTree dispatch (PR α)

### DIFF
--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -1,15 +1,20 @@
 # Core — Composition Primitives
 
-The composition primitives (`Operator`, `Sequential`, `Graph`, `Input`,
-`Node`, `Tap`) live in the carrier-agnostic
+The composition primitives (`Sequential`, `Graph`, `Input`, `Node`,
+`Tap`) live in the carrier-agnostic
 [`pipekit`](https://github.com/jejjohnson/pipekit) framework and are
 re-exported at the top level of `xrtoolz` for convenience (e.g.
-`from xrtoolz import Sequential, Augment`). The xarray-Dataset-specific
-combinators (`Augment`, `ApplyToEach`) live in `xrtoolz.combinators`.
+`from xrtoolz import Sequential, Augment`).
+
+`xrtoolz.Operator` is a thin xarray-aware subclass of `pipekit.Operator`
+that adds `DataTree` dispatch to `__call__` — every operator in the
+library inherits it and therefore gains free leaf-wise mapping over
+`xarray.DataTree` inputs. The xarray-Dataset-specific combinators
+(`Augment`, `ApplyToEach`) live in `xrtoolz.combinators`.
 
 ## Operator base class
 
-::: pipekit.Operator
+::: xrtoolz.Operator
 
 ## Sequential pipelines
 

--- a/docs/design/xarray-native-primitives.md
+++ b/docs/design/xarray-native-primitives.md
@@ -1,0 +1,390 @@
+---
+status: draft
+version: 0.1.0
+---
+
+# Xarray-Native Primitives — Two-Layer Public Contract
+
+A follow-on refactor to D11 (revised). Flips every primitive in the
+package to an xarray-only public signature, keeping user-authored
+numpy implementations as private helpers inside the same module.
+Lifts DataTree support to the Operator base class so it falls out for
+every existing subclass with no per-operator code.
+
+## Motivation
+
+After PR #200, the package has two public tiers (Layer 0 xarray,
+Layer 1 Operator) but Layer 0 signatures are still inconsistent:
+
+- `metrics.rmse(ds_pred, ds_ref, variable, dims)` — Dataset + selector kwargs
+- `interpolate.gaussian_smooth(ds, dim, sigma)` — Dataset, loops over every
+  numeric variable internally
+- `geo._src.wavelet1d.cwt1d(da, dim, ...)` — DataArray
+
+Three different shapes for the same conceptual position in the stack.
+Users calling primitives directly hit a different ergonomic story per
+module, and the "Dataset + variable selector" idiom forces every
+primitive to grow `variable_var: str` plumbing that the Operator
+layer is already paid to handle.
+
+Separately, DataTree is becoming the canonical xarray container for
+multi-group / multi-resolution datasets, and the library has no story
+for it.
+
+## Contract
+
+| Layer | Accepts | Returns | Selectors |
+|---|---|---|---|
+| **Primitive** (private `_src/`) | `DataArray` (one or more positional) | `DataArray`, or `Dataset` when the result is a structured multi-field output (e.g. `geostrophic_velocity(ssh, lat)` → `Dataset(u_g, v_g)`) | None — the caller passes the field |
+| **Operator** (public Layer 1) | `Dataset`, or `DataTree` (auto-mapped), or two of either for multi-input | Same container shape as input; reductions may narrow to `DataArray` / scalar; terminal viz returns `matplotlib.Figure` / `Axes` (D10) | Constructor kwargs (`variable=`, `u_var=`, `v_var=`, …) |
+
+Hard rules:
+
+- **No** `np.ndarray` in any public signature.
+- **No** `Dataset` in primitive *input* signatures. Multi-field input is
+  multiple positional `DataArray`s.
+- **Private numpy helpers OK** when the math is genuinely easier as
+  `(ndarray, axis)` (e.g. NaN-aware reductions, FFT shape juggling).
+  They live as underscore-prefixed functions in the same primitive's
+  `_src/` module — no separate `_*_kernels.py` sibling files. Bridge
+  with `xr.apply_ufunc`.
+
+## Primitive shapes — common patterns
+
+### 1. Single-input, shape-preserving along a dim
+
+Smoothers, filters, normalizations.
+
+```python
+def gaussian_smooth(da: DataArray, *, dim: str, sigma: float) -> DataArray:
+    """Same shape; smoothed along `dim`."""
+    def _kernel(arr):
+        return scipy.ndimage.gaussian_filter1d(arr, sigma, axis=-1)
+    return xr.apply_ufunc(
+        _kernel, da,
+        input_core_dims=[[dim]], output_core_dims=[[dim]],
+        vectorize=True, keep_attrs=True,
+    )
+```
+
+### 2. Single-input, reducing along a dim
+
+Custom reductions where xarray's built-in `.mean(dim=...)` etc. is
+insufficient (e.g. NaN policies, weighted reductions, robust stats).
+
+```python
+def variance_skipna(da: DataArray, *, dim: str | Sequence[str]) -> DataArray:
+    """Drops `dim`."""
+    core = [dim] if isinstance(dim, str) else list(dim)
+    def _kernel(arr):
+        return np.nanvar(arr, axis=tuple(range(-len(core), 0)))
+    return xr.apply_ufunc(_kernel, da, input_core_dims=[core])
+```
+
+### 3. Single-input, dim-replacing (coord remap, regrid, refine)
+
+```python
+def remap_axis(
+    da: DataArray, *,
+    source_dim: str,
+    target_coords: DataArray,
+    method: str = "linear",
+) -> DataArray:
+    """`source_dim` replaced by the dim/length of `target_coords`."""
+    ...
+```
+
+### 4. Single-input, spectral (dim → freq_dim)
+
+```python
+def power_spectrum(da: DataArray, *, dim: str) -> DataArray:
+    """Returns DataArray with `dim` replaced by `freq_<dim>`."""
+    ...
+```
+
+### 5. Single-input, structured multi-output (Dataset out)
+
+When one input field naturally produces several output fields —
+gradients, geostrophy from SSH, decompositions.
+
+```python
+def gradient(da: DataArray, *, dims: tuple[str, ...]) -> Dataset:
+    """One partial-derivative field per requested dim."""
+    return Dataset({f"d{da.name}_d{d}": da.differentiate(d) for d in dims})
+
+def geostrophic_velocity(ssh: DataArray, lat: DataArray) -> Dataset:
+    """SSH → (u_g, v_g)."""
+    return Dataset({"u_g": ..., "v_g": ...})
+```
+
+### 6. Multi-input (paired), reducing (metrics)
+
+```python
+def rmse(pred: DataArray, ref: DataArray, *, dim: str | Sequence[str]) -> DataArray:
+    diff_sq = (pred - ref) ** 2
+    return np.sqrt(_nanmean_via_apply_ufunc(diff_sq, dim))
+```
+
+### 7. Multi-input (independent fields), derived elementwise
+
+```python
+def kinetic_energy(u: DataArray, v: DataArray) -> DataArray:
+    return 0.5 * (u**2 + v**2)
+```
+
+### 8. Multi-input with auxiliary coords/fields
+
+```python
+def relative_vorticity(
+    u: DataArray, v: DataArray, lat: DataArray, *,
+    lon_dim: str = "lon", lat_dim: str = "lat",
+) -> DataArray:
+    """Curl on a sphere. lat is broadcast over u/v."""
+    ...
+```
+
+## Operator shapes — common patterns
+
+Operators wrap primitives. Constructor stores config + variable
+selectors; `_apply` selects fields from the Dataset, calls primitive,
+reassembles into Dataset (or returns DataArray / Figure for the
+reducing / terminal cases).
+
+### 1. Shape-preserving op on one variable
+
+```python
+class GaussianSmooth(Operator):
+    def __init__(self, variable: str, *, dim: str, sigma: float):
+        self.variable, self.dim, self.sigma = variable, dim, sigma
+    def _apply(self, ds: Dataset) -> Dataset:
+        smoothed = gaussian_smooth(ds[self.variable], dim=self.dim, sigma=self.sigma)
+        return ds.assign({self.variable: smoothed})
+```
+
+### 2. Multi-input metric (reduces to DataArray)
+
+```python
+class RMSE(Operator):
+    def __init__(self, variable: str, *, dim: str | Sequence[str]):
+        self.variable, self.dim = variable, dim
+    def _apply(self, ds_pred: Dataset, ds_ref: Dataset) -> DataArray:
+        return rmse(ds_pred[self.variable], ds_ref[self.variable], dim=self.dim)
+```
+
+### 3. Derived field from multiple input variables (kinematics)
+
+```python
+class KineticEnergy(Operator):
+    def __init__(self, *, u_var: str = "u", v_var: str = "v", output_var: str = "ke"):
+        self.u_var, self.v_var, self.output_var = u_var, v_var, output_var
+    def _apply(self, ds: Dataset) -> Dataset:
+        ke = kinetic_energy(ds[self.u_var], ds[self.v_var])
+        return ds.assign({self.output_var: ke})
+```
+
+### 4. Structured multi-output
+
+```python
+class GeostrophicVelocity(Operator):
+    def __init__(self, *, ssh_var: str = "ssh", lat_var: str = "lat"):
+        self.ssh_var, self.lat_var = ssh_var, lat_var
+    def _apply(self, ds: Dataset) -> Dataset:
+        derived = geostrophic_velocity(ds[self.ssh_var], ds[self.lat_var])
+        return xr.merge([ds, derived])
+```
+
+### 5. Operator-only modules (no primitive layer)
+
+`validation`, `subset`, `masks`, `crs` — coord/attr work; no array
+math, no primitive layer:
+
+```python
+class SubsetBBox(Operator):
+    def __init__(self, *, lon_bnds: tuple[float, float], lat_bnds: tuple[float, float]):
+        ...
+    def _apply(self, ds: Dataset) -> Dataset:
+        return ds.sel(lon=slice(*self.lon_bnds), lat=slice(*self.lat_bnds))
+```
+
+## DataTree polymorphism — `Operator.__call__` dispatch
+
+`Operator.__call__` grows one branch. Existing `Node`-detection
+(symbolic graph) stays; new branch maps over a DataTree:
+
+```python
+def __call__(self, *args, **kwargs):
+    if any(isinstance(a, Node) for a in args):
+        return Node(operator=self, parents=args)
+    if any(isinstance(a, DataTree) for a in args):
+        return xr.map_over_subtree(self._apply)(*args, **kwargs)
+    return self._apply(*args, **kwargs)
+```
+
+Consequence: every operator gets DataTree support for free.
+
+```python
+op = GaussianSmooth("ssh", dim="time", sigma=3)
+op(ds)                       # → Dataset
+op(dt)                       # → DataTree, each leaf smoothed independently
+
+metric = RMSE("ssh", dim="time")
+metric(ds_pred, ds_ref)      # → DataArray
+metric(dt_pred, dt_ref)      # → DataTree of DataArrays, leaf-by-leaf
+
+pipeline = Sequential([Regrid(...), GaussianSmooth("ssh", dim="time", sigma=3)])
+pipeline(dt)                 # → DataTree, full pipeline applied per leaf
+```
+
+Multi-input ops require both inputs to be DataTrees with matching
+structure when used in tree mode — `xr.map_over_subtree` enforces
+this.
+
+## What goes away
+
+- Every `variable: str` / `var_ref: str` / `*_var: str` selector kwarg
+  on a Layer 0 function. Moves to the Operator constructor.
+- Every "loop over `ds.data_vars`, apply to each numeric var" helper
+  inside a primitive (e.g. `_apply_along_dim` in
+  `interpolate/_src/smooth.py`). The Operator handles the loop now.
+- The `_*_kernels.py` files introduced by #200. The numpy code gets
+  inlined into the primitive that uses it as an underscore-prefixed
+  module-level helper. A numpy helper shared by multiple primitives
+  stays as a module-level underscore function in one of them and is
+  imported.
+
+## What stays untouched
+
+- Every numpy implementation — algorithms, NaN handling, edge cases.
+  Preserved verbatim, just folded into the primitive.
+- The Operator / Sequential / Graph composition story.
+- All public Operator subclass names and constructor signatures.
+- Test files — only their imports / argument shapes shift.
+
+## Module migration map
+
+| Module | Today | After |
+|---|---|---|
+| `core/operator.py` | Dispatches `Node` only | Adds `DataTree` branch (one new `if`) |
+| `core/sequential.py`, `core/graph.py` | Type-check Dataset returns at non-terminal steps | Type-check `Dataset | DataTree` at non-terminal steps |
+| `metrics/_src/pixel.py` | `rmse(ds_pred, ds_ref, variable, dims)` | `rmse(da_pred, da_ref, *, dim)` |
+| `metrics/_src/segmented_psd.py` | `along_track_psd_score(ds, var_ref, var_pred, ...)` | `along_track_psd_score(ref, pred, ...)` |
+| `metrics/_src/{spectral,multiscale,distributional,structural,physical,probabilistic,residuals,forecast,masked,composite,dm,leaderboard,object,lagrangian}.py` | Mixed Dataset+selectors | DataArray-positional |
+| `interpolate/_src/smooth.py` | `gaussian_smooth(ds, dim, sigma)` (loops vars) | `gaussian_smooth(da, dim=, sigma=)`; operator does the Dataset loop |
+| `interpolate/_src/{grid_to_grid,gap_fill,resample,coord_remap,binning,points_to_grid,grid_to_points,knn,downscale}.py` | Mixed Dataset/DataArray | DataArray (multi-DataArray where appropriate) |
+| `transforms/_src/{fourier,decompose,coord_remap,morphology,encoders,*}.py` | Mostly DataArray already | Audit & normalize |
+| `geo/_src/{validation,subset,masks,crs}.py` | Operator-only (Dataset coord/attr work) | **Unchanged** — operator-only modules per the contract |
+| `geo/_src/wavelet1d.py` and other single-field geo primitives | DataArray already | Unchanged |
+| `kinematics/_src/*` (when written, D9) | N/A | Multi-DataArray positional (`kinetic_energy(u, v)`, `geostrophic_velocity(ssh, lat)`) |
+| Every `<module>/operators.py` | Wraps Layer 0, selects from Dataset | Same role — selects vars and hands DataArrays to the primitive. Most diffs are 1–2 lines per class |
+
+## Phasing — three sequential PRs
+
+The full migration is too big for one PR. Suggested order:
+
+### PR α — Core + DataTree dispatch
+
+Adds DataTree polymorphism with no primitive changes. Operators still
+call current Dataset-shaped Layer 0; they just gain free DataTree
+support via the base-class dispatch.
+
+- `core/operator.py`: +~15 LOC (one new `if`).
+- `core/sequential.py`, `core/graph.py`: ~5 LOC each (broaden the
+  non-terminal type check to `Dataset | DataTree`).
+- New `tests/test_core_datatree.py`: ~80 LOC (round-trip a smoother
+  and a metric through a 2-leaf DataTree).
+- Doc update: this design doc + a paragraph in `architecture.md`.
+
+**Total: ~100–150 LOC.** Low risk — surgical dispatch addition, no
+signature changes.
+
+### PR β — Metrics + interpolate primitive flip
+
+The two biggest modules. Inlines kernels, flips signatures to
+DataArray-positional, moves Dataset selection into the operators.
+
+- metrics: ~16 `_src/*.py` files + their operator wrappers + tests.
+- interpolate: ~10 `_src/*.py` files + their operator wrappers + tests.
+- Removes the `_*_kernels.py` files introduced by #200 by folding
+  their numpy back into the primitive.
+
+**Total: ~1500–2500 LOC changed** (large share of that is deletions
+of plumbing — `_apply_along_dim`, selector kwargs, kernel files).
+Medium risk: many signature flips, tests need re-pointing. Numerical
+behavior unchanged.
+
+### PR γ — Transforms + geo single-field + cleanup
+
+- transforms: ~6 `_src/*.py` files + operators.
+- Single-field geo primitives (`wavelet1d`, encoder helpers): audit.
+- Docstring + design-doc sweep.
+
+**Total: ~500–900 LOC.** Low–medium risk — smaller surface than β.
+
+## Code change estimate — totals
+
+| PR | Files touched | LOC delta (gross) | Risk |
+|---|---|---|---|
+| α — Core + DataTree | 3–4 src + 1 new test | **~100–150** | Low |
+| β — Metrics + interpolate | ~50 files | **~1500–2500** | Medium |
+| γ — Transforms + geo + cleanup | ~15 files | **~500–900** | Low–medium |
+| **Total** | **~65 files** | **~2100–3550 LOC** over 3 PRs | — |
+
+For comparison, PR #200 was ~1200 LOC. Each individual PR in this
+plan is in the same ballpark as recent work on the repo.
+
+A meaningful share of the diff is **deletions** — the
+`_apply_along_dim` Dataset-looping helpers in each `_src/*.py` go
+away (operators handle the loop now), and the `_*_kernels.py` files
+from #200 collapse into their primitive.
+
+## Breaking changes
+
+This is a breaking change for anyone calling Layer 0 functions
+directly:
+
+- `metrics.rmse(ds_pred, ds_ref, variable="ssh", dims="time")` →
+  `metrics.rmse(ds_pred["ssh"], ds_ref["ssh"], dim="time")`
+- `interpolate.gaussian_smooth(ds, dim="time", sigma=2.0)`
+  (Dataset-wide) → `interpolate.gaussian_smooth(ds["x"], dim="time",
+  sigma=2.0)` (single var); use the `GaussianSmooth()` operator if
+  you want the Dataset-wide loop.
+
+Operator-level API (`RMSE(...)`, `GaussianSmooth(...)`,
+`Sequential([...])`) is unchanged — anyone going through Operators
+sees no break.
+
+Per current project status ("noone is using my lib except me"), the
+breaking-change cost is contained. No deprecation shims planned,
+consistent with prior pre-1.0 churn (e.g. F3 module consolidation in
+#98, public array tier removal in #200).
+
+## Relationship to existing decisions
+
+- **Revises D11** (which already stepped down from three tiers to
+  two). D11 stated the *public surface* is two-tier; this doc
+  tightens what each tier *accepts and returns* so the two layers are
+  contract-clean across every module.
+- **Compatible with D1, D2, D3, D6, D10** — Operator-as-callable,
+  split-object stateful pattern, dual-mode `__call__`, dict-in/out
+  Graph, viz-as-Operator: all unchanged.
+- **D4** (no framework dep for `ModelOp`) and **D5** (numpy/scipy for
+  compute) are unchanged — user-authored numpy implementations remain
+  the compute core; the refactor only changes how they're plumbed.
+- **D9** (kinematics submodule) — kinematics is greenfield and will
+  be written in the new style from day one. No migration cost for
+  this module.
+- **D12** (`interpolate` unified resampling module) — unchanged
+  structure; only the primitive signatures inside `interpolate/_src/`
+  shift.
+
+## Open questions for sign-off
+
+1. Confirm the contract (top table + hard rules) matches expectations.
+2. Confirm the operator pattern of "augment the Dataset in place"
+   (`ds.assign({var: result})` or `xr.merge([ds, derived])`) is the
+   intended idiom for derived-field operators, rather than "operator
+   returns only the new variable, caller merges."
+3. Confirm phasing α → β → γ in that order.
+4. Confirm DataTree dispatch goes in `Operator.__call__` (Option 1
+   from prior discussion) rather than an explicit `MapOverTree`
+   combinator.

--- a/docs/design/xarray-native-primitives.md
+++ b/docs/design/xarray-native-primitives.md
@@ -1,9 +1,19 @@
 ---
-status: draft
-version: 0.1.0
+status: in-progress
+version: 0.1.1
 ---
 
 # Xarray-Native Primitives — Two-Layer Public Contract
+
+> **Implementation status.** PR α (Core + DataTree dispatch) is
+> implemented in `src/xrtoolz/_operator.py` and re-exported as
+> `xrtoolz.Operator`. The architecture differs slightly from the
+> original sketch: since the composition core lives in carrier-agnostic
+> `pipekit`, the DataTree branch lives on an xarray-aware
+> `xrtoolz.Operator` subclass rather than on `pipekit.Operator`
+> itself. `pipekit.Sequential` and `pipekit.Graph` thread the
+> resulting `DataTree`s through without changes — they are
+> carrier-agnostic. PRs β and γ remain to be done.
 
 A follow-on refactor to D11 (revised). Flips every primitive in the
 package to an xarray-only public signature, keeping user-authored

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,11 @@ dependencies = [
     "numpy>=1.26",
     "scipy>=1.12",
     "scikit-learn>=1.4",
-    "xarray>=2024.2",
+    # DataTree polymorphism on xrtoolz.Operator depends on
+    # ``xr.DataTree`` + ``xr.map_over_datasets``, both stabilised in
+    # xarray 2024.10. Older versions raise ``AttributeError`` on the
+    # isinstance check even for plain Dataset calls.
+    "xarray>=2024.10",
     "pandas>=2.1",
     "rioxarray>=0.15",
     "pyproj>=3.6",

--- a/src/xrtoolz/__init__.py
+++ b/src/xrtoolz/__init__.py
@@ -1,7 +1,8 @@
 """xrtoolz — composable operators for Earth System Data Cubes."""
 
-from pipekit import Graph, Input, Node, Operator, Sequential, Tap
+from pipekit import Graph, Input, Node, Sequential, Tap
 
+from xrtoolz._operator import Operator
 from xrtoolz.combinators import ApplyToEach, Augment
 from xrtoolz.signature import Signature
 

--- a/src/xrtoolz/_operator.py
+++ b/src/xrtoolz/_operator.py
@@ -1,0 +1,101 @@
+"""xarray-aware :class:`Operator` — adds ``DataTree`` dispatch on top of pipekit.
+
+``pipekit.Operator`` is carrier-agnostic and only knows two call modes:
+eager ``_apply`` and symbolic ``Node``-construction. Earth-science data
+also flows through ``xarray.DataTree`` (multi-group / multi-resolution
+hierarchies). Rather than asking every diagnostic operator to opt in to
+tree handling by hand, we widen the base class with one additional
+branch: if any positional argument is a ``DataTree``, the operator is
+mapped over every leaf via ``xr.map_over_datasets``.
+
+The dispatch order matches the design doc (see
+``docs/design/xarray-native-primitives.md``):
+
+1. **Symbolic graph mode** — any ``Node`` argument routes to
+   ``pipekit.Operator.__call__`` (which builds a ``Node`` recording this
+   operator and its parents).
+2. **DataTree mode** — any ``DataTree`` argument: apply
+   ``xr.map_over_datasets`` to thread ``_apply`` over each matching
+   leaf. ``xarray`` enforces the multi-input structural-match
+   requirement; mixing a ``DataTree`` with a plain ``Dataset`` raises.
+3. **Eager mode** — fall through to ``pipekit.Operator.__call__``,
+   which runs ``_apply`` directly on the carrier(s).
+
+Consequence: every operator that inherits from this class — every
+``xrtoolz`` diagnostic, every combinator, every ``Sequential`` /
+``Graph`` built out of them — gains ``DataTree`` support for free.
+``Sequential`` and ``Graph`` themselves do not need changes: they are
+carrier-agnostic in pipekit and simply thread whatever each step
+returns to the next, so a ``DataTree`` in / ``DataTree`` out chain
+composes naturally.
+
+This is the implementation of "PR α" from the design doc.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import xarray as xr
+from pipekit import Operator as _PipekitOperator
+
+
+class Operator(_PipekitOperator):
+    """``pipekit.Operator`` plus xarray ``DataTree`` dispatch.
+
+    Subclasses implement ``_apply(carrier, *extra)`` exactly as they
+    would against ``pipekit.Operator`` — the override only affects
+    ``__call__`` dispatch, not ``_apply``.
+
+    Example:
+        A shape-preserving diagnostic works against any of the three
+        xarray containers without per-class branching::
+
+            class GaussianSmooth(Operator):
+                def __init__(self, variable, *, dim, sigma):
+                    self.variable, self.dim, self.sigma = variable, dim, sigma
+
+                def _apply(self, ds: xr.Dataset) -> xr.Dataset:
+                    return ds.assign({self.variable: ...})
+
+            op = GaussianSmooth("ssh", dim="time", sigma=3)
+            op(ds)   # → Dataset
+            op(dt)   # → DataTree, each leaf smoothed independently
+    """
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        """Dispatch eager / symbolic / DataTree modes on positional args.
+
+        - Any ``Node`` arg → pipekit's symbolic graph construction.
+        - Any ``DataTree`` arg → leaf-wise map via
+          ``xr.map_over_datasets``; the operator is applied to every
+          matching ``Dataset`` leaf and the resulting leaves are
+          reassembled into a ``DataTree`` with the input's structure.
+          Empty-payload nodes (notably the implicit root of a tree
+          built from ``DataTree.from_dict``) are skipped via a
+          ``None``-return passthrough — there's nothing to operate on
+          and most ``_apply`` implementations would raise a ``KeyError``
+          trying to look up their variable.
+        - Otherwise → eager ``_apply`` via the pipekit base class.
+        """
+        # Lazy import — Node lives in pipekit but pulling it eagerly at
+        # module import would create a strict load order between the
+        # base classes.
+        from pipekit._base.graph import Node
+
+        if any(isinstance(a, Node) for a in args):
+            return super().__call__(*args, **kwargs)
+        if any(isinstance(a, xr.DataTree) for a in args):
+            apply = self._apply
+
+            def _leaf(*leaves: xr.Dataset) -> xr.Dataset | None:
+                # Skip empty-payload nodes (e.g. the synthetic root of
+                # a tree assembled from a flat ``{path: Dataset}`` dict).
+                # Returning ``None`` tells ``map_over_datasets`` to keep
+                # the node in place without rewriting its contents.
+                if any(len(leaf.data_vars) == 0 for leaf in leaves):
+                    return None
+                return apply(*leaves, **kwargs)
+
+            return xr.map_over_datasets(_leaf, *args)
+        return super().__call__(*args, **kwargs)

--- a/src/xrtoolz/_operator.py
+++ b/src/xrtoolz/_operator.py
@@ -37,7 +37,7 @@ from __future__ import annotations
 from typing import Any
 
 import xarray as xr
-from pipekit import Operator as _PipekitOperator
+from pipekit import Node, Operator as _PipekitOperator
 
 
 class Operator(_PipekitOperator):
@@ -71,31 +71,43 @@ class Operator(_PipekitOperator):
           ``xr.map_over_datasets``; the operator is applied to every
           matching ``Dataset`` leaf and the resulting leaves are
           reassembled into a ``DataTree`` with the input's structure.
-          Empty-payload nodes (notably the implicit root of a tree
-          built from ``DataTree.from_dict``) are skipped via a
-          ``None``-return passthrough — there's nothing to operate on
-          and most ``_apply`` implementations would raise a ``KeyError``
-          trying to look up their variable.
+          A node is skipped (via ``None`` return) only when **every**
+          input leaf at that path is empty — this handles the synthetic
+          root of a tree assembled from a flat ``{path: Dataset}`` dict
+          without silently swallowing a real / empty mismatch in
+          multi-input mode. ``DataArray`` returns are wrapped into a
+          single-variable ``Dataset`` so ``map_over_datasets`` can stitch
+          them into a result tree; anything other than ``Dataset`` /
+          ``DataArray`` (e.g. a ``Figure`` from a terminal viz op) is
+          rejected with a clear ``TypeError`` — terminal/visualisation
+          operators are not meaningful in DataTree mode.
         - Otherwise → eager ``_apply`` via the pipekit base class.
         """
-        # Lazy import — Node lives in pipekit but pulling it eagerly at
-        # module import would create a strict load order between the
-        # base classes.
-        from pipekit._base.graph import Node
-
         if any(isinstance(a, Node) for a in args):
             return super().__call__(*args, **kwargs)
         if any(isinstance(a, xr.DataTree) for a in args):
             apply = self._apply
+            cls_name = type(self).__name__
 
             def _leaf(*leaves: xr.Dataset) -> xr.Dataset | None:
-                # Skip empty-payload nodes (e.g. the synthetic root of
-                # a tree assembled from a flat ``{path: Dataset}`` dict).
-                # Returning ``None`` tells ``map_over_datasets`` to keep
-                # the node in place without rewriting its contents.
-                if any(len(leaf.data_vars) == 0 for leaf in leaves):
+                # Only skip when *every* input leaf is empty (synthetic
+                # root of a ``from_dict`` tree). Partial emptiness should
+                # fall through to ``_apply`` so the user sees a real
+                # error rather than a silent no-op.
+                if all(len(leaf.data_vars) == 0 for leaf in leaves):
                     return None
-                return apply(*leaves, **kwargs)
+                result = apply(*leaves, **kwargs)
+                if isinstance(result, xr.Dataset) or result is None:
+                    return result
+                if isinstance(result, xr.DataArray):
+                    name = result.name if result.name is not None else "value"
+                    return result.to_dataset(name=name)
+                raise TypeError(
+                    f"{cls_name}: DataTree dispatch requires _apply to return "
+                    f"a Dataset or DataArray, got {type(result).__name__}. "
+                    "Terminal / visualisation operators are not supported in "
+                    "DataTree mode — call them on a single Dataset leaf."
+                )
 
             return xr.map_over_datasets(_leaf, *args)
         return super().__call__(*args, **kwargs)

--- a/src/xrtoolz/budgets/operators.py
+++ b/src/xrtoolz/budgets/operators.py
@@ -6,8 +6,8 @@ from collections.abc import Sequence
 from typing import Any
 
 import xarray as xr
-from pipekit import Operator
 
+from xrtoolz._operator import Operator
 from xrtoolz.budgets._src.flux import boundary_flux
 from xrtoolz.budgets._src.heat import heat_budget_residual
 from xrtoolz.budgets._src.ke import kinetic_energy_budget_residual

--- a/src/xrtoolz/combinators.py
+++ b/src/xrtoolz/combinators.py
@@ -111,7 +111,7 @@ class Augment(Operator):
             variables.
     """
 
-    def __init__(self, inner: Operator) -> None:
+    def __init__(self, inner: _PipekitOperator) -> None:
         # Accept any pipekit Operator (xrtoolz.Operator is a subclass), so
         # users can wrap composites like ``Sequential`` that still live on
         # pipekit's carrier-agnostic base.
@@ -236,7 +236,7 @@ class ApplyToEach(Operator):
 
     def __init__(
         self,
-        prototype: Operator,
+        prototype: _PipekitOperator,
         *,
         kwarg: str,
         values: Sequence[Any],

--- a/src/xrtoolz/combinators.py
+++ b/src/xrtoolz/combinators.py
@@ -37,7 +37,9 @@ from collections.abc import Sequence
 from typing import Any
 
 import xarray as xr
-from pipekit import Operator
+from pipekit import Operator as _PipekitOperator
+
+from xrtoolz._operator import Operator
 
 
 class Augment(Operator):
@@ -110,7 +112,10 @@ class Augment(Operator):
     """
 
     def __init__(self, inner: Operator) -> None:
-        if not isinstance(inner, Operator):
+        # Accept any pipekit Operator (xrtoolz.Operator is a subclass), so
+        # users can wrap composites like ``Sequential`` that still live on
+        # pipekit's carrier-agnostic base.
+        if not isinstance(inner, _PipekitOperator):
             raise TypeError(
                 f"Augment expects an Operator instance, got {type(inner).__name__}."
             )
@@ -236,7 +241,7 @@ class ApplyToEach(Operator):
         kwarg: str,
         values: Sequence[Any],
     ) -> None:
-        if not isinstance(prototype, Operator):
+        if not isinstance(prototype, _PipekitOperator):
             raise TypeError(
                 f"ApplyToEach expects an Operator prototype, "
                 f"got {type(prototype).__name__}."

--- a/src/xrtoolz/geo/operators.py
+++ b/src/xrtoolz/geo/operators.py
@@ -19,8 +19,8 @@ from typing import Any, Literal
 
 import regionmask
 import xarray as xr
-from pipekit import Operator
 
+from xrtoolz._operator import Operator
 from xrtoolz.geo._src import (
     along_track as _along_track,
     detrend as _detrend,

--- a/src/xrtoolz/inference/modelop.py
+++ b/src/xrtoolz/inference/modelop.py
@@ -20,7 +20,8 @@ from typing import Any
 
 import numpy as np
 import xarray as xr
-from pipekit import Operator
+
+from xrtoolz._operator import Operator
 
 
 _XR_TYPES = (xr.DataArray, xr.Dataset)

--- a/src/xrtoolz/interpolate/_src/downscale.py
+++ b/src/xrtoolz/interpolate/_src/downscale.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from pipekit import Operator
+from xrtoolz._operator import Operator
 
 
 class _ResolutionOp(Operator):

--- a/src/xrtoolz/interpolate/operators.py
+++ b/src/xrtoolz/interpolate/operators.py
@@ -14,8 +14,8 @@ from typing import Any, Literal
 
 import numpy as np
 import xarray as xr
-from pipekit import Operator
 
+from xrtoolz._operator import Operator
 from xrtoolz.interpolate._src import (
     binning as _binning,
     downscale as _downscale,

--- a/src/xrtoolz/metrics/_src/distributional.py
+++ b/src/xrtoolz/metrics/_src/distributional.py
@@ -22,8 +22,9 @@ from typing import Any, cast
 import numpy as np
 import xarray as xr
 import xskillscore as xs
-from pipekit import Operator
 from scipy.stats import energy_distance as _scipy_energy_distance, wasserstein_distance
+
+from xrtoolz._operator import Operator
 
 
 def _check_member_dim(da: xr.DataArray, dim: str) -> None:

--- a/src/xrtoolz/metrics/_src/forecast.py
+++ b/src/xrtoolz/metrics/_src/forecast.py
@@ -16,7 +16,8 @@ from typing import Any
 
 import numpy as np
 import xarray as xr
-from pipekit import Operator
+
+from xrtoolz._operator import Operator
 
 
 # ---------- Layer-0 (xarray) ----------------------------------------------

--- a/src/xrtoolz/metrics/_src/masked.py
+++ b/src/xrtoolz/metrics/_src/masked.py
@@ -15,7 +15,8 @@ from __future__ import annotations
 from typing import Any
 
 import xarray as xr
-from pipekit import Operator
+
+from xrtoolz._operator import Operator
 
 
 # ---------- Layer-0 -------------------------------------------------------

--- a/src/xrtoolz/metrics/_src/multiscale.py
+++ b/src/xrtoolz/metrics/_src/multiscale.py
@@ -23,7 +23,8 @@ from typing import Any
 
 import numpy as np
 import xarray as xr
-from pipekit import Operator
+
+from xrtoolz._operator import Operator
 
 
 def _import_regionmask() -> Any:

--- a/src/xrtoolz/metrics/_src/object.py
+++ b/src/xrtoolz/metrics/_src/object.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from pipekit import Operator
+from xrtoolz._operator import Operator
 
 
 class _ObjectMetricStub(Operator):

--- a/src/xrtoolz/metrics/_src/physical.py
+++ b/src/xrtoolz/metrics/_src/physical.py
@@ -32,9 +32,9 @@ from typing import Any
 
 import numpy as np
 import xarray as xr
-from pipekit import Operator
 
 from xrtoolz import calc
+from xrtoolz._operator import Operator
 from xrtoolz.ocn._src.kinematics import coriolis_parameter
 
 

--- a/src/xrtoolz/metrics/_src/pixel.py
+++ b/src/xrtoolz/metrics/_src/pixel.py
@@ -19,8 +19,8 @@ from typing import Any
 
 import numpy as np
 import xarray as xr
-from pipekit import Operator
 
+from xrtoolz._operator import Operator
 from xrtoolz.metrics._src import array_pixel
 from xrtoolz.signature import Signature
 

--- a/src/xrtoolz/metrics/_src/probabilistic.py
+++ b/src/xrtoolz/metrics/_src/probabilistic.py
@@ -21,7 +21,8 @@ from typing import Any
 
 import numpy as np
 import xarray as xr
-from pipekit import Operator
+
+from xrtoolz._operator import Operator
 
 
 def _check_ensemble_dim(da: xr.DataArray, dim: str) -> None:

--- a/src/xrtoolz/metrics/_src/residuals.py
+++ b/src/xrtoolz/metrics/_src/residuals.py
@@ -9,8 +9,9 @@ import numpy as np
 import pandas as pd
 import regionmask
 import xarray as xr
-from pipekit import Operator
 from scipy.stats import binned_statistic_2d
+
+from xrtoolz._operator import Operator
 
 
 def bin_residuals_2d(

--- a/src/xrtoolz/metrics/_src/segmented_psd.py
+++ b/src/xrtoolz/metrics/_src/segmented_psd.py
@@ -7,10 +7,10 @@ from typing import Any
 import numpy as np
 import xarray as xr
 from numpy.typing import ArrayLike, NDArray
-from pipekit import Operator
 from scipy import signal
 from scipy.stats import circmean
 
+from xrtoolz._operator import Operator
 from xrtoolz.metrics._src.array_segmented_psd import _segment_bounds
 
 

--- a/src/xrtoolz/metrics/_src/spectral.py
+++ b/src/xrtoolz/metrics/_src/spectral.py
@@ -26,9 +26,9 @@ from typing import Any
 
 import numpy as np
 import xarray as xr
-from pipekit import Operator
 from scipy.interpolate import interp1d
 
+from xrtoolz._operator import Operator
 from xrtoolz.geo._src.wavelet import wvlt_power_spectrum
 from xrtoolz.geo._src.wavelet_utils import scale_to_wavenumber
 from xrtoolz.transforms._src.fourier import (

--- a/src/xrtoolz/metrics/_src/structural.py
+++ b/src/xrtoolz/metrics/_src/structural.py
@@ -23,8 +23,8 @@ from typing import Any
 
 import numpy as np
 import xarray as xr
-from pipekit import Operator
 
+from xrtoolz._operator import Operator
 from xrtoolz.utils._src.optional_imports import _require_optional
 
 

--- a/src/xrtoolz/ocn/operators.py
+++ b/src/xrtoolz/ocn/operators.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from pipekit import Operator
-
+from xrtoolz._operator import Operator
 from xrtoolz.ocn._src import (
     kinematics as _kinematics,
     ssh as _ssh,

--- a/src/xrtoolz/transforms/_src/sklearn_op.py
+++ b/src/xrtoolz/transforms/_src/sklearn_op.py
@@ -7,8 +7,8 @@ from typing import Any, Literal
 
 import numpy as np
 import xarray as xr
-from pipekit import Operator
 
+from xrtoolz._operator import Operator
 from xrtoolz.utils import XarrayEstimator
 from xrtoolz.utils._src.sklearn_wrap import NanPolicy
 

--- a/src/xrtoolz/transforms/operators.py
+++ b/src/xrtoolz/transforms/operators.py
@@ -20,8 +20,8 @@ from typing import Any
 
 import numpy as np
 import xarray as xr
-from pipekit import Operator
 
+from xrtoolz._operator import Operator
 from xrtoolz.transforms._src import (
     dct as _dct,
     fourier as _fourier,

--- a/src/xrtoolz/viz/validation/_src/base.py
+++ b/src/xrtoolz/viz/validation/_src/base.py
@@ -14,7 +14,8 @@ from typing import Any
 
 import matplotlib.figure as mpl_figure
 import matplotlib.pyplot as plt
-from pipekit import Operator
+
+from xrtoolz._operator import Operator
 
 
 class _ValidationPanel(Operator):

--- a/tests/test_datatree_dispatch.py
+++ b/tests/test_datatree_dispatch.py
@@ -53,6 +53,24 @@ class _Diff(Operator):
         return xr.Dataset({self.variable: pred[self.variable] - ref[self.variable]})
 
 
+class _DiffArray(Operator):
+    """Two-input op that returns a DataArray (e.g. an RMSE-style metric)."""
+
+    def __init__(self, variable: str) -> None:
+        self.variable = variable
+
+    def _apply(self, pred: xr.Dataset, ref: xr.Dataset) -> xr.DataArray:
+        out = pred[self.variable] - ref[self.variable]
+        return out.rename("delta")
+
+
+class _ReturnsObject(Operator):
+    """Op that returns a non-xarray object (stand-in for terminal viz)."""
+
+    def _apply(self, ds: xr.Dataset) -> object:
+        return object()
+
+
 # ---------- fixtures -------------------------------------------------------
 
 
@@ -178,3 +196,44 @@ def test_node_construction_still_works() -> None:
     inp = Input("ds")
     result = _ScaleVar("x", factor=2.0)(inp)
     assert isinstance(result, Node)
+
+
+# ---------- DataArray returns get wrapped into a Dataset -------------------
+
+
+def test_datatree_dispatch_wraps_dataarray_returns(dt: xr.DataTree) -> None:
+    """A metric returning DataArray maps cleanly over a DataTree."""
+    op = _DiffArray("x")
+    out = op(dt, dt)
+    assert isinstance(out, xr.DataTree)
+    for path in ("a", "b"):
+        ds_leaf = out[path].dataset
+        assert "delta" in ds_leaf.data_vars
+        np.testing.assert_array_equal(ds_leaf["delta"].values, np.zeros(4, dtype=float))
+
+
+# ---------- non-Dataset / non-DataArray returns are rejected ---------------
+
+
+def test_datatree_dispatch_rejects_non_xarray_return(dt: xr.DataTree) -> None:
+    op = _ReturnsObject()
+    with pytest.raises(TypeError, match="DataTree dispatch"):
+        op(dt)
+
+
+# ---------- partial-empty multi-input surfaces a real error ----------------
+
+
+def test_partial_empty_multi_input_surfaces_apply_error() -> None:
+    """If one tree has data and the other does not, ``_apply`` runs and
+    its KeyError surfaces rather than being silently swallowed.
+    """
+    ds_full = xr.Dataset(
+        {"x": (("t",), np.arange(4, dtype=float))},
+        coords={"t": np.arange(4)},
+    )
+    tree_full = xr.DataTree.from_dict({"a": ds_full})
+    tree_empty = xr.DataTree.from_dict({"a": xr.Dataset()})
+    op = _Diff("x")
+    with pytest.raises(KeyError):
+        op(tree_full, tree_empty)

--- a/tests/test_datatree_dispatch.py
+++ b/tests/test_datatree_dispatch.py
@@ -1,0 +1,180 @@
+"""Tests for the xarray-aware :class:`xrtoolz.Operator`.
+
+Covers the three ``__call__`` dispatch modes added on top of
+``pipekit.Operator``:
+
+1. Symbolic ``Node`` construction passes through to pipekit unchanged.
+2. ``DataTree`` arguments map ``_apply`` over every leaf, returning a
+   tree with the same structure.
+3. Plain ``Dataset`` / ``DataArray`` arguments hit ``_apply`` directly
+   (the existing eager path).
+
+The DataTree path is exercised end-to-end via ``Sequential`` and the
+functional ``Graph`` API to confirm composition flows through without
+per-step changes.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from xrtoolz import (
+    Graph,
+    Input,
+    Node,
+    Operator,
+    Sequential,
+)
+
+
+# ---------- toy operators --------------------------------------------------
+
+
+class _ScaleVar(Operator):
+    """Multiply ``variable`` by ``factor`` in-place on the Dataset."""
+
+    def __init__(self, variable: str, *, factor: float) -> None:
+        self.variable = variable
+        self.factor = factor
+
+    def _apply(self, ds: xr.Dataset) -> xr.Dataset:
+        return ds.assign({self.variable: ds[self.variable] * self.factor})
+
+
+class _Diff(Operator):
+    """Two-input op: ``pred - ref`` of ``variable``, returns a Dataset."""
+
+    def __init__(self, variable: str) -> None:
+        self.variable = variable
+
+    def _apply(self, pred: xr.Dataset, ref: xr.Dataset) -> xr.Dataset:
+        return xr.Dataset({self.variable: pred[self.variable] - ref[self.variable]})
+
+
+# ---------- fixtures -------------------------------------------------------
+
+
+@pytest.fixture
+def ds() -> xr.Dataset:
+    return xr.Dataset(
+        {"x": (("t",), np.arange(4, dtype=float))},
+        coords={"t": np.arange(4)},
+    )
+
+
+@pytest.fixture
+def dt() -> xr.DataTree:
+    leaf_a = xr.Dataset(
+        {"x": (("t",), np.array([1.0, 2.0, 3.0, 4.0]))},
+        coords={"t": np.arange(4)},
+    )
+    leaf_b = xr.Dataset(
+        {"x": (("t",), np.array([10.0, 20.0, 30.0, 40.0]))},
+        coords={"t": np.arange(4)},
+    )
+    return xr.DataTree.from_dict({"a": leaf_a, "b": leaf_b})
+
+
+# ---------- eager Dataset mode (no regression) -----------------------------
+
+
+def test_dataset_path_unchanged(ds: xr.Dataset) -> None:
+    op = _ScaleVar("x", factor=2.0)
+    out = op(ds)
+    assert isinstance(out, xr.Dataset)
+    np.testing.assert_array_equal(out["x"].values, ds["x"].values * 2.0)
+
+
+# ---------- single-input DataTree dispatch ---------------------------------
+
+
+def test_single_input_datatree_dispatch(dt: xr.DataTree) -> None:
+    op = _ScaleVar("x", factor=3.0)
+    out = op(dt)
+    assert isinstance(out, xr.DataTree)
+    assert set(out.children) == {"a", "b"}
+    np.testing.assert_array_equal(
+        out["a"].dataset["x"].values, np.array([3.0, 6.0, 9.0, 12.0])
+    )
+    np.testing.assert_array_equal(
+        out["b"].dataset["x"].values, np.array([30.0, 60.0, 90.0, 120.0])
+    )
+
+
+def test_datatree_preserves_structure(dt: xr.DataTree) -> None:
+    op = _ScaleVar("x", factor=1.0)
+    out = op(dt)
+    assert set(out.children) == set(dt.children)
+    for path in dt.children:
+        assert out[path].dataset.equals(dt[path].dataset)
+
+
+# ---------- multi-input DataTree dispatch ----------------------------------
+
+
+def test_multi_input_datatree_dispatch(dt: xr.DataTree) -> None:
+    op = _Diff("x")
+    out = op(dt, dt)  # identical trees → zero everywhere
+    assert isinstance(out, xr.DataTree)
+    for path in ("a", "b"):
+        np.testing.assert_array_equal(
+            out[path].dataset["x"].values, np.zeros(4, dtype=float)
+        )
+
+
+def test_multi_input_mismatched_structure_raises(dt: xr.DataTree) -> None:
+    other = xr.DataTree.from_dict(
+        {
+            "a": xr.Dataset({"x": (("t",), np.zeros(4))}, coords={"t": np.arange(4)}),
+        }
+    )
+    op = _Diff("x")
+    with pytest.raises(ValueError):
+        op(dt, other)
+
+
+# ---------- Sequential threads DataTrees end-to-end ------------------------
+
+
+def test_sequential_threads_datatree(dt: xr.DataTree) -> None:
+    pipeline = Sequential([_ScaleVar("x", factor=2.0), _ScaleVar("x", factor=5.0)])
+    out = pipeline(dt)
+    assert isinstance(out, xr.DataTree)
+    np.testing.assert_array_equal(
+        out["a"].dataset["x"].values, np.array([10.0, 20.0, 30.0, 40.0])
+    )
+    np.testing.assert_array_equal(
+        out["b"].dataset["x"].values, np.array([100.0, 200.0, 300.0, 400.0])
+    )
+
+
+def test_sequential_still_works_on_dataset(ds: xr.Dataset) -> None:
+    pipeline = Sequential([_ScaleVar("x", factor=2.0), _ScaleVar("x", factor=5.0)])
+    out = pipeline(ds)
+    assert isinstance(out, xr.Dataset)
+    np.testing.assert_array_equal(out["x"].values, ds["x"].values * 10.0)
+
+
+# ---------- Graph dispatch over DataTrees ----------------------------------
+
+
+def test_graph_over_datatree(dt: xr.DataTree) -> None:
+    inp = Input("dt")
+    node = _ScaleVar("x", factor=4.0)(inp)
+    graph = Graph(inputs={"dt": inp}, outputs={"out": node})
+    out = graph(dt=dt)["out"]
+    assert isinstance(out, xr.DataTree)
+    np.testing.assert_array_equal(
+        out["a"].dataset["x"].values, np.array([4.0, 8.0, 12.0, 16.0])
+    )
+
+
+# ---------- symbolic Node dispatch still works -----------------------------
+
+
+def test_node_construction_still_works() -> None:
+    inp = Input("ds")
+    result = _ScaleVar("x", factor=2.0)(inp)
+    assert isinstance(result, Node)

--- a/uv.lock
+++ b/uv.lock
@@ -3325,7 +3325,7 @@ requires-dist = [
     { name = "scikit-image", marker = "extra == 'image'", specifier = ">=0.21" },
     { name = "scikit-learn", specifier = ">=1.4" },
     { name = "scipy", specifier = ">=1.12" },
-    { name = "xarray", specifier = ">=2024.2" },
+    { name = "xarray", specifier = ">=2024.10" },
     { name = "xrft", specifier = ">=1.0" },
     { name = "xskillscore", specifier = ">=0.0.26" },
 ]


### PR DESCRIPTION
Implements **PR α** from [`docs/design/xarray-native-primitives.md`](docs/design/xarray-native-primitives.md): every operator gains free `xarray.DataTree` polymorphism via one new dispatch branch in `__call__`.

## Summary

- New `xrtoolz.Operator` subclass of `pipekit.Operator` adds a DataTree branch to `__call__`. If any positional arg is a `DataTree`, the operator is mapped over every matching leaf via `xr.map_over_datasets`; empty-payload nodes (e.g. the synthetic root of `DataTree.from_dict({"a": ds, ...})`) are passed through via a `None` return so user `_apply`s don't have to guard against empty variable lookups.
- Every in-repo operator now inherits from `xrtoolz.Operator` (mechanical import rewrite across ~23 files).
- `xrtoolz.combinators.Augment` / `ApplyToEach` widen their `isinstance` check back to `pipekit.Operator` so users can still wrap composites like `Sequential` whose direct base is pipekit's.
- `pipekit.Sequential` and `pipekit.Graph` are **unchanged** — they're carrier-agnostic and thread whatever each step returns. The dispatch flowing through them is exercised by tests.

## Architecture note

The original design doc placed the DataTree branch on `core/operator.py` inside the package. Since the composition core now lives in carrier-agnostic `pipekit`, the xarray-aware variant lives on an `xrtoolz` subclass — consistent with the existing split (`pipekit` for generic composition, `xrtoolz` for xarray flavour, `xrtoolz.combinators` for xarray-specific combinators).

## Scope

- **Done here**: PR α (the core + DataTree dispatch). ~100 LOC of new src + ~180 LOC of tests, plus mechanical import shuffles.
- **Not in this PR**: PR β (metrics + interpolate primitive flip to DataArray-positional) and PR γ (transforms + geo cleanup). Tracked by the design doc.

## Test plan

- [x] New `tests/test_datatree_dispatch.py` (9 tests): eager Dataset path unchanged; single-input DataTree dispatch; multi-input dispatch; structure preservation; mismatched-structure error; `Sequential` over DataTree; `Sequential` still works on Dataset; `Graph` over DataTree; symbolic `Node` construction still works.
- [x] Full test suite passes (1,241 passed; 9 failures are pre-existing on `main`, all from missing optional deps like `scikit-image`).
- [x] `ruff check .` + `ruff format --check .` clean.
- [x] `ty check src/xrtoolz` — no new diagnostics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)