### PR TITLE
feat!: flip metrics + interpolate primitives to DataArray-positional (PR β)

### DIFF
--- a/docs/design/xarray-native-primitives.md
+++ b/docs/design/xarray-native-primitives.md
@@ -13,7 +13,18 @@ version: 0.1.1
 > `xrtoolz.Operator` subclass rather than on `pipekit.Operator`
 > itself. `pipekit.Sequential` and `pipekit.Graph` thread the
 > resulting `DataTree`s through without changes — they are
-> carrier-agnostic. PRs β and γ remain to be done.
+> carrier-agnostic.
+>
+> **PR β is now complete.** Every Layer-0 primitive in
+> `metrics/_src/{pixel,spectral,composite,structural,segmented_psd,distributional,probabilistic}.py`
+> and `interpolate/_src/{smooth,resample}.py` takes positional
+> `DataArray` inputs and keyword-only configuration; the Dataset
+> selection / per-variable loop moved into the matching Layer-1
+> `Operator._apply`. `metrics/_src/spectral.evaluate_by_frequency_band`
+> intentionally stays Dataset-flavoured (it composes an inner
+> Operator), and `metrics/_src/dm.dm_test` stays array-positional
+> (no Dataset to flip). Operator constructor signatures are
+> unchanged. PR γ remains to be done.
 
 A follow-on refactor to D11 (revised). Flips every primitive in the
 package to an xarray-only public signature, keeping user-authored

--- a/src/xrtoolz/geo/_src/along_track.py
+++ b/src/xrtoolz/geo/_src/along_track.py
@@ -97,6 +97,12 @@ def bandpass_wavelength(
         Dataset filtered along ``dim``. Variables without ``dim`` or with
         non-numeric dtype pass through unchanged.
     """
+    if dim not in ds.dims:
+        # The previous Dataset-flavoured ``fir_filter(ds, ...)`` raised on a
+        # missing dim; the new per-variable loop would otherwise pass every
+        # variable through unchanged when ``dim`` is misspelled — a quiet
+        # no-op that's worse than a clear failure for downstream metrics.
+        raise ValueError(f"dim {dim!r} not in Dataset dims {tuple(ds.dims)}")
     if lambda_min_km is None and lambda_max_km is None:
         raise ValueError("at least one of lambda_min_km or lambda_max_km is required")
     if (

--- a/src/xrtoolz/geo/_src/along_track.py
+++ b/src/xrtoolz/geo/_src/along_track.py
@@ -143,15 +143,24 @@ def bandpass_wavelength(
             _cutoff_from_wavelength(lambda_min_km, spacing_km),
         )
 
-    return fir_filter(
-        ds,
-        dim=dim,
-        cutoff=cutoff,
-        method=method,
-        btype=btype,
-        num_taps=num_taps,
-        attenuation_db=attenuation_db,
-    )
+    # ``fir_filter`` is DataArray-only after the PR β primitive flip. Loop
+    # over numeric data variables that carry the filter dim and pass other
+    # variables through unchanged.
+    out_vars: dict[str, xr.DataArray] = {}
+    for name, da in ds.data_vars.items():
+        if dim not in da.dims or not np.issubdtype(da.dtype, np.number):
+            out_vars[str(name)] = da
+            continue
+        out_vars[str(name)] = fir_filter(
+            da,
+            dim=dim,
+            cutoff=cutoff,
+            method=method,
+            btype=btype,
+            num_taps=num_taps,
+            attenuation_db=attenuation_db,
+        )
+    return xr.Dataset(out_vars, coords=ds.coords, attrs=dict(ds.attrs))
 
 
 __all__ = ["bandpass_wavelength", "median_dx_km"]

--- a/src/xrtoolz/interpolate/_src/resample.py
+++ b/src/xrtoolz/interpolate/_src/resample.py
@@ -74,9 +74,7 @@ def _ensure_datetime_like_time(da: xr.DataArray, *, time: str) -> None:
         ) from exc
 
 
-def _target_is_coarser_than_source(
-    da: xr.DataArray, *, freq: str, time: str
-) -> bool:
+def _target_is_coarser_than_source(da: xr.DataArray, *, freq: str, time: str) -> bool:
     coord = da[time]
     if coord.size < 2:
         return False

--- a/src/xrtoolz/interpolate/_src/resample.py
+++ b/src/xrtoolz/interpolate/_src/resample.py
@@ -15,17 +15,21 @@ _ALLOWED_RESAMPLE_METHODS = frozenset(
 
 
 def resample_time(
-    ds: xr.Dataset | xr.DataArray,
+    da: xr.DataArray,
     freq: str = "1D",
     method: str = "mean",
     time: str = "time",
     *,
     interp_method: Literal["linear", "nearest", "cubic"] = "linear",
-) -> xr.Dataset | xr.DataArray:
-    """Resample along the time axis via xarray's built-in resampler.
+) -> xr.DataArray:
+    """Resample a DataArray along the time axis via xarray's built-in resampler.
+
+    Per the PR β primitive-flip, this primitive is DataArray-only.
+    The Layer-1 ``ResampleTime`` operator handles ``ds.map``-style
+    dispatch when a Dataset is supplied.
 
     Args:
-        ds: Input.
+        da: Input DataArray.
         freq: Pandas-style frequency string (e.g. ``"1D"``, ``"6H"``,
             ``"1M"``).
         method: Zero-argument aggregation method; one of ``"mean"``,
@@ -39,7 +43,7 @@ def resample_time(
             ``method="interpolate"``.
 
     Returns:
-        Resampled container.
+        Resampled DataArray.
     """
     if method not in _ALLOWED_RESAMPLE_METHODS | {"interpolate"}:
         raise ValueError(
@@ -48,21 +52,21 @@ def resample_time(
         )
 
     if method == "interpolate":
-        _ensure_datetime_like_time(ds, time=time)
-        if _target_is_coarser_than_source(ds, freq=freq, time=time):
+        _ensure_datetime_like_time(da, time=time)
+        if _target_is_coarser_than_source(da, freq=freq, time=time):
             raise ValueError(
                 "resample_time(method='interpolate') only supports upsampling; "
                 f"got target frequency {freq!r} coarser than the input."
             )
-        return ds.resample({time: freq}).interpolate(interp_method)
+        return da.resample({time: freq}).interpolate(interp_method)
 
-    resampler = ds.resample({time: freq})
+    resampler = da.resample({time: freq})
     return getattr(resampler, method)()
 
 
-def _ensure_datetime_like_time(ds: xr.Dataset | xr.DataArray, *, time: str) -> None:
+def _ensure_datetime_like_time(da: xr.DataArray, *, time: str) -> None:
     try:
-        _ = ds[time].dt.year
+        _ = da[time].dt.year
     except AttributeError as exc:
         raise ValueError(
             f"{time!r} coordinate must be datetime-like for "
@@ -71,9 +75,9 @@ def _ensure_datetime_like_time(ds: xr.Dataset | xr.DataArray, *, time: str) -> N
 
 
 def _target_is_coarser_than_source(
-    ds: xr.Dataset | xr.DataArray, *, freq: str, time: str
+    da: xr.DataArray, *, freq: str, time: str
 ) -> bool:
-    coord = ds[time]
+    coord = da[time]
     if coord.size < 2:
         return False
 

--- a/src/xrtoolz/interpolate/_src/smooth.py
+++ b/src/xrtoolz/interpolate/_src/smooth.py
@@ -1,9 +1,11 @@
-"""Tier B — value-preserving smoothers on xarray Datasets (D12, F3.3).
+"""Tier B — value-preserving smoothers on xarray DataArrays (D12, F3.3).
 
-Functions take an :class:`xr.Dataset`, a dimension name, and smoother
-parameters; they return a Dataset with the same shape and coords, every
-numeric data variable smoothed along ``dim``. Variables that don't
-carry ``dim`` (or are non-numeric) pass through untouched.
+Per the PR β primitive-flip (``docs/design/xarray-native-primitives.md``),
+the Layer-0 smoothers in this module are DataArray-in / DataArray-out:
+one variable goes in, one variable comes out. The Dataset loop —
+applying the kernel to every numeric data variable that carries
+``dim``, while passing other variables through — lives in the Layer-1
+``Operator`` wrappers at :mod:`xrtoolz.interpolate.operators`.
 
 Per D12 the smoothers are deterministic and parameter-free —
 ``KalmanSmoother`` is out of scope here and lives under future
@@ -23,12 +25,36 @@ import xarray as xr
 from xrtoolz.interpolate._src import array_smooth as _array
 
 
-def _apply_along_dim(
+def _apply_kernel_to_dataarray(
+    da: xr.DataArray,
+    dim: str,
+    fn: Callable[..., Any],
+) -> xr.DataArray:
+    """Apply a Tier A kernel along ``dim`` of a single DataArray."""
+    if dim not in da.dims:
+        raise ValueError(f"dim {dim!r} not in DataArray dims {tuple(da.dims)}")
+    axis = da.get_axis_num(dim)
+    smoothed = fn(da.values, axis=axis)
+    return xr.DataArray(
+        smoothed,
+        dims=da.dims,
+        coords=da.coords,
+        attrs=dict(da.attrs),
+        name=da.name,
+    )
+
+
+def _apply_dataset_loop(
     ds: xr.Dataset,
     dim: str,
     fn: Callable[..., Any],
 ) -> xr.Dataset:
-    """Apply a Tier A kernel to every numeric data variable that carries ``dim``."""
+    """Apply ``fn`` to every numeric data variable carrying ``dim``.
+
+    Operator-side helper; primitives themselves are DataArray-only.
+    Variables that don't carry ``dim`` (or are non-numeric) pass
+    through untouched.
+    """
     if dim not in ds.dims:
         raise ValueError(f"dim {dim!r} not in Dataset dims {tuple(ds.dims)}")
 
@@ -37,26 +63,18 @@ def _apply_along_dim(
         if dim not in da.dims or not np.issubdtype(da.dtype, np.number):
             out_vars[str(name)] = da
             continue
-        axis = da.get_axis_num(dim)
-        smoothed = fn(da.values, axis=axis)
-        out_vars[str(name)] = xr.DataArray(
-            smoothed,
-            dims=da.dims,
-            coords=da.coords,
-            attrs=dict(da.attrs),
-            name=da.name,
-        )
+        out_vars[str(name)] = _apply_kernel_to_dataarray(da, dim, fn)
     return xr.Dataset(out_vars, coords=ds.coords, attrs=dict(ds.attrs))
 
 
 def moving_average(
-    ds: xr.Dataset,
+    da: xr.DataArray,
     *,
     dim: str,
     window: int,
     center: bool = True,
     min_periods: int | None = None,
-) -> xr.Dataset:
+) -> xr.DataArray:
     """Sliding-window mean along ``dim``.
 
     See :func:`xrtoolz.interpolate.array.moving_average` for the Tier A
@@ -72,22 +90,22 @@ def moving_average(
             min_periods=min_periods,
         )
 
-    return _apply_along_dim(ds, dim, _fn)
+    return _apply_kernel_to_dataarray(da, dim, _fn)
 
 
 def gaussian_smooth(
-    ds: xr.Dataset,
+    da: xr.DataArray,
     *,
     dim: str,
     sigma: float,
     truncate: float = 4.0,
-) -> xr.Dataset:
+) -> xr.DataArray:
     """Gaussian smoothing along ``dim`` with standard deviation ``sigma``."""
 
     def _fn(arr: np.ndarray, *, axis: int) -> np.ndarray:
         return _array.gaussian_smooth(arr, axis=axis, sigma=sigma, truncate=truncate)
 
-    return _apply_along_dim(ds, dim, _fn)
+    return _apply_kernel_to_dataarray(da, dim, _fn)
 
 
 def _normalize_dims(dim: str | Sequence[str]) -> tuple[str, ...]:
@@ -169,7 +187,7 @@ def _gaussian_smooth_masked_dataarray(
 
 
 def gaussian_smooth_masked(
-    ds: xr.Dataset | xr.DataArray,
+    da: xr.DataArray,
     *,
     dim: str | Sequence[str],
     sigma: float | Mapping[str, float],
@@ -177,8 +195,12 @@ def gaussian_smooth_masked(
     mode: str = "reflect",
     nan_aware: bool = True,
     min_weight: float = 1e-6,
-) -> xr.Dataset | xr.DataArray:
-    """NaN-aware N-D Gaussian smoothing along one or more dimensions."""
+) -> xr.DataArray:
+    """NaN-aware N-D Gaussian smoothing along one or more dimensions.
+
+    Operates on a single :class:`xr.DataArray`. The Layer-1
+    ``GaussianSmoothMasked`` operator handles the Dataset loop.
+    """
     if truncate <= 0:
         raise ValueError(f"truncate must be > 0, got {truncate}")
     if min_weight < 0:
@@ -187,47 +209,28 @@ def gaussian_smooth_masked(
     dims = _normalize_dims(dim)
     sigmas = _normalize_sigmas(sigma, dims)
 
-    if isinstance(ds, xr.DataArray):
-        missing = tuple(d for d in dims if d not in ds.dims)
-        if missing:
-            raise ValueError(f"dim entries {missing} not in DataArray dims {ds.dims}")
-        return _gaussian_smooth_masked_dataarray(
-            ds,
-            dims=dims,
-            sigmas=sigmas,
-            truncate=truncate,
-            mode=mode,
-            nan_aware=nan_aware,
-            min_weight=min_weight,
-        )
-
-    missing = tuple(d for d in dims if d not in ds.dims)
+    missing = tuple(d for d in dims if d not in da.dims)
     if missing:
-        raise ValueError(f"dim entries {missing} not in Dataset dims {tuple(ds.dims)}")
-
-    out_vars = {
-        str(name): _gaussian_smooth_masked_dataarray(
-            da,
-            dims=dims,
-            sigmas=sigmas,
-            truncate=truncate,
-            mode=mode,
-            nan_aware=nan_aware,
-            min_weight=min_weight,
-        )
-        for name, da in ds.data_vars.items()
-    }
-    return xr.Dataset(out_vars, coords=ds.coords, attrs=dict(ds.attrs))
+        raise ValueError(f"dim entries {missing} not in DataArray dims {da.dims}")
+    return _gaussian_smooth_masked_dataarray(
+        da,
+        dims=dims,
+        sigmas=sigmas,
+        truncate=truncate,
+        mode=mode,
+        nan_aware=nan_aware,
+        min_weight=min_weight,
+    )
 
 
 def lowpass_filter(
-    ds: xr.Dataset,
+    da: xr.DataArray,
     *,
     dim: str,
     cutoff: float | tuple[float, float] | list[float] | np.ndarray,
     order: int = 4,
     btype: str = "low",
-) -> xr.Dataset:
+) -> xr.DataArray:
     """Zero-phase Butterworth filter along ``dim``.
 
     ``cutoff`` is the normalized critical frequency (fraction of the
@@ -241,11 +244,11 @@ def lowpass_filter(
             arr, axis=axis, cutoff=cutoff, order=order, btype=btype
         )
 
-    return _apply_along_dim(ds, dim, _fn)
+    return _apply_kernel_to_dataarray(da, dim, _fn)
 
 
 def fir_filter(
-    ds: xr.Dataset,
+    da: xr.DataArray,
     *,
     dim: str,
     cutoff: float | tuple[float, float] | list[float] | np.ndarray,
@@ -253,7 +256,7 @@ def fir_filter(
     btype: str = "low",
     num_taps: int | None = None,
     attenuation_db: float | None = None,
-) -> xr.Dataset:
+) -> xr.DataArray:
     """Zero-phase FIR filter along ``dim``.
 
     See :func:`xrtoolz.interpolate.array.fir_filter` for cutoff, window,
@@ -271,7 +274,7 @@ def fir_filter(
             attenuation_db=attenuation_db,
         )
 
-    return _apply_along_dim(ds, dim, _fn)
+    return _apply_kernel_to_dataarray(da, dim, _fn)
 
 
 __all__ = [

--- a/src/xrtoolz/interpolate/_src/smooth.py
+++ b/src/xrtoolz/interpolate/_src/smooth.py
@@ -44,29 +44,6 @@ def _apply_kernel_to_dataarray(
     )
 
 
-def _apply_dataset_loop(
-    ds: xr.Dataset,
-    dim: str,
-    fn: Callable[..., Any],
-) -> xr.Dataset:
-    """Apply ``fn`` to every numeric data variable carrying ``dim``.
-
-    Operator-side helper; primitives themselves are DataArray-only.
-    Variables that don't carry ``dim`` (or are non-numeric) pass
-    through untouched.
-    """
-    if dim not in ds.dims:
-        raise ValueError(f"dim {dim!r} not in Dataset dims {tuple(ds.dims)}")
-
-    out_vars: dict[str, xr.DataArray] = {}
-    for name, da in ds.data_vars.items():
-        if dim not in da.dims or not np.issubdtype(da.dtype, np.number):
-            out_vars[str(name)] = da
-            continue
-        out_vars[str(name)] = _apply_kernel_to_dataarray(da, dim, fn)
-    return xr.Dataset(out_vars, coords=ds.coords, attrs=dict(ds.attrs))
-
-
 def moving_average(
     da: xr.DataArray,
     *,

--- a/src/xrtoolz/interpolate/operators.py
+++ b/src/xrtoolz/interpolate/operators.py
@@ -465,7 +465,20 @@ class ResampleTime(Operator):
                     out_vars[str(name)] = da
                 else:
                     out_vars[str(name)] = _fn(da)
-            return xr.Dataset(out_vars, attrs=dict(ds.attrs))
+            out_ds = xr.Dataset(out_vars, attrs=dict(ds.attrs))
+            # Preserve standalone coordinates that the per-variable loop
+            # would otherwise drop — anything not riding on the resampled
+            # ``time`` dim is safe to re-attach; coords *on* time are
+            # replaced by the resampled grid carried through the
+            # per-variable outputs.
+            extra_coords = {
+                name: coord
+                for name, coord in ds.coords.items()
+                if name not in out_ds.coords and self.time not in coord.dims
+            }
+            if extra_coords:
+                out_ds = out_ds.assign_coords(extra_coords)
+            return out_ds
         return _fn(ds)
 
     def compute_output_signature(self, input_signature: Signature) -> Signature:

--- a/src/xrtoolz/interpolate/operators.py
+++ b/src/xrtoolz/interpolate/operators.py
@@ -1112,9 +1112,7 @@ def _map_over_dataset_or_dataarray(
     if isinstance(data, xr.DataArray):
         return fn(data)
 
-    dims_required: tuple[str, ...] = (
-        (dim,) if isinstance(dim, str) else tuple(dim)
-    )
+    dims_required: tuple[str, ...] = (dim,) if isinstance(dim, str) else tuple(dim)
     missing = tuple(d for d in dims_required if d not in data.dims)
     if missing:
         if len(missing) == 1:

--- a/src/xrtoolz/interpolate/operators.py
+++ b/src/xrtoolz/interpolate/operators.py
@@ -446,13 +446,27 @@ class ResampleTime(Operator):
         self.interp_method = interp_method
 
     def _apply(self, ds):
-        return _resample.resample_time(
-            ds,
-            freq=self.freq,
-            method=self.method,
-            time=self.time,
-            interp_method=self.interp_method,
-        )
+        def _fn(da: xr.DataArray) -> xr.DataArray:
+            return _resample.resample_time(
+                da,
+                freq=self.freq,
+                method=self.method,
+                time=self.time,
+                interp_method=self.interp_method,
+            )
+
+        if isinstance(ds, xr.Dataset):
+            # Map per-variable so non-time variables pass through
+            # untouched, mirroring the smoother operators after the PR β
+            # primitive flip.
+            out_vars: dict[str, xr.DataArray] = {}
+            for name, da in ds.data_vars.items():
+                if self.time not in da.dims:
+                    out_vars[str(name)] = da
+                else:
+                    out_vars[str(name)] = _fn(da)
+            return xr.Dataset(out_vars, attrs=dict(ds.attrs))
+        return _fn(ds)
 
     def compute_output_signature(self, input_signature: Signature) -> Signature:
         return input_signature.replace_dims({self.time: None})

--- a/src/xrtoolz/interpolate/operators.py
+++ b/src/xrtoolz/interpolate/operators.py
@@ -1084,6 +1084,42 @@ class AlongTrack(Operator):
 # ---------- smoothers ------------------------------------------------------
 
 
+def _map_over_dataset_or_dataarray(
+    data: xr.Dataset | xr.DataArray,
+    dim: str | Sequence[str],
+    fn,
+) -> xr.Dataset | xr.DataArray:
+    """Apply a DataArray-only smoother kernel to a Dataset or DataArray.
+
+    Variables that don't carry every requested dim (or aren't numeric)
+    pass through unchanged; everything else is run through ``fn``. The
+    Dataset must itself carry every requested dim.
+    """
+    if isinstance(data, xr.DataArray):
+        return fn(data)
+
+    dims_required: tuple[str, ...] = (
+        (dim,) if isinstance(dim, str) else tuple(dim)
+    )
+    missing = tuple(d for d in dims_required if d not in data.dims)
+    if missing:
+        if len(missing) == 1:
+            raise ValueError(
+                f"dim {missing[0]!r} not in Dataset dims {tuple(data.dims)}"
+            )
+        raise ValueError(
+            f"dim entries {missing} not in Dataset dims {tuple(data.dims)}"
+        )
+    out_vars: dict[str, xr.DataArray] = {}
+    for name, da in data.data_vars.items():
+        carries_all = all(d in da.dims for d in dims_required)
+        if not carries_all or not np.issubdtype(da.dtype, np.number):
+            out_vars[str(name)] = da
+            continue
+        out_vars[str(name)] = fn(da)
+    return xr.Dataset(out_vars, coords=data.coords, attrs=dict(data.attrs))
+
+
 class MovingAverage(Operator):
     """Wrap :func:`xrtoolz.interpolate._src.smooth.moving_average`."""
 
@@ -1111,13 +1147,16 @@ class MovingAverage(Operator):
         self.min_periods = min_periods
 
     def _apply(self, ds):
-        return _smooth.moving_average(
-            ds,
-            dim=self.dim,
-            window=self.window,
-            center=self.center,
-            min_periods=self.min_periods,
-        )
+        def _fn(da: xr.DataArray) -> xr.DataArray:
+            return _smooth.moving_average(
+                da,
+                dim=self.dim,
+                window=self.window,
+                center=self.center,
+                min_periods=self.min_periods,
+            )
+
+        return _map_over_dataset_or_dataarray(ds, self.dim, _fn)
 
     def get_config(self) -> dict[str, Any]:
         return {
@@ -1139,9 +1178,12 @@ class GaussianSmooth(Operator):
         self.truncate = float(truncate)
 
     def _apply(self, ds):
-        return _smooth.gaussian_smooth(
-            ds, dim=self.dim, sigma=self.sigma, truncate=self.truncate
-        )
+        def _fn(da: xr.DataArray) -> xr.DataArray:
+            return _smooth.gaussian_smooth(
+                da, dim=self.dim, sigma=self.sigma, truncate=self.truncate
+            )
+
+        return _map_over_dataset_or_dataarray(ds, self.dim, _fn)
 
     def get_config(self) -> dict[str, Any]:
         return {"dim": self.dim, "sigma": self.sigma, "truncate": self.truncate}
@@ -1179,15 +1221,18 @@ class GaussianSmoothMasked(Operator):
         self.min_weight = float(min_weight)
 
     def _apply(self, ds):
-        return _smooth.gaussian_smooth_masked(
-            ds,
-            dim=self.dim,
-            sigma=self.sigma,
-            truncate=self.truncate,
-            mode=self.mode,
-            nan_aware=self.nan_aware,
-            min_weight=self.min_weight,
-        )
+        def _fn(da: xr.DataArray) -> xr.DataArray:
+            return _smooth.gaussian_smooth_masked(
+                da,
+                dim=self.dim,
+                sigma=self.sigma,
+                truncate=self.truncate,
+                mode=self.mode,
+                nan_aware=self.nan_aware,
+                min_weight=self.min_weight,
+            )
+
+        return _map_over_dataset_or_dataarray(ds, self.dim, _fn)
 
     def get_config(self) -> dict[str, Any]:
         return {
@@ -1231,13 +1276,16 @@ class LowpassFilter(Operator):
         self.btype = btype
 
     def _apply(self, ds):
-        return _smooth.lowpass_filter(
-            ds,
-            dim=self.dim,
-            cutoff=self.cutoff,
-            order=self.order,
-            btype=self.btype,
-        )
+        def _fn(da: xr.DataArray) -> xr.DataArray:
+            return _smooth.lowpass_filter(
+                da,
+                dim=self.dim,
+                cutoff=self.cutoff,
+                order=self.order,
+                btype=self.btype,
+            )
+
+        return _map_over_dataset_or_dataarray(ds, self.dim, _fn)
 
     def get_config(self) -> dict[str, Any]:
         return {

--- a/src/xrtoolz/metrics/_src/composite.py
+++ b/src/xrtoolz/metrics/_src/composite.py
@@ -12,19 +12,17 @@ from xrtoolz.metrics._src.spectral import psd_score, resolved_scale_2d
 
 
 def rmse_skill_scores(
-    ds_pred: xr.Dataset,
-    ds_ref: xr.Dataset,
+    pred: xr.DataArray,
+    ref: xr.DataArray,
     *,
-    variable: str,
     space_dims: Sequence[str] = ("lat", "lon"),
     time_dim: str = "time",
 ) -> xr.Dataset:
     """Bundle the canonical RMSE-based skill diagnostics.
 
     Args:
-        ds_pred: Prediction dataset.
-        ds_ref: Reference dataset.
-        variable: Variable to score.
+        pred: Prediction DataArray.
+        ref: Reference DataArray (same shape and coords as ``pred``).
         space_dims: Spatial dimensions reduced for the per-time skill.
         time_dim: Temporal dimension reduced for the per-cell RMSE map.
 
@@ -34,7 +32,7 @@ def rmse_skill_scores(
         ``error_stability``.
 
     Examples:
-        >>> rmse_skill_scores(pred, ref, variable="ssh")
+        >>> rmse_skill_scores(pred_da, ref_da)
 
     ``error_stability`` uses xarray's default ``std(..., ddof=0)`` to
     match the upstream OSSE report.
@@ -45,13 +43,12 @@ def rmse_skill_scores(
             f"time_dim={time_dim!r} must not appear in space_dims={space_dims_t!r};"
             " duplicate core dims are rejected by xr.apply_ufunc."
         )
-    rmse_t = nrmse(ds_pred, ds_ref, variable, dims=space_dims_t).rename("rmse_t")
-    rmse_xy = rmse(ds_pred, ds_ref, variable, dims=time_dim).rename("rmse_xy")
+    rmse_t = nrmse(pred, ref, dim=space_dims_t).rename("rmse_t")
+    rmse_xy = rmse(pred, ref, dim=time_dim).rename("rmse_xy")
     leaderboard_rmse = nrmse(
-        ds_pred,
-        ds_ref,
-        variable,
-        dims=(time_dim, *space_dims_t),
+        pred,
+        ref,
+        dim=(time_dim, *space_dims_t),
     ).rename("leaderboard_rmse")
     # Pin ddof=0 explicitly to match the OSSE-report convention; relying
     # on xarray's default could shift quietly if it ever changes.
@@ -67,10 +64,9 @@ def rmse_skill_scores(
 
 
 def psd_score_spacetime(
-    ds_pred: xr.Dataset,
-    ds_ref: xr.Dataset,
+    pred: xr.DataArray,
+    ref: xr.DataArray,
     *,
-    variable: str,
     space_dim: str = "lon",
     time_dim: str = "time",
     avg_dims: Sequence[str] | None = ("lat",),
@@ -80,9 +76,8 @@ def psd_score_spacetime(
     """Compute a 2-D space-time PSD score and resolved-scale summary.
 
     Args:
-        ds_pred: Prediction dataset.
-        ds_ref: Reference dataset.
-        variable: Variable to score.
+        pred: Prediction DataArray.
+        ref: Reference DataArray (same shape and coords as ``pred``).
         space_dim: Spatial dimension used in the PSD.
         time_dim: Temporal dimension used in the PSD.
         avg_dims: Optional dimensions averaged out after the PSD.
@@ -96,7 +91,7 @@ def psd_score_spacetime(
         and ``summary`` contains the min/max resolved wavelengths.
 
     Examples:
-        >>> score, summary = psd_score_spacetime(pred, ref, variable="ssh")
+        >>> score, summary = psd_score_spacetime(pred_da, ref_da)
     """
     if xrft_kwargs.get("isotropic"):
         # Isotropic mode collapses the two spatial axes into a single
@@ -110,9 +105,8 @@ def psd_score_spacetime(
     freq_space_dim = f"freq_{space_dim}"
     freq_time_dim = f"freq_{time_dim}"
     score = psd_score(
-        ds_pred,
-        ds_ref,
-        variable,
+        pred,
+        ref,
         psd_dims=(space_dim, time_dim),
         avg_dims=avg_dims,
         **xrft_kwargs,

--- a/src/xrtoolz/metrics/_src/distributional.py
+++ b/src/xrtoolz/metrics/_src/distributional.py
@@ -43,10 +43,9 @@ def _check_member_dim(da: xr.DataArray, dim: str) -> None:
 
 
 def crps_ensemble(
-    ds_ensemble: xr.Dataset,
-    ds_ref: xr.Dataset,
+    ensemble: xr.DataArray,
+    ref: xr.DataArray,
     *,
-    variable: str,
     ensemble_dim: str = "member",
     dims: Sequence[str] | None = None,
 ) -> xr.DataArray:
@@ -55,22 +54,18 @@ def crps_ensemble(
     Delegates to :func:`xskillscore.crps_ensemble`.
 
     Args:
-        ds_ensemble: Dataset containing the ensemble forecast variable
-            with an ``ensemble_dim`` axis.
-        ds_ref: Dataset containing the deterministic reference.
-        variable: Variable name (must be present in both datasets).
+        ensemble: Ensemble forecast DataArray with an ``ensemble_dim`` axis.
+        ref: Deterministic reference DataArray.
         ensemble_dim: Name of the ensemble member dimension. Default
             ``"member"``.
         dims: Optional dims to average over after the per-pixel CRPS
             (e.g. ``("time", "lat", "lon")``); ``None`` keeps full
             shape.
     """
-    da_ens = ds_ensemble[variable]
-    da_ref = ds_ref[variable]
-    _check_member_dim(da_ens, ensemble_dim)
+    _check_member_dim(ensemble, ensemble_dim)
     crps = cast(
         xr.DataArray,
-        xs.crps_ensemble(da_ref, da_ens, member_dim=ensemble_dim, dim=[]),
+        xs.crps_ensemble(ref, ensemble, member_dim=ensemble_dim, dim=[]),
     )
     if dims:
         crps = crps.mean(dim=list(dims))
@@ -81,10 +76,9 @@ def crps_ensemble(
 
 
 def energy_distance(
-    ds_a: xr.Dataset,
-    ds_b: xr.Dataset,
+    a: xr.DataArray,
+    b: xr.DataArray,
     *,
-    variable: str,
     sample_dim_a: str = "member",
     sample_dim_b: str = "member",
     dims: Sequence[str] | None = None,
@@ -100,16 +94,15 @@ def energy_distance(
     sample dimensions and is **not** vectorised over additional dims.
 
     Args:
-        ds_a: Dataset with sample variable along ``sample_dim_a``.
-        ds_b: Dataset with sample variable along ``sample_dim_b``.
-        variable: Variable name in both datasets.
-        sample_dim_a: Sample dim in ``ds_a``.
-        sample_dim_b: Sample dim in ``ds_b``.
+        a: Sample DataArray with samples along ``sample_dim_a``.
+        b: Sample DataArray with samples along ``sample_dim_b``.
+        sample_dim_a: Sample dim in ``a``.
+        sample_dim_b: Sample dim in ``b``.
         dims: Optional non-sample dims to average over. ``None`` keeps
             the result un-reduced (per-pixel energy distance).
     """
-    da_a = ds_a[variable]
-    da_b = ds_b[variable]
+    da_a = a
+    da_b = b
     _check_member_dim(da_a, sample_dim_a)
     _check_member_dim(da_b, sample_dim_b)
 
@@ -148,10 +141,9 @@ def energy_distance(
 
 
 def wasserstein_1(
-    ds_a: xr.Dataset,
-    ds_b: xr.Dataset,
+    a: xr.DataArray,
+    b: xr.DataArray,
     *,
-    variable: str,
     sample_dim_a: str = "member",
     sample_dim_b: str = "member",
     dims: Sequence[str] | None = None,
@@ -162,15 +154,13 @@ def wasserstein_1(
     dims; supports broadcasting over the remaining dims.
 
     Args:
-        ds_a: Dataset whose ``variable`` carries samples along
-            ``sample_dim_a``.
-        ds_b: Same shape (modulo sample dim) as ``ds_a``.
-        variable: Variable name.
+        a: Sample DataArray with samples along ``sample_dim_a``.
+        b: Sample DataArray with samples along ``sample_dim_b``.
         sample_dim_a, sample_dim_b: Names of the sample dims.
         dims: Optional non-sample dims to average over.
     """
-    da_a = ds_a[variable]
-    da_b = ds_b[variable]
+    da_a = a
+    da_b = b
     _check_member_dim(da_a, sample_dim_a)
     _check_member_dim(da_b, sample_dim_b)
 
@@ -234,9 +224,8 @@ class CRPS(_DistributionalOp):
 
     def _apply(self, ds_ensemble: xr.Dataset, ds_ref: xr.Dataset) -> xr.DataArray:
         return crps_ensemble(
-            ds_ensemble,
-            ds_ref,
-            variable=self.variable,
+            ds_ensemble[self.variable],
+            ds_ref[self.variable],
             ensemble_dim=self.ensemble_dim,
             dims=self.dims,
         )
@@ -272,9 +261,8 @@ class EnergyDistance(_TwoSampleOp):
 
     def _apply(self, ds_a: xr.Dataset, ds_b: xr.Dataset) -> xr.DataArray:
         return energy_distance(
-            ds_a,
-            ds_b,
-            variable=self.variable,
+            ds_a[self.variable],
+            ds_b[self.variable],
             sample_dim_a=self.sample_dim_a,
             sample_dim_b=self.sample_dim_b,
             dims=self.dims,
@@ -286,9 +274,8 @@ class Wasserstein1(_TwoSampleOp):
 
     def _apply(self, ds_a: xr.Dataset, ds_b: xr.Dataset) -> xr.DataArray:
         return wasserstein_1(
-            ds_a,
-            ds_b,
-            variable=self.variable,
+            ds_a[self.variable],
+            ds_b[self.variable],
             sample_dim_a=self.sample_dim_a,
             sample_dim_b=self.sample_dim_b,
             dims=self.dims,

--- a/src/xrtoolz/metrics/_src/distributional.py
+++ b/src/xrtoolz/metrics/_src/distributional.py
@@ -107,12 +107,12 @@ def energy_distance(
     _check_member_dim(da_b, sample_dim_b)
 
     # Move sample dims to the leading axis for clarity.
-    a = da_a.transpose(sample_dim_a, ...).values  # (n, *rest)
-    b = da_b.transpose(sample_dim_b, ...).values  # (m, *rest)
-    rest_shape = a.shape[1:]
+    arr_a = da_a.transpose(sample_dim_a, ...).values  # (n, *rest)
+    arr_b = da_b.transpose(sample_dim_b, ...).values  # (m, *rest)
+    rest_shape = arr_a.shape[1:]
 
-    a_flat = a.reshape(a.shape[0], -1)  # (n, K)
-    b_flat = b.reshape(b.shape[0], -1)  # (m, K)
+    a_flat = arr_a.reshape(arr_a.shape[0], -1)  # (n, K)
+    b_flat = arr_b.reshape(arr_b.shape[0], -1)  # (m, K)
 
     # Per-pixel energy distance via scipy: O(n+m) per pixel rather than
     # O((n+m)^2), and uses the unbiased self-distance estimator (excludes
@@ -164,11 +164,11 @@ def wasserstein_1(
     _check_member_dim(da_a, sample_dim_a)
     _check_member_dim(da_b, sample_dim_b)
 
-    a = da_a.transpose(sample_dim_a, ...).values
-    b = da_b.transpose(sample_dim_b, ...).values
-    rest_shape = a.shape[1:]
-    a_flat = a.reshape(a.shape[0], -1)
-    b_flat = b.reshape(b.shape[0], -1)
+    arr_a = da_a.transpose(sample_dim_a, ...).values
+    arr_b = da_b.transpose(sample_dim_b, ...).values
+    rest_shape = arr_a.shape[1:]
+    a_flat = arr_a.reshape(arr_a.shape[0], -1)
+    b_flat = arr_b.reshape(arr_b.shape[0], -1)
 
     out_flat = np.array(
         [

--- a/src/xrtoolz/metrics/_src/pixel.py
+++ b/src/xrtoolz/metrics/_src/pixel.py
@@ -1,15 +1,21 @@
 """Pixel-level (pointwise) evaluation metrics.
 
-Layer-0 functions take ``ds_pred`` (prediction) and ``ds_ref`` (reference)
-Datasets, a variable name, and a list of reduction dimensions; they
-return a :class:`xr.DataArray` with the remaining dimensions.
+Layer-0 primitives take ``DataArray`` inputs positionally (``pred``,
+``ref``) and reduce over the requested ``dim``. They return a
+``DataArray`` with the remaining dimensions.
 
 Convention: positive ``bias`` means the prediction is larger than the
 reference. Correlation is Pearson's ``r``.
 
-Per design decision D11, the pointwise math lives in the Tier A array
-kernels at :mod:`xrtoolz.metrics._src.array_pixel`; the Tier B wrappers
-below delegate to those kernels via :func:`xr.apply_ufunc`.
+Per the design refresh in ``docs/design/xarray-native-primitives.md``
+(PR β), primitives are DataArray-positional. The Layer-1 operator
+wrappers below carry the ``variable=`` selector so that pipelines
+threading Datasets still see a uniform Dataset-in interface; the
+selection happens in the operator ``_apply``, not in the primitive.
+
+The pointwise math lives in the Tier A array kernels at
+:mod:`xrtoolz.metrics._src.array_pixel`; the Tier B wrappers below
+delegate to those kernels via :func:`xr.apply_ufunc`.
 """
 
 from __future__ import annotations
@@ -25,26 +31,25 @@ from xrtoolz.metrics._src import array_pixel
 from xrtoolz.signature import Signature
 
 
-Dims = str | Sequence[str]
+Dim = str | Sequence[str]
 
 
-def _normalize_dims(dims: Dims) -> list[str]:
-    return [dims] if isinstance(dims, str) else list(dims)
+def _normalize_dim(dim: Dim) -> list[str]:
+    return [dim] if isinstance(dim, str) else list(dim)
 
 
 def _apply_pixel_kernel(
     fn: Any,
-    ds_pred: xr.Dataset,
-    ds_ref: xr.Dataset,
-    variable: str,
-    dims: Dims,
+    pred: xr.DataArray,
+    ref: xr.DataArray,
+    dim: Dim,
 ) -> xr.DataArray:
-    """Run a Tier A pixel kernel on the named variable, reducing ``dims``.
+    """Run a Tier A pixel kernel on two DataArrays, reducing ``dim``.
 
-    Selects ``variable`` from each Dataset, then dispatches to the array
-    kernel via :func:`xr.apply_ufunc` with ``dims`` as the input core
-    dimensions. The kernel sees a flattened trailing block of axes and
-    reduces with ``axis=tuple(range(-len(core), 0))``.
+    Dispatches to the array kernel via :func:`xr.apply_ufunc` with
+    ``dim`` as the input core dimensions. The kernel sees a flattened
+    trailing block of axes and reduces with
+    ``axis=tuple(range(-len(core), 0))``.
 
     For dask-backed inputs, ``allow_rechunk=True`` is set so a core
     dimension that is split across multiple chunks is rechunked into a
@@ -55,14 +60,12 @@ def _apply_pixel_kernel(
     Output dtype is promoted to at least ``float64`` so that integer
     inputs don't truncate floating-point reductions.
     """
-    da_pred = ds_pred[variable]
-    da_ref = ds_ref[variable]
-    core = _normalize_dims(dims)
-    out_dtype = np.result_type(da_pred.dtype, np.float64)
+    core = _normalize_dim(dim)
+    out_dtype = np.result_type(pred.dtype, np.float64)
     out: xr.DataArray = xr.apply_ufunc(
         lambda p, r: fn(p, r, axis=tuple(range(-len(core), 0))),
-        da_pred,
-        da_ref,
+        pred,
+        ref,
         input_core_dims=[core, core],
         dask="parallelized",
         output_dtypes=[out_dtype],
@@ -71,97 +74,72 @@ def _apply_pixel_kernel(
     return out
 
 
-# ---------- Layer-0 (xarray) ----------------------------------------------
+# ---------- Layer-0 (xarray DataArray-positional) -------------------------
 
 
-def mse(
-    ds_pred: xr.Dataset,
-    ds_ref: xr.Dataset,
-    variable: str,
-    dims: Dims,
-) -> xr.DataArray:
-    """Mean squared error reduced over ``dims``."""
-    return _apply_pixel_kernel(array_pixel.mse, ds_pred, ds_ref, variable, dims)
+def mse(pred: xr.DataArray, ref: xr.DataArray, *, dim: Dim) -> xr.DataArray:
+    """Mean squared error reduced over ``dim``."""
+    return _apply_pixel_kernel(array_pixel.mse, pred, ref, dim)
 
 
-def rmse(
-    ds_pred: xr.Dataset,
-    ds_ref: xr.Dataset,
-    variable: str,
-    dims: Dims,
-) -> xr.DataArray:
-    """Root mean squared error reduced over ``dims``."""
-    return _apply_pixel_kernel(array_pixel.rmse, ds_pred, ds_ref, variable, dims)
+def rmse(pred: xr.DataArray, ref: xr.DataArray, *, dim: Dim) -> xr.DataArray:
+    """Root mean squared error reduced over ``dim``."""
+    return _apply_pixel_kernel(array_pixel.rmse, pred, ref, dim)
 
 
-def nrmse(
-    ds_pred: xr.Dataset,
-    ds_ref: xr.Dataset,
-    variable: str,
-    dims: Dims,
-) -> xr.DataArray:
+def nrmse(pred: xr.DataArray, ref: xr.DataArray, *, dim: Dim) -> xr.DataArray:
     """Normalized RMSE: ``1 - RMSE / sqrt(<ref^2>)``.
 
     Returns a score in ``(-inf, 1]`` where 1 means a perfect match and 0
     means the prediction is as wrong as a zero prediction.
     """
-    return _apply_pixel_kernel(array_pixel.nrmse, ds_pred, ds_ref, variable, dims)
+    return _apply_pixel_kernel(array_pixel.nrmse, pred, ref, dim)
 
 
-def mae(
-    ds_pred: xr.Dataset,
-    ds_ref: xr.Dataset,
-    variable: str,
-    dims: Dims,
-) -> xr.DataArray:
-    """Mean absolute error reduced over ``dims``."""
-    return _apply_pixel_kernel(array_pixel.mae, ds_pred, ds_ref, variable, dims)
+def mae(pred: xr.DataArray, ref: xr.DataArray, *, dim: Dim) -> xr.DataArray:
+    """Mean absolute error reduced over ``dim``."""
+    return _apply_pixel_kernel(array_pixel.mae, pred, ref, dim)
 
 
-def bias(
-    ds_pred: xr.Dataset,
-    ds_ref: xr.Dataset,
-    variable: str,
-    dims: Dims,
-) -> xr.DataArray:
-    """Mean bias ``<pred - ref>`` reduced over ``dims``."""
-    return _apply_pixel_kernel(array_pixel.bias, ds_pred, ds_ref, variable, dims)
+def bias(pred: xr.DataArray, ref: xr.DataArray, *, dim: Dim) -> xr.DataArray:
+    """Mean bias ``<pred - ref>`` reduced over ``dim``."""
+    return _apply_pixel_kernel(array_pixel.bias, pred, ref, dim)
 
 
-def correlation(
-    ds_pred: xr.Dataset,
-    ds_ref: xr.Dataset,
-    variable: str,
-    dims: Dims,
-) -> xr.DataArray:
-    """Pearson correlation between prediction and reference over ``dims``."""
-    return _apply_pixel_kernel(array_pixel.correlation, ds_pred, ds_ref, variable, dims)
+def correlation(pred: xr.DataArray, ref: xr.DataArray, *, dim: Dim) -> xr.DataArray:
+    """Pearson correlation between prediction and reference over ``dim``."""
+    return _apply_pixel_kernel(array_pixel.correlation, pred, ref, dim)
 
 
-def r2_score(
-    ds_pred: xr.Dataset,
-    ds_ref: xr.Dataset,
-    variable: str,
-    dims: Dims,
-) -> xr.DataArray:
+def r2_score(pred: xr.DataArray, ref: xr.DataArray, *, dim: Dim) -> xr.DataArray:
     """Coefficient of determination: ``1 - SS_res / SS_tot``."""
-    return _apply_pixel_kernel(array_pixel.r2_score, ds_pred, ds_ref, variable, dims)
+    return _apply_pixel_kernel(array_pixel.r2_score, pred, ref, dim)
 
 
 # ---------- Layer-1 (Operator wrappers) -----------------------------------
 
 
 class _PixelMetricOp(Operator):
-    """Base class for two-input pixel metrics."""
+    """Base class for two-input pixel metrics.
+
+    The constructor carries the Dataset-level selector (``variable``)
+    and the reduce-axis spec (``dims``). ``_apply`` selects the named
+    variable from each input Dataset and forwards the resulting
+    DataArrays to the Layer-0 primitive.
+    """
 
     _fn: Any = None
 
-    def __init__(self, variable: str, dims: str | Sequence[str]):
+    def __init__(self, variable: str, dims: Dim):
         self.variable = variable
         self.dims = dims if isinstance(dims, str) else list(dims)
 
-    def _apply(self, ds_pred, ds_ref):
-        return self.__class__._fn(ds_pred, ds_ref, self.variable, self.dims)
+    def _apply(self, ds_pred: xr.Dataset, ds_ref: xr.Dataset) -> xr.DataArray:
+        return self.__class__._fn(
+            ds_pred[self.variable],
+            ds_ref[self.variable],
+            dim=self.dims,
+        )
 
     def get_config(self) -> dict[str, Any]:
         return {
@@ -244,5 +222,4 @@ __all__ = [
     "mse",
     "nrmse",
     "r2_score",
-    "rmse",
 ]

--- a/src/xrtoolz/metrics/_src/pixel.py
+++ b/src/xrtoolz/metrics/_src/pixel.py
@@ -222,4 +222,5 @@ __all__ = [
     "mse",
     "nrmse",
     "r2_score",
+    "rmse",
 ]

--- a/src/xrtoolz/metrics/_src/probabilistic.py
+++ b/src/xrtoolz/metrics/_src/probabilistic.py
@@ -40,10 +40,9 @@ def _check_ensemble_dim(da: xr.DataArray, dim: str) -> None:
 
 
 def spread_skill_ratio(
-    ds_ensemble: xr.Dataset,
-    ds_ref: xr.Dataset,
+    ensemble: xr.DataArray,
+    ref: xr.DataArray,
     *,
-    variable: str,
     ensemble_dim: str = "member",
     dims: Sequence[str] | None = None,
 ) -> xr.DataArray:
@@ -54,34 +53,30 @@ def spread_skill_ratio(
     < 1 indicate under-dispersion, > 1 over-dispersion.
 
     Args:
-        ds_ensemble: Dataset with the ensemble variable.
-        ds_ref: Deterministic reference.
-        variable: Variable name.
+        ensemble: Ensemble DataArray with an ``ensemble_dim`` axis.
+        ref: Deterministic reference DataArray.
         ensemble_dim: Member dim.
         dims: Dims to reduce over (e.g. ``("time", "lat", "lon")``).
             ``None`` reduces over every non-ensemble dim.
     """
-    da_ens = ds_ensemble[variable]
-    da_ref = ds_ref[variable]
-    _check_ensemble_dim(da_ens, ensemble_dim)
+    _check_ensemble_dim(ensemble, ensemble_dim)
 
     if dims is None:
-        reduce = [d for d in da_ens.dims if d != ensemble_dim]
+        reduce = [d for d in ensemble.dims if d != ensemble_dim]
     else:
         reduce = list(dims)
 
-    ens_mean = da_ens.mean(dim=ensemble_dim)
-    ens_std = da_ens.std(dim=ensemble_dim, ddof=1)
+    ens_mean = ensemble.mean(dim=ensemble_dim)
+    ens_std = ensemble.std(dim=ensemble_dim, ddof=1)
     spread = (ens_std**2).mean(dim=reduce) ** 0.5
-    skill = ((ens_mean - da_ref) ** 2).mean(dim=reduce) ** 0.5
+    skill = ((ens_mean - ref) ** 2).mean(dim=reduce) ** 0.5
     return spread / skill
 
 
 def rank_histogram(
-    ds_ensemble: xr.Dataset,
-    ds_ref: xr.Dataset,
+    ensemble: xr.DataArray,
+    ref: xr.DataArray,
     *,
-    variable: str,
     ensemble_dim: str = "member",
 ) -> xr.Dataset:
     """Talagrand rank histogram.
@@ -92,22 +87,19 @@ def rank_histogram(
     ensemble produces a flat histogram.
 
     Args:
-        ds_ensemble: Ensemble forecast.
-        ds_ref: Reference.
-        variable: Variable name.
+        ensemble: Ensemble forecast DataArray with an ``ensemble_dim`` axis.
+        ref: Reference DataArray.
         ensemble_dim: Member dim.
 
     Returns:
         Dataset with a ``"rank_count"`` variable indexed by ``"rank"``
         (size ``n_members + 1``).
     """
-    da_ens = ds_ensemble[variable]
-    da_ref = ds_ref[variable]
-    _check_ensemble_dim(da_ens, ensemble_dim)
+    _check_ensemble_dim(ensemble, ensemble_dim)
 
-    n = da_ens.sizes[ensemble_dim]
-    ens_arr = da_ens.transpose(ensemble_dim, ...).values
-    ref_arr = da_ref.broadcast_like(da_ens.isel({ensemble_dim: 0})).values
+    n = ensemble.sizes[ensemble_dim]
+    ens_arr = ensemble.transpose(ensemble_dim, ...).values
+    ref_arr = ref.broadcast_like(ensemble.isel({ensemble_dim: 0})).values
     ranks = np.sum(ens_arr < ref_arr[None, ...], axis=0)
     counts = np.bincount(ranks.ravel(), minlength=n + 1)
     return xr.Dataset(
@@ -117,10 +109,9 @@ def rank_histogram(
 
 
 def ensemble_coverage(
-    ds_ensemble: xr.Dataset,
-    ds_ref: xr.Dataset,
+    ensemble: xr.DataArray,
+    ref: xr.DataArray,
     *,
-    variable: str,
     q: tuple[float, float] = (0.05, 0.95),
     ensemble_dim: str = "member",
 ) -> xr.DataArray:
@@ -129,9 +120,8 @@ def ensemble_coverage(
     For ``q=(0.05, 0.95)`` a calibrated ensemble produces ≈ 0.9.
 
     Args:
-        ds_ensemble: Ensemble forecast.
-        ds_ref: Reference.
-        variable: Variable name.
+        ensemble: Ensemble forecast DataArray with an ``ensemble_dim`` axis.
+        ref: Reference DataArray.
         q: ``(low, high)`` quantiles in ``[0, 1]``.
         ensemble_dim: Member dim.
 
@@ -141,20 +131,17 @@ def ensemble_coverage(
     if not 0.0 <= q[0] < q[1] <= 1.0:
         raise ValueError(f"q must be (low, high) with 0 <= low < high <= 1, got {q}.")
 
-    da_ens = ds_ensemble[variable]
-    da_ref = ds_ref[variable]
-    _check_ensemble_dim(da_ens, ensemble_dim)
-    lo = da_ens.quantile(q[0], dim=ensemble_dim).drop_vars("quantile")
-    hi = da_ens.quantile(q[1], dim=ensemble_dim).drop_vars("quantile")
-    inside = (da_ref >= lo) & (da_ref <= hi)
+    _check_ensemble_dim(ensemble, ensemble_dim)
+    lo = ensemble.quantile(q[0], dim=ensemble_dim).drop_vars("quantile")
+    hi = ensemble.quantile(q[1], dim=ensemble_dim).drop_vars("quantile")
+    inside = (ref >= lo) & (ref <= hi)
     return inside.mean()
 
 
 def reliability_curve(
-    ds_probability: xr.Dataset,
-    ds_event: xr.Dataset,
+    probability: xr.DataArray,
+    event: xr.DataArray,
     *,
-    variable: str,
     probability_bins: np.ndarray | None = None,
 ) -> xr.Dataset:
     """Reliability diagram coordinates.
@@ -164,11 +151,8 @@ def reliability_curve(
     calibrated forecast lies on the identity line.
 
     Args:
-        ds_probability: Dataset whose ``variable`` holds forecast
-            probabilities in ``[0, 1]``.
-        ds_event: Dataset whose ``variable`` is a 0/1 event indicator
-            on the same grid.
-        variable: Variable name (same in both).
+        probability: DataArray of forecast probabilities in ``[0, 1]``.
+        event: DataArray of 0/1 event indicators on the same grid.
         probability_bins: Bin edges in ``[0, 1]``. Defaults to
             ``np.linspace(0, 1, 11)`` (10 bins).
 
@@ -181,8 +165,8 @@ def reliability_curve(
         if probability_bins is None
         else np.asarray(probability_bins)
     )
-    p = ds_probability[variable].values.ravel()
-    o = ds_event[variable].values.ravel()
+    p = probability.values.ravel()
+    o = event.values.ravel()
     valid = np.isfinite(p) & np.isfinite(o)
     p = p[valid]
     o = o[valid]
@@ -240,9 +224,8 @@ class SpreadSkillRatio(_ProbabilisticOp):
 
     def _apply(self, ds_ensemble: xr.Dataset, ds_ref: xr.Dataset) -> xr.DataArray:
         return spread_skill_ratio(
-            ds_ensemble,
-            ds_ref,
-            variable=self.variable,
+            ds_ensemble[self.variable],
+            ds_ref[self.variable],
             ensemble_dim=self.ensemble_dim,
             dims=self.dims,
         )
@@ -258,9 +241,8 @@ class RankHistogram(_ProbabilisticOp):
 
     def _apply(self, ds_ensemble: xr.Dataset, ds_ref: xr.Dataset) -> xr.Dataset:
         return rank_histogram(
-            ds_ensemble,
-            ds_ref,
-            variable=self.variable,
+            ds_ensemble[self.variable],
+            ds_ref[self.variable],
             ensemble_dim=self.ensemble_dim,
         )
 
@@ -280,9 +262,8 @@ class EnsembleCoverage(_ProbabilisticOp):
 
     def _apply(self, ds_ensemble: xr.Dataset, ds_ref: xr.Dataset) -> xr.DataArray:
         return ensemble_coverage(
-            ds_ensemble,
-            ds_ref,
-            variable=self.variable,
+            ds_ensemble[self.variable],
+            ds_ref[self.variable],
             q=self.q,
             ensemble_dim=self.ensemble_dim,
         )
@@ -306,9 +287,8 @@ class ReliabilityCurve(Operator):
 
     def _apply(self, ds_probability: xr.Dataset, ds_event: xr.Dataset) -> xr.Dataset:
         return reliability_curve(
-            ds_probability,
-            ds_event,
-            variable=self.variable,
+            ds_probability[self.variable],
+            ds_event[self.variable],
             probability_bins=self.probability_bins,
         )
 

--- a/src/xrtoolz/metrics/_src/segmented_psd.py
+++ b/src/xrtoolz/metrics/_src/segmented_psd.py
@@ -20,23 +20,21 @@ _DEFAULT_LAT_CENTERS = np.arange(-80, 91, 1)
 _DEFAULT_LON_CENTERS = np.arange(0, 360, 1)
 
 
-def _coord_values(ds: xr.Dataset, name: str, dim: str) -> NDArray[np.floating]:
-    if name not in ds:
-        raise ValueError(f"{name!r} is not present in the track Dataset.")
-    values = np.asarray(ds[name].transpose(dim).values, dtype=float)
+def _coord_values_from_da(
+    da: xr.DataArray, *, name: str, dim: str
+) -> NDArray[np.floating]:
+    values = np.asarray(da.transpose(dim).values, dtype=float)
     if values.ndim != 1:
         raise ValueError(f"{name!r} must be 1-D along {dim!r}.")
     return values
 
 
-def _gap_indices(
-    ds: xr.Dataset, *, time: str, dim: str, max_gap: Any
+def _gap_indices_from_da(
+    time_da: xr.DataArray, *, dim: str, max_gap: Any
 ) -> NDArray[np.integer]:
     if max_gap is None:
         return np.empty(0, dtype=int)
-    if time not in ds:
-        raise ValueError(f"{time!r} is not present in the track Dataset.")
-    values = np.asarray(ds[time].transpose(dim).values)
+    values = np.asarray(time_da.transpose(dim).values)
     return np.flatnonzero(np.diff(values) > max_gap)
 
 
@@ -114,47 +112,72 @@ def _empty_spectra(
 
 
 def along_track_psd_score(
-    ds_track: xr.Dataset,
+    pred: xr.DataArray,
+    ref: xr.DataArray,
     *,
-    var_ref: str,
-    var_pred: str,
+    lon: xr.DataArray,
+    lat: xr.DataArray,
+    time: xr.DataArray | None = None,
     dim: str = "num_lines",
     npt: int,
     overlap: float = 0.5,
     max_gap: np.timedelta64 | None = _DEFAULT_MAX_GAP,
     spacing_km: float | None = None,
-    lon: str = "lon",
-    lat: str = "lat",
-    time: str = "time",
     window: str | tuple[str, float] | ArrayLike = "hann",
     scaling: str = "density",
 ) -> xr.Dataset:
-    """Compute per-window along-track PSD score for a colocated track Dataset."""
-    if dim not in ds_track.dims:
-        raise ValueError(f"{dim!r} is not a dimension in the track Dataset.")
-    if var_ref not in ds_track or var_pred not in ds_track:
-        raise ValueError(f"{var_ref!r} and {var_pred!r} must both be present.")
+    """Compute per-window along-track PSD score from prediction/reference tracks.
 
-    ref = np.asarray(ds_track[var_ref].transpose(dim).values, dtype=float)
-    pred = np.asarray(ds_track[var_pred].transpose(dim).values, dtype=float)
-    if ref.ndim != 1 or pred.ndim != 1:
-        raise ValueError("var_ref and var_pred must be 1-D along the track dimension.")
-    if ref.shape != pred.shape:
-        raise ValueError("var_ref and var_pred must have the same shape.")
+    Args:
+        pred: Prediction DataArray (1-D along ``dim``).
+        ref: Reference DataArray (1-D along ``dim``).
+        lon: Longitude DataArray aligned with ``pred``/``ref`` on ``dim``.
+        lat: Latitude DataArray aligned with ``pred``/``ref`` on ``dim``.
+        time: Time DataArray; required when ``max_gap`` is not ``None``.
+        dim: Track dimension name (default ``"num_lines"``).
+        npt: Window length in samples.
+        overlap: Welch overlap fraction.
+        max_gap: Maximum allowed time gap before splitting a segment; pass
+            ``None`` to disable gap detection.
+        spacing_km: Override along-track spacing; otherwise inferred from
+            ``lon``/``lat`` via haversine.
+        window: Welch window spec.
+        scaling: Welch ``scaling`` (``"density"`` or ``"spectrum"``).
 
-    lon_values = _coord_values(ds_track, lon, dim)
-    lat_values = _coord_values(ds_track, lat, dim)
+    Returns:
+        Per-segment Dataset with ``psd_ref``, ``psd_pred``, ``psd_err``,
+        ``psd_score`` and ``coherence`` variables.
+    """
+    if dim not in pred.dims or dim not in ref.dims:
+        raise ValueError(f"{dim!r} is not a dimension of pred/ref.")
+
+    ref_values = np.asarray(ref.transpose(dim).values, dtype=float)
+    pred_values = np.asarray(pred.transpose(dim).values, dtype=float)
+    if ref_values.ndim != 1 or pred_values.ndim != 1:
+        raise ValueError("pred and ref must be 1-D along the track dimension.")
+    if ref_values.shape != pred_values.shape:
+        raise ValueError("pred and ref must have the same shape.")
+
+    lon_values = _coord_values_from_da(lon, name="lon", dim=dim)
+    lat_values = _coord_values_from_da(lat, name="lat", dim=dim)
     spacing = (
         _median_dx_km(lon_values, lat_values)
         if spacing_km is None
         else float(spacing_km)
     )
     fs = 1.0 / spacing
-    gaps = _gap_indices(ds_track, time=time, dim=dim, max_gap=max_gap)
-    bounds = _segment_bounds(ref.size, npt=npt, overlap=overlap, gap_indices=gaps)
+    if max_gap is not None:
+        if time is None:
+            raise ValueError("time DataArray is required when max_gap is not None.")
+        gaps = _gap_indices_from_da(time, dim=dim, max_gap=max_gap)
+    else:
+        gaps = np.empty(0, dtype=int)
+    bounds = _segment_bounds(
+        ref_values.size, npt=npt, overlap=overlap, gap_indices=gaps
+    )
 
-    ref_segments = _segment_stack(ref, bounds)
-    pred_segments = _segment_stack(pred, bounds)
+    ref_segments = _segment_stack(ref_values, bounds)
+    pred_segments = _segment_stack(pred_values, bounds)
     lon_segments = _segment_stack(lon_values, bounds)
     lat_segments = _segment_stack(lat_values, bounds)
     if ref_segments.size == 0:
@@ -362,18 +385,25 @@ class SegmentedPSDScore(Operator):
         self.scaling = scaling
 
     def _apply(self, ds_track: xr.Dataset) -> xr.Dataset:
+        if self.dim not in ds_track.dims:
+            raise ValueError(f"{self.dim!r} is not a dimension in the track Dataset.")
+        for name in (self.var_ref, self.var_pred, self.lon, self.lat):
+            if name not in ds_track:
+                raise ValueError(f"{name!r} is not present in the track Dataset.")
+        time_da = ds_track[self.time] if self.time in ds_track else None
+        if self.max_gap is not None and time_da is None:
+            raise ValueError(f"{self.time!r} is required when max_gap is not None.")
         return along_track_psd_score(
-            ds_track,
-            var_ref=self.var_ref,
-            var_pred=self.var_pred,
+            ds_track[self.var_pred],
+            ds_track[self.var_ref],
+            lon=ds_track[self.lon],
+            lat=ds_track[self.lat],
+            time=time_da,
             dim=self.dim,
             npt=self.npt,
             overlap=self.overlap,
             max_gap=self.max_gap,
             spacing_km=self.spacing_km,
-            lon=self.lon,
-            lat=self.lat,
-            time=self.time,
             window=self.window,
             scaling=self.scaling,
         )

--- a/src/xrtoolz/metrics/_src/segmented_psd.py
+++ b/src/xrtoolz/metrics/_src/segmented_psd.py
@@ -390,7 +390,7 @@ class SegmentedPSDScore(Operator):
         for name in (self.var_ref, self.var_pred, self.lon, self.lat):
             if name not in ds_track:
                 raise ValueError(f"{name!r} is not present in the track Dataset.")
-        time_da = ds_track[self.time] if self.time in ds_track else None
+        time_da = ds_track.get(self.time, None)
         if self.max_gap is not None and time_da is None:
             raise ValueError(f"{self.time!r} is required when max_gap is not None.")
         return along_track_psd_score(

--- a/src/xrtoolz/metrics/_src/spectral.py
+++ b/src/xrtoolz/metrics/_src/spectral.py
@@ -124,9 +124,7 @@ def psd_score(
         isotropic=isotropic,
         **kwargs,
     )
-    ref_psd = power_spectrum(
-        ref, dim=list(psd_dims), isotropic=isotropic, **kwargs
-    )
+    ref_psd = power_spectrum(ref, dim=list(psd_dims), isotropic=isotropic, **kwargs)
     ref_name = ref.name if ref.name is not None else "ref"
     ref_ds = ref_psd.rename(ref_name).to_dataset()
     if avg_dims is not None:

--- a/src/xrtoolz/metrics/_src/spectral.py
+++ b/src/xrtoolz/metrics/_src/spectral.py
@@ -59,9 +59,9 @@ _LON_UNITS = {
 
 
 def psd_error(
-    ds_pred: xr.Dataset,
-    ds_ref: xr.Dataset,
-    variable: str,
+    pred: xr.DataArray,
+    ref: xr.DataArray,
+    *,
     psd_dims: Sequence[str],
     avg_dims: Sequence[str] | None = None,
     isotropic: bool = False,
@@ -70,9 +70,8 @@ def psd_error(
     """PSD of the prediction error ``pred - ref``.
 
     Args:
-        ds_pred: Prediction dataset.
-        ds_ref: Reference dataset.
-        variable: Variable to score.
+        pred: Prediction DataArray.
+        ref: Reference DataArray.
         psd_dims: Dimensions over which to take the PSD.
         avg_dims: Optional dims to conditionally average out after the
             PSD (e.g. average over ``lat`` after computing the lon/time
@@ -84,7 +83,7 @@ def psd_error(
         Dataset with a single ``"error"`` variable containing the
         PSD of the error.
     """
-    diff = (ds_pred[variable] - ds_ref[variable]).rename("error")
+    diff = (pred - ref).rename("error")
     err = power_spectrum(diff, dim=list(psd_dims), isotropic=isotropic, **kwargs)
     err_ds = err.rename("error").to_dataset()
     if avg_dims is not None:
@@ -93,9 +92,9 @@ def psd_error(
 
 
 def psd_score(
-    ds_pred: xr.Dataset,
-    ds_ref: xr.Dataset,
-    variable: str,
+    pred: xr.DataArray,
+    ref: xr.DataArray,
+    *,
     psd_dims: Sequence[str],
     avg_dims: Sequence[str] | None = None,
     isotropic: bool = False,
@@ -107,9 +106,8 @@ def psd_score(
     means the error has as much power as the reference signal.
 
     Args:
-        ds_pred: Prediction dataset.
-        ds_ref: Reference dataset.
-        variable: Variable to score.
+        pred: Prediction DataArray.
+        ref: Reference DataArray.
         psd_dims: Dimensions over which to take the PSD.
         avg_dims: Optional conditional-average dims applied after PSD.
         isotropic: If ``True``, use the isotropic power spectrum.
@@ -119,15 +117,21 @@ def psd_score(
         Dataset with a single ``"score"`` variable.
     """
     err = psd_error(
-        ds_pred, ds_ref, variable, psd_dims, avg_dims, isotropic=isotropic, **kwargs
+        pred,
+        ref,
+        psd_dims=psd_dims,
+        avg_dims=avg_dims,
+        isotropic=isotropic,
+        **kwargs,
     )
     ref_psd = power_spectrum(
-        ds_ref[variable], dim=list(psd_dims), isotropic=isotropic, **kwargs
+        ref, dim=list(psd_dims), isotropic=isotropic, **kwargs
     )
-    ref_ds = ref_psd.rename(variable).to_dataset()
+    ref_name = ref.name if ref.name is not None else "ref"
+    ref_ds = ref_psd.rename(ref_name).to_dataset()
     if avg_dims is not None:
         ref_ds = drop_negative_frequencies(ref_ds, dims=avg_dims, drop=True)
-    score = 1.0 - err["error"] / ref_ds[variable]
+    score = 1.0 - err["error"] / ref_ds[ref_name]
     return score.to_dataset(name="score")
 
 
@@ -227,9 +231,8 @@ def resolved_scale_2d(
 
 
 def wavelet_psd_score(
-    ds_pred: xr.Dataset,
-    ds_ref: xr.Dataset,
-    variable: str,
+    pred: xr.DataArray,
+    ref: xr.DataArray,
     scales: xr.DataArray,
     *,
     dim: tuple[str, str] = ("y", "x"),
@@ -241,9 +244,8 @@ def wavelet_psd_score(
     """Localized wavelet PSD score ``1 - WPSD(err) / WPSD(ref)``.
 
     Args:
-        ds_pred: Prediction dataset containing ``variable``.
-        ds_ref: Reference dataset containing ``variable`` on the same grid.
-        variable: Data variable to score.
+        pred: Prediction DataArray on a locally Cartesian grid.
+        ref: Reference DataArray on the same grid.
         scales: Positive Morlet scales. The first dimension is used as the
             scale axis.
         dim: Spatial dimensions as ``(y, x)`` on a locally Cartesian grid.
@@ -255,11 +257,7 @@ def wavelet_psd_score(
     Returns:
         Dataset containing ``score`` with untrusted COI samples masked to NaN.
     """
-    if variable not in ds_pred.data_vars:
-        raise KeyError(f"prediction missing variable {variable!r}")
-    if variable not in ds_ref.data_vars:
-        raise KeyError(f"reference missing variable {variable!r}")
-    err = (ds_pred[variable] - ds_ref[variable]).rename("error")
+    err = (pred - ref).rename("error")
     err_psd = wvlt_power_spectrum(
         err,
         scales,
@@ -270,7 +268,7 @@ def wavelet_psd_score(
         isotropic=isotropic,
     )
     ref_psd = wvlt_power_spectrum(
-        ds_ref[variable],
+        ref,
         scales,
         dim=dim,
         x0=x0,
@@ -318,12 +316,9 @@ def wavelet_resolved_scale_map(
         Locations with fewer than two trusted scale samples, or where
         the threshold isn't bracketed by the score column, are NaN.
     """
-    ds_pred = pred.rename("field").to_dataset()
-    ds_ref = truth.rename("field").to_dataset()
     score = wavelet_psd_score(
-        ds_pred,
-        ds_ref,
-        "field",
+        pred,
+        truth,
         scales,
         dim=dim,
         x0=x0,
@@ -519,12 +514,11 @@ class PSDScore(Operator):
         self.isotropic = isotropic
         self.kwargs = dict(kwargs)
 
-    def _apply(self, ds_pred, ds_ref):
+    def _apply(self, ds_pred: xr.Dataset, ds_ref: xr.Dataset) -> xr.Dataset:
         return psd_score(
-            ds_pred,
-            ds_ref,
-            self.variable,
-            self.psd_dims,
+            ds_pred[self.variable],
+            ds_ref[self.variable],
+            psd_dims=self.psd_dims,
             avg_dims=self.avg_dims,
             isotropic=self.isotropic,
             **self.kwargs,
@@ -564,9 +558,8 @@ class WaveletPSDScore(Operator):
 
     def _apply(self, ds_pred: xr.Dataset, ds_ref: xr.Dataset) -> xr.Dataset:
         return wavelet_psd_score(
-            ds_pred,
-            ds_ref,
-            self.variable,
+            ds_pred[self.variable],
+            ds_ref[self.variable],
             self.scales,
             dim=self.dim,
             x0=self.x0,

--- a/src/xrtoolz/metrics/_src/structural.py
+++ b/src/xrtoolz/metrics/_src/structural.py
@@ -46,19 +46,17 @@ def _normalize_dims(dims: str | Sequence[str]) -> list[str]:
 
 
 def ssim(
-    ds_pred: xr.Dataset,
-    ds_ref: xr.Dataset,
+    pred: xr.DataArray,
+    ref: xr.DataArray,
     *,
-    variable: str,
     dims: str | Sequence[str],
     window: int | None = None,
 ) -> xr.DataArray:
     """Structural similarity index over ``dims`` per leading-dim slice.
 
     Args:
-        ds_pred: Prediction dataset.
-        ds_ref: Reference dataset.
-        variable: Variable name.
+        pred: Prediction DataArray.
+        ref: Reference DataArray.
         dims: One or two image dims (e.g. ``("lat", "lon")``).
         window: Optional :func:`skimage.metrics.structural_similarity`
             ``win_size`` override.
@@ -68,12 +66,10 @@ def ssim(
         over ``dims``.
     """
     core = _normalize_dims(dims)
-    da_p = ds_pred[variable]
-    da_r = ds_ref[variable]
-    rest = [d for d in da_p.dims if d not in core]
+    rest = [d for d in pred.dims if d not in core]
 
-    p = da_p.transpose(*rest, *core).values
-    r = da_r.transpose(*rest, *core).values
+    p = pred.transpose(*rest, *core).values
+    r = ref.transpose(*rest, *core).values
     rest_shape = p.shape[: len(rest)]
     img_shape = p.shape[len(rest) :]
     p_flat = p.reshape(-1, *img_shape)
@@ -100,7 +96,7 @@ def ssim(
     out = out.reshape(rest_shape) if rest_shape else float(out.item())
     coords = {
         name: coord
-        for name, coord in da_p.coords.items()
+        for name, coord in pred.coords.items()
         if set(coord.dims).issubset(set(rest))
     }
     return xr.DataArray(np.asarray(out), dims=tuple(rest), coords=coords)
@@ -110,10 +106,9 @@ def ssim(
 
 
 def gradient_difference(
-    ds_pred: xr.Dataset,
-    ds_ref: xr.Dataset,
+    pred: xr.DataArray,
+    ref: xr.DataArray,
     *,
-    variable: str,
     dims: str | Sequence[str],
 ) -> xr.DataArray:
     """RMS of the finite-difference gradient discrepancy.
@@ -123,13 +118,11 @@ def gradient_difference(
     only at the boundary of the field of view.
     """
     core = _normalize_dims(dims)
-    da_p = ds_pred[variable]
-    da_r = ds_ref[variable]
 
-    sq = xr.zeros_like(da_p, dtype=np.float64)
+    sq = xr.zeros_like(pred, dtype=np.float64)
     for d in core:
-        gp = da_p.differentiate(d)
-        gr = da_r.differentiate(d)
+        gp = pred.differentiate(d)
+        gr = ref.differentiate(d)
         sq = sq + (gp - gr) ** 2
     return sq.mean(dim=core) ** 0.5
 
@@ -138,10 +131,9 @@ def gradient_difference(
 
 
 def phase_shift_error(
-    ds_pred: xr.Dataset,
-    ds_ref: xr.Dataset,
+    pred: xr.DataArray,
+    ref: xr.DataArray,
     *,
-    variable: str,
     dims: str | Sequence[str],
     periodic: bool = False,
 ) -> xr.Dataset:
@@ -151,9 +143,8 @@ def phase_shift_error(
     image dim plus the residual RMSE after applying that shift.
 
     Args:
-        ds_pred: Prediction dataset.
-        ds_ref: Reference dataset.
-        variable: Variable name.
+        pred: Prediction DataArray.
+        ref: Reference DataArray.
         dims: Image dims (1-D or 2-D supported).
         periodic: When True, treat ``dims`` as periodic (longitude
             wrap). When False the search is still circular but the
@@ -167,11 +158,9 @@ def phase_shift_error(
     core = _normalize_dims(dims)
     if len(core) not in (1, 2):
         raise ValueError("phase_shift_error supports 1-D or 2-D image dims only.")
-    da_p = ds_pred[variable]
-    da_r = ds_ref[variable]
-    rest = [d for d in da_p.dims if d not in core]
-    p = da_p.transpose(*rest, *core).values
-    r = da_r.transpose(*rest, *core).values
+    rest = [d for d in pred.dims if d not in core]
+    p = pred.transpose(*rest, *core).values
+    r = ref.transpose(*rest, *core).values
     rest_shape = p.shape[: len(rest)]
     img_shape = p.shape[len(rest) :]
     p_flat = p.reshape(-1, *img_shape)
@@ -209,7 +198,7 @@ def phase_shift_error(
     rest_dims = tuple(rest)
     coords = {
         name: coord
-        for name, coord in da_p.coords.items()
+        for name, coord in pred.coords.items()
         if set(coord.dims).issubset(set(rest_dims))
     }
     out = xr.Dataset(coords=coords)
@@ -334,9 +323,8 @@ class SSIM(Operator):
 
     def _apply(self, ds_pred: xr.Dataset, ds_ref: xr.Dataset) -> xr.DataArray:
         return ssim(
-            ds_pred,
-            ds_ref,
-            variable=self.variable,
+            ds_pred[self.variable],
+            ds_ref[self.variable],
             dims=self.dims,
             window=self.window,
         )
@@ -358,7 +346,7 @@ class GradientDifference(Operator):
 
     def _apply(self, ds_pred: xr.Dataset, ds_ref: xr.Dataset) -> xr.DataArray:
         return gradient_difference(
-            ds_pred, ds_ref, variable=self.variable, dims=self.dims
+            ds_pred[self.variable], ds_ref[self.variable], dims=self.dims
         )
 
     def get_config(self) -> dict[str, Any]:
@@ -381,9 +369,8 @@ class PhaseShiftError(Operator):
 
     def _apply(self, ds_pred: xr.Dataset, ds_ref: xr.Dataset) -> xr.Dataset:
         return phase_shift_error(
-            ds_pred,
-            ds_ref,
-            variable=self.variable,
+            ds_pred[self.variable],
+            ds_ref[self.variable],
             dims=self.dims,
             periodic=self.periodic,
         )

--- a/tests/test_geo.py
+++ b/tests/test_geo.py
@@ -344,34 +344,36 @@ def _pair(values_pred, values_ref):
 
 def test_mse_and_rmse_known_values():
     p, r = _pair([1.0, 2.0, 3.0], [0.0, 0.0, 0.0])
-    assert float(mse(p, r, "x", "i")) == pytest.approx(14.0 / 3.0)
-    assert float(rmse(p, r, "x", "i")) == pytest.approx((14.0 / 3.0) ** 0.5)
+    assert float(mse(p["x"], r["x"], dim="i")) == pytest.approx(14.0 / 3.0)
+    assert float(rmse(p["x"], r["x"], dim="i")) == pytest.approx(
+        (14.0 / 3.0) ** 0.5
+    )
 
 
 def test_mae_known_value():
     p, r = _pair([1.0, -2.0, 3.0], [0.0, 0.0, 0.0])
-    assert float(mae(p, r, "x", "i")) == pytest.approx(2.0)
+    assert float(mae(p["x"], r["x"], dim="i")) == pytest.approx(2.0)
 
 
 def test_bias_signed():
     p, r = _pair([1.0, 2.0, 3.0], [0.0, 0.0, 0.0])
-    assert float(bias(p, r, "x", "i")) == pytest.approx(2.0)
-    assert float(bias(r, p, "x", "i")) == pytest.approx(-2.0)
+    assert float(bias(p["x"], r["x"], dim="i")) == pytest.approx(2.0)
+    assert float(bias(r["x"], p["x"], dim="i")) == pytest.approx(-2.0)
 
 
 def test_correlation_perfect_for_identical_series():
     p, r = _pair([1.0, 2.0, 3.0, 4.0], [1.0, 2.0, 3.0, 4.0])
-    assert float(correlation(p, r, "x", "i")) == pytest.approx(1.0)
+    assert float(correlation(p["x"], r["x"], dim="i")) == pytest.approx(1.0)
 
 
 def test_correlation_negative_one_for_inverted_series():
     p, r = _pair([1.0, 2.0, 3.0, 4.0], [4.0, 3.0, 2.0, 1.0])
-    assert float(correlation(p, r, "x", "i")) == pytest.approx(-1.0)
+    assert float(correlation(p["x"], r["x"], dim="i")) == pytest.approx(-1.0)
 
 
 def test_nrmse_is_one_for_perfect_prediction():
     p, r = _pair([1.0, 2.0, 3.0, 4.0], [1.0, 2.0, 3.0, 4.0])
-    assert float(nrmse(p, r, "x", "i")) == pytest.approx(1.0)
+    assert float(nrmse(p["x"], r["x"], dim="i")) == pytest.approx(1.0)
 
 
 def test_metrics_preserve_non_reduced_dims():
@@ -383,6 +385,6 @@ def test_metrics_preserve_non_reduced_dims():
         {"x": (("t", "i"), np.zeros((3, 4)))},
         coords={"t": [10, 20, 30], "i": [0, 1, 2, 3]},
     )
-    out = rmse(pred, ref, "x", dims="i")
+    out = rmse(pred["x"], ref["x"], dim="i")
     assert out.dims == ("t",)
     np.testing.assert_allclose(out.values, np.array([1.0, 1.0, 1.0]))

--- a/tests/test_geo.py
+++ b/tests/test_geo.py
@@ -345,9 +345,7 @@ def _pair(values_pred, values_ref):
 def test_mse_and_rmse_known_values():
     p, r = _pair([1.0, 2.0, 3.0], [0.0, 0.0, 0.0])
     assert float(mse(p["x"], r["x"], dim="i")) == pytest.approx(14.0 / 3.0)
-    assert float(rmse(p["x"], r["x"], dim="i")) == pytest.approx(
-        (14.0 / 3.0) ** 0.5
-    )
+    assert float(rmse(p["x"], r["x"], dim="i")) == pytest.approx((14.0 / 3.0) ** 0.5)
 
 
 def test_mae_known_value():

--- a/tests/test_geo_along_track.py
+++ b/tests/test_geo_along_track.py
@@ -39,9 +39,9 @@ def test_bandpass_wavelength_translates_cutoffs(monkeypatch):
     ds = _track_dataset()
     calls: dict[str, object] = {}
 
-    def fake_fir_filter(ds, **kwargs):
+    def fake_fir_filter(da, **kwargs):
         calls.update(kwargs)
-        return ds
+        return da
 
     monkeypatch.setattr(along_track, "fir_filter", fake_fir_filter)
 
@@ -53,7 +53,7 @@ def test_bandpass_wavelength_translates_cutoffs(monkeypatch):
         spacing_km=5.0,
     )
 
-    assert out is ds
+    assert isinstance(out, type(ds))
     assert calls["btype"] == "bandpass"
     assert calls["cutoff"] == pytest.approx((0.1, 0.5))
 

--- a/tests/test_geo_along_track.py
+++ b/tests/test_geo_along_track.py
@@ -105,6 +105,21 @@ def test_bandpass_wavelength_raises_on_multidim_lon_lat_without_spacing():
         bandpass_wavelength(ds, dim="num_lines", lambda_min_km=20.0)
 
 
+def test_bandpass_wavelength_raises_on_misspelled_dim_with_explicit_spacing():
+    """Regression: a misspelled ``dim`` used to silently pass every variable
+    through after the PR β primitive flip (every var lacked the bad dim so
+    the loop continued); now it raises like the original Dataset-flavoured
+    ``fir_filter`` did."""
+    ds = _track_dataset()
+    with pytest.raises(ValueError, match="not in Dataset dims"):
+        bandpass_wavelength(
+            ds,
+            dim="num_linez",  # typo
+            lambda_min_km=20.0,
+            spacing_km=5.0,
+        )
+
+
 def test_bandpass_wavelength_raises_below_nyquist():
     ds = _track_dataset()
     with pytest.raises(ValueError, match="Nyquist"):

--- a/tests/test_geo_extended.py
+++ b/tests/test_geo_extended.py
@@ -75,7 +75,7 @@ def ds_grid_daily() -> xr.Dataset:
 
 def test_psd_score_perfect_prediction_is_one(ds_grid_daily):
     ds_small = ds_grid_daily.isel(time=slice(0, 64), lat=4)
-    score = psd_score(ds_small, ds_small, "ssh", psd_dims=["time", "lon"])
+    score = psd_score(ds_small["ssh"], ds_small["ssh"], psd_dims=["time", "lon"])
     # error is zero everywhere -> score is 1 everywhere
     np.testing.assert_allclose(
         score["score"].values, np.ones_like(score["score"].values), atol=1e-10

--- a/tests/test_geo_extended.py
+++ b/tests/test_geo_extended.py
@@ -153,7 +153,7 @@ def test_fillnan_temporal_uses_xarray_native():
 
 
 def test_resample_time_daily_to_monthly(ds_grid_daily):
-    monthly = resample_time(ds_grid_daily, freq="1ME", method="mean")
+    monthly = resample_time(ds_grid_daily["ssh"], freq="1ME", method="mean")
     # 2 years -> 24 months
     assert monthly.sizes["time"] == 24
 
@@ -161,43 +161,45 @@ def test_resample_time_daily_to_monthly(ds_grid_daily):
 def test_resample_time_interpolate_preserves_existing_stamps():
     time = pd.date_range("2020-01-01", periods=5, freq="1D")
     values = np.sin(np.arange(time.size, dtype=float))
-    ds = xr.Dataset({"x": ("time", values)}, coords={"time": time})
+    da = xr.DataArray(values, dims=("time",), coords={"time": time}, name="x")
 
-    out = resample_time(ds, freq="12h", method="interpolate")
+    out = resample_time(da, freq="12h", method="interpolate")
 
-    xr.testing.assert_allclose(out.sel(time=time), ds)
+    xr.testing.assert_allclose(out.sel(time=time), da)
 
 
 def test_resample_time_interpolate_linear_upsamples_daily_to_hourly():
     time = pd.date_range("2020-01-01", periods=3, freq="1D")
-    ds = xr.Dataset({"x": ("time", [0.0, 24.0, 48.0])}, coords={"time": time})
+    da = xr.DataArray(
+        [0.0, 24.0, 48.0], dims=("time",), coords={"time": time}, name="x"
+    )
 
-    out = resample_time(ds, freq="1h", method="interpolate")
+    out = resample_time(da, freq="1h", method="interpolate")
 
     assert out.sizes["time"] == 49
-    assert float(out["x"].sel(time="2020-01-01T12:00")) == pytest.approx(12.0)
-    assert float(out["x"].sel(time="2020-01-02T12:00")) == pytest.approx(36.0)
+    assert float(out.sel(time="2020-01-01T12:00")) == pytest.approx(12.0)
+    assert float(out.sel(time="2020-01-02T12:00")) == pytest.approx(36.0)
 
 
 def test_resample_time_interpolate_accepts_cubic():
     time = pd.date_range("2020-01-01", periods=6, freq="1D")
     values = np.sin(np.linspace(0.0, np.pi, time.size))
-    ds = xr.Dataset({"x": ("time", values)}, coords={"time": time})
+    da = xr.DataArray(values, dims=("time",), coords={"time": time}, name="x")
 
-    out = resample_time(ds, freq="12h", method="interpolate", interp_method="cubic")
+    out = resample_time(da, freq="12h", method="interpolate", interp_method="cubic")
 
     assert out.sizes["time"] == 11
-    assert np.isfinite(out["x"].values).all()
+    assert np.isfinite(out.values).all()
 
 
 def test_resample_time_interpolate_rejects_downsampling(ds_grid_daily):
     with pytest.raises(ValueError, match="only supports upsampling"):
-        resample_time(ds_grid_daily, freq="2D", method="interpolate")
+        resample_time(ds_grid_daily["ssh"], freq="2D", method="interpolate")
 
 
 def test_resample_time_rejects_unknown_method(ds_grid_daily):
     with pytest.raises(ValueError, match="Unknown resample method"):
-        resample_time(ds_grid_daily, freq="1D", method="unicorn")
+        resample_time(ds_grid_daily["ssh"], freq="1D", method="unicorn")
 
 
 def _monthly_climatology_series() -> xr.DataArray:

--- a/tests/test_interpolate_operators.py
+++ b/tests/test_interpolate_operators.py
@@ -137,6 +137,28 @@ def test_fillnan_climatology_operator_matches_function() -> None:
     xr.testing.assert_allclose(op(missing), expected)
 
 
+def test_resample_time_operator_preserves_non_time_coords() -> None:
+    """Regression: the per-variable Dataset loop must not drop standalone
+    coords (e.g. ``lat`` / ``lon`` ride-along axes) when none of the
+    surviving data variables carry them."""
+    time = pd.date_range("2020-01-01", periods=4, freq="1D")
+    ds = xr.Dataset(
+        {"sst": (("time",), np.arange(4.0))},
+        coords={
+            "time": time,
+            "lat": 0.5,  # scalar standalone coord — not on any data_var
+            "lon": ("lon", [10.0, 20.0]),
+        },
+    )
+
+    out = ResampleTime(freq="2D", method="mean")(ds)
+
+    assert "lat" in out.coords
+    assert "lon" in out.coords
+    assert float(out["lat"]) == 0.5
+    np.testing.assert_array_equal(out["lon"].values, np.array([10.0, 20.0]))
+
+
 def test_resample_time_operator_passes_interp_method() -> None:
     time = pd.date_range("2020-01-01", periods=3, freq="1D")
     ds = xr.Dataset({"x": ("time", [0.0, 24.0, 48.0])}, coords={"time": time})

--- a/tests/test_interpolate_smooth.py
+++ b/tests/test_interpolate_smooth.py
@@ -214,38 +214,33 @@ def ds_signal():
 
 
 def test_tier_b_moving_average_preserves_shape(ds_signal):
-    out = moving_average(ds_signal, dim="time", window=5)
-    assert out["x"].shape == ds_signal["x"].shape
-    assert out["x"].dims == ("time",)
+    out = moving_average(ds_signal["x"], dim="time", window=5)
+    assert out.shape == ds_signal["x"].shape
+    assert out.dims == ("time",)
 
 
 def test_tier_b_gaussian_smooth_matches_tier_a(ds_signal):
-    out = gaussian_smooth(ds_signal, dim="time", sigma=3.0)
+    out = gaussian_smooth(ds_signal["x"], dim="time", sigma=3.0)
     expected = ia.gaussian_smooth(ds_signal["x"].values, axis=-1, sigma=3.0)
-    np.testing.assert_allclose(out["x"].values, expected)
+    np.testing.assert_allclose(out.values, expected)
 
 
 def test_tier_b_gaussian_smooth_masked_matches_tier_a():
     rng = np.random.default_rng(1)
     x = rng.standard_normal((3, 8, 9))
     x[:, 3, 4] = np.nan
-    ds = xr.Dataset(
-        {
-            "x": (("time", "lat", "lon"), x),
-            "lat_only": (("lat",), np.arange(8, dtype=float)),
-            "label": (("lat",), np.array(["a"] * 8)),
-        },
+    da = xr.DataArray(
+        x,
+        dims=("time", "lat", "lon"),
         coords={"time": np.arange(3), "lat": np.arange(8), "lon": np.arange(9)},
     )
 
-    out = gaussian_smooth_masked(ds, dim=("lat", "lon"), sigma={"lat": 1.0, "lon": 2.0})
+    out = gaussian_smooth_masked(da, dim=("lat", "lon"), sigma={"lat": 1.0, "lon": 2.0})
     expected = np.stack(
         [ia.gaussian_smooth_nd(block, sigma=(1.0, 2.0)) for block in x],
         axis=0,
     )
-    np.testing.assert_allclose(out["x"].values, expected)
-    np.testing.assert_array_equal(out["lat_only"].values, ds["lat_only"].values)
-    np.testing.assert_array_equal(out["label"].values, ds["label"].values)
+    np.testing.assert_allclose(out.values, expected)
 
 
 def test_tier_b_gaussian_smooth_masked_dataarray():
@@ -278,18 +273,20 @@ def test_tier_b_gaussian_smooth_masked_dask_contract():
 
 
 def test_tier_b_lowpass_filter_matches_tier_a(ds_signal):
-    out = lowpass_filter(ds_signal, dim="time", cutoff=0.1, order=4)
+    out = lowpass_filter(ds_signal["x"], dim="time", cutoff=0.1, order=4)
     expected = ia.lowpass_filter(ds_signal["x"].values, axis=-1, cutoff=0.1, order=4)
-    np.testing.assert_allclose(out["x"].values, expected)
+    np.testing.assert_allclose(out.values, expected)
 
 
 def test_tier_b_fir_filter_matches_tier_a(ds_signal):
-    out = fir_filter(ds_signal, dim="time", cutoff=0.2, num_taps=15)
+    out = fir_filter(ds_signal["x"], dim="time", cutoff=0.2, num_taps=15)
     expected = ia.fir_filter(ds_signal["x"].values, axis=-1, cutoff=0.2, num_taps=15)
-    np.testing.assert_allclose(out["x"].values, expected)
+    np.testing.assert_allclose(out.values, expected)
 
 
-def test_tier_b_passes_through_non_dim_variables():
+def test_operator_moving_average_passes_through_non_dim_variables():
+    from xrtoolz.interpolate.operators import MovingAverage
+
     ds = xr.Dataset(
         {
             "x": (("time",), np.arange(10, dtype=float)),
@@ -297,11 +294,13 @@ def test_tier_b_passes_through_non_dim_variables():
         },
         coords={"time": np.arange(10)},
     )
-    out = moving_average(ds, dim="time", window=3)
+    out = MovingAverage(dim="time", window=3)(ds)
     assert float(out["static"]) == 7.0
 
 
-def test_tier_b_fir_passes_through_non_numeric_and_no_dim_variables():
+def test_operator_lowpass_passes_through_non_numeric_and_no_dim_variables():
+    from xrtoolz.interpolate.operators import LowpassFilter
+
     ds = xr.Dataset(
         {
             "x": (("time",), np.arange(64, dtype=float)),
@@ -310,7 +309,7 @@ def test_tier_b_fir_passes_through_non_numeric_and_no_dim_variables():
         },
         coords={"time": np.arange(64)},
     )
-    out = fir_filter(ds, dim="time", cutoff=0.2, num_taps=15)
+    out = LowpassFilter(dim="time", cutoff=0.2)(ds)
     assert not np.array_equal(out["x"].values, ds["x"].values)
     np.testing.assert_array_equal(out["label"].values, ds["label"].values)
     assert float(out["static"]) == 7.0
@@ -318,7 +317,7 @@ def test_tier_b_fir_passes_through_non_numeric_and_no_dim_variables():
 
 def test_tier_b_unknown_dim_raises(ds_signal):
     with pytest.raises(ValueError):
-        moving_average(ds_signal, dim="bogus", window=3)
+        moving_average(ds_signal["x"], dim="bogus", window=3)
 
 
 # ---------------------------------------------------------------------------
@@ -330,7 +329,7 @@ def test_tier_c_moving_average_matches_tier_b(ds_signal):
     op = MovingAverage("time", window=5)
     np.testing.assert_allclose(
         op(ds_signal)["x"].values,
-        moving_average(ds_signal, dim="time", window=5)["x"].values,
+        moving_average(ds_signal["x"], dim="time", window=5).values,
     )
 
 
@@ -338,7 +337,7 @@ def test_tier_c_gaussian_smooth_matches_tier_b(ds_signal):
     op = GaussianSmooth("time", sigma=2.5)
     np.testing.assert_allclose(
         op(ds_signal)["x"].values,
-        gaussian_smooth(ds_signal, dim="time", sigma=2.5)["x"].values,
+        gaussian_smooth(ds_signal["x"], dim="time", sigma=2.5).values,
     )
 
 
@@ -358,7 +357,7 @@ def test_tier_c_lowpass_filter_matches_tier_b(ds_signal):
     op = LowpassFilter("time", cutoff=0.1)
     np.testing.assert_allclose(
         op(ds_signal)["x"].values,
-        lowpass_filter(ds_signal, dim="time", cutoff=0.1)["x"].values,
+        lowpass_filter(ds_signal["x"], dim="time", cutoff=0.1).values,
     )
 
 

--- a/tests/test_metrics_composite.py
+++ b/tests/test_metrics_composite.py
@@ -67,11 +67,11 @@ def test_nrmse_and_rmse_skill_scores_match_manual_formula() -> None:
     expected_leaderboard = 1.0 - 1.0 / np.sqrt(np.mean(ref["ssh"].values ** 2))
 
     np.testing.assert_allclose(
-        nrmse(pred, ref, "ssh", ("lat", "lon")).values,
+        nrmse(pred["ssh"], ref["ssh"], dim=("lat", "lon")).values,
         expected_rmse_t,
     )
 
-    scores = rmse_skill_scores(pred, ref, variable="ssh")
+    scores = rmse_skill_scores(pred["ssh"], ref["ssh"])
     np.testing.assert_allclose(scores["rmse_t"].values, expected_rmse_t)
     np.testing.assert_allclose(scores["rmse_xy"].values, expected_rmse_xy)
     assert float(scores["leaderboard_rmse"]) == pytest.approx(expected_leaderboard)
@@ -84,7 +84,7 @@ def test_rmse_skill_scores_identical_fields_have_perfect_skill() -> None:
     ref = xr.Dataset(
         {"ssh": (("time", "lat", "lon"), np.arange(12.0).reshape(3, 2, 2))}
     )
-    scores = rmse_skill_scores(ref, ref, variable="ssh")
+    scores = rmse_skill_scores(ref["ssh"], ref["ssh"])
 
     np.testing.assert_allclose(scores["rmse_t"].values, np.ones(3))
     np.testing.assert_allclose(scores["rmse_xy"].values, np.zeros((2, 2)))
@@ -182,7 +182,7 @@ def test_psd_score_spacetime_returns_positive_frequency_score_and_summary() -> N
         coords={"time": time, "lat": lat, "lon": lon},
     )
 
-    score, summary = psd_score_spacetime(pred, ref, variable="ssh")
+    score, summary = psd_score_spacetime(pred["ssh"], ref["ssh"])
 
     assert score["score"].dims == ("freq_lon", "freq_time")
     assert np.all(score["freq_lon"].values > 0.0)
@@ -204,7 +204,7 @@ def test_rmse_skill_scores_rejects_time_dim_in_space_dims() -> None:
         coords={"time": [0, 1], "lat": [0, 1], "lon": [0, 1]},
     )
     with pytest.raises(ValueError, match="time_dim"):
-        rmse_skill_scores(ds, ds, variable="ssh", space_dims=("time", "lat"))
+        rmse_skill_scores(ds["ssh"], ds["ssh"], space_dims=("time", "lat"))
 
 
 def test_psd_score_spacetime_rejects_isotropic_kwarg() -> None:
@@ -214,4 +214,4 @@ def test_psd_score_spacetime_rejects_isotropic_kwarg() -> None:
         coords={"time": np.arange(16.0), "lon": np.arange(16.0)},
     )
     with pytest.raises(ValueError, match="isotropic"):
-        psd_score_spacetime(ds, ds, variable="ssh", isotropic=True)
+        psd_score_spacetime(ds["ssh"], ds["ssh"], isotropic=True)

--- a/tests/test_metrics_pixel_semantics.py
+++ b/tests/test_metrics_pixel_semantics.py
@@ -36,7 +36,7 @@ def ds_with_nans() -> tuple[xr.Dataset, xr.Dataset]:
 def test_metrics_skip_nans(ds_with_nans: tuple[xr.Dataset, xr.Dataset], fn) -> None:
     """A NaN sample shouldn't poison the entire reduction."""
     ds_p, ds_r = ds_with_nans
-    out = fn(ds_p, ds_r, "x", "time")
+    out = fn(ds_p["x"], ds_r["x"], dim="time")
     assert np.isfinite(out.values).all(), (
         f"{fn.__name__} returned NaN despite skipna semantics: {out.values}"
     )
@@ -49,7 +49,7 @@ def test_metrics_promote_int_input_to_float() -> None:
     ds_r = xr.Dataset(
         {"x": (("time",), np.arange(8, dtype=np.int64) + 1)}, coords=coords
     )
-    out = pixel.mse(ds_p, ds_r, "x", "time")
+    out = pixel.mse(ds_p["x"], ds_r["x"], dim="time")
     assert np.issubdtype(out.dtype, np.floating)
     np.testing.assert_allclose(out.values, 1.0)
 
@@ -68,8 +68,8 @@ def test_metrics_handle_chunked_core_dim() -> None:
         {"time": 4}
     )
     # Should not raise; values should match the eager computation.
-    chunked = pixel.mse(ds_p, ds_r, "x", "time").compute()
+    chunked = pixel.mse(ds_p["x"], ds_r["x"], dim="time").compute()
     eager_p = xr.Dataset({"x": (("sample", "time"), pred)}, coords=coords)
     eager_r = xr.Dataset({"x": (("sample", "time"), ref)}, coords=coords)
-    eager = pixel.mse(eager_p, eager_r, "x", "time")
+    eager = pixel.mse(eager_p["x"], eager_r["x"], dim="time")
     np.testing.assert_allclose(chunked.values, eager.values)

--- a/tests/test_metrics_segmented_psd.py
+++ b/tests/test_metrics_segmented_psd.py
@@ -95,17 +95,21 @@ def _is_near_zero_meridian(lon: float) -> bool:
 def test_along_track_psd_score_detects_time_gaps() -> None:
     ds = _track_dataset()
     out = along_track_psd_score(
-        ds,
-        var_ref="ssh_ref",
-        var_pred="ssh_pred",
+        ds["ssh_pred"],
+        ds["ssh_ref"],
+        lon=ds["lon"],
+        lat=ds["lat"],
+        time=ds["time"],
         npt=64,
         overlap=0.5,
         spacing_km=7.0,
     )
     no_gap = along_track_psd_score(
-        ds,
-        var_ref="ssh_ref",
-        var_pred="ssh_pred",
+        ds["ssh_pred"],
+        ds["ssh_ref"],
+        lon=ds["lon"],
+        lat=ds["lat"],
+        time=ds["time"],
         npt=64,
         overlap=0.5,
         max_gap=np.timedelta64(1, "D"),
@@ -119,9 +123,11 @@ def test_along_track_psd_score_detects_time_gaps() -> None:
 def test_along_track_psd_score_bounds() -> None:
     ds = _track_dataset()
     out = along_track_psd_score(
-        ds,
-        var_ref="ssh_ref",
-        var_pred="ssh_pred",
+        ds["ssh_pred"],
+        ds["ssh_ref"],
+        lon=ds["lon"],
+        lat=ds["lat"],
+        time=ds["time"],
         npt=64,
         overlap=0.5,
         spacing_km=7.0,
@@ -151,9 +157,11 @@ def test_along_track_segment_longitude_uses_circular_mean() -> None:
     )
 
     out = along_track_psd_score(
-        ds,
-        var_ref="ssh_ref",
-        var_pred="ssh_pred",
+        ds["ssh_pred"],
+        ds["ssh_ref"],
+        lon=ds["lon"],
+        lat=ds["lat"],
+        time=ds["time"],
         npt=npt,
         spacing_km=7.0,
     )

--- a/tests/test_metrics_v2_data_representation.py
+++ b/tests/test_metrics_v2_data_representation.py
@@ -299,9 +299,7 @@ def test_phase_shift_error_2d_periodic() -> None:
     coords = {"lat": np.arange(n), "lon": np.arange(n)}
     ds_p = xr.Dataset({"x": (("lat", "lon"), shifted)}, coords=coords)
     ds_r = xr.Dataset({"x": (("lat", "lon"), blob)}, coords=coords)
-    out = phase_shift_error(
-        ds_p["x"], ds_r["x"], dims=("lat", "lon"), periodic=False
-    )
+    out = phase_shift_error(ds_p["x"], ds_r["x"], dims=("lat", "lon"), periodic=False)
     assert int(out["shift_lat"].values) == 3
     assert int(out["shift_lon"].values) == -4
 

--- a/tests/test_metrics_v2_data_representation.py
+++ b/tests/test_metrics_v2_data_representation.py
@@ -300,7 +300,7 @@ def test_phase_shift_error_2d_periodic() -> None:
     ds_p = xr.Dataset({"x": (("lat", "lon"), shifted)}, coords=coords)
     ds_r = xr.Dataset({"x": (("lat", "lon"), blob)}, coords=coords)
     out = phase_shift_error(
-        ds_p, ds_r, variable="x", dims=("lat", "lon"), periodic=False
+        ds_p["x"], ds_r["x"], dims=("lat", "lon"), periodic=False
     )
     assert int(out["shift_lat"].values) == 3
     assert int(out["shift_lon"].values) == -4

--- a/tests/test_metrics_wavelet.py
+++ b/tests/test_metrics_wavelet.py
@@ -25,7 +25,7 @@ def _dataset(nx: int = 48, ny: int = 48) -> xr.Dataset:
 def test_wavelet_psd_score_perfect_prediction_is_one_on_trusted_pixels() -> None:
     ds = _dataset()
     scales = xr.DataArray([2.0, 4.0, 8.0], dims="scale")
-    out = wavelet_psd_score(ds, ds, "ssh", scales, x0=1.0, ntheta=4)
+    out = wavelet_psd_score(ds["ssh"], ds["ssh"], scales, x0=1.0, ntheta=4)
     trusted = out["score"].where(out["score"]["coi_mask"])
     values = trusted.values[np.isfinite(trusted.values)]
     np.testing.assert_allclose(values, 1.0, rtol=1e-12, atol=1e-12)

--- a/tests/test_tier_contract.py
+++ b/tests/test_tier_contract.py
@@ -60,7 +60,7 @@ def test_metrics_tier_b_matches_tier_a(name: str) -> None:
     a_out = getattr(ma, name)(pred, ref, axis=-1)
     ds_pred = xr.Dataset({"x": (("a", "b"), pred)})
     ds_ref = xr.Dataset({"x": (("a", "b"), ref)})
-    b_out = getattr(tier_b, name)(ds_pred, ds_ref, "x", "b").values
+    b_out = getattr(tier_b, name)(ds_pred["x"], ds_ref["x"], dim="b").values
 
     np.testing.assert_allclose(a_out, b_out, rtol=1e-12, atol=1e-12)
 
@@ -90,7 +90,7 @@ def test_metrics_tier_c_matches_tier_b(op_name: str, fn_name: str) -> None:
 
     op = getattr(ops, op_name)(variable="x", dims="b")
     c_out = op(ds_pred, ds_ref).values
-    b_out = getattr(tier_b, fn_name)(ds_pred, ds_ref, "x", "b").values
+    b_out = getattr(tier_b, fn_name)(ds_pred["x"], ds_ref["x"], dim="b").values
 
     np.testing.assert_allclose(c_out, b_out, rtol=1e-12, atol=1e-12)
 

--- a/tests/test_tier_contract.py
+++ b/tests/test_tier_contract.py
@@ -225,7 +225,7 @@ def test_interpolate_smooth_tier_b_matches_tier_a() -> None:
 
 
 def test_interpolate_smooth_tier_c_matches_tier_b() -> None:
-    """Tier C ``Operator`` output equals Tier B function output applied to a DataArray."""
+    """Tier C operator equals Tier B output applied to a DataArray."""
     from xrtoolz.interpolate._src import smooth as tier_b
     from xrtoolz.interpolate.operators import (
         GaussianSmooth,

--- a/tests/test_tier_contract.py
+++ b/tests/test_tier_contract.py
@@ -203,29 +203,29 @@ def test_interpolate_array_namespace_exports(name: str) -> None:
 
 
 def test_interpolate_smooth_tier_b_matches_tier_a() -> None:
-    """Tier B (Dataset, ``dim=``) numerically matches Tier A (``axis=``)."""
+    """Tier B (DataArray, ``dim=``) numerically matches Tier A (``axis=``)."""
     from xrtoolz.interpolate import array as ia
     from xrtoolz.interpolate._src import smooth as tier_b
 
     rng = np.random.default_rng(0)
     x = rng.standard_normal((3, 64))
-    ds = xr.Dataset({"x": (("a", "time"), x)})
+    da = xr.DataArray(x, dims=("a", "time"))
 
-    b_ma = tier_b.moving_average(ds, dim="time", window=5)["x"].values
+    b_ma = tier_b.moving_average(da, dim="time", window=5).values
     a_ma = ia.moving_average(x, axis=-1, window=5)
     np.testing.assert_allclose(a_ma, b_ma)
 
-    b_g = tier_b.gaussian_smooth(ds, dim="time", sigma=2.0)["x"].values
+    b_g = tier_b.gaussian_smooth(da, dim="time", sigma=2.0).values
     a_g = ia.gaussian_smooth(x, axis=-1, sigma=2.0)
     np.testing.assert_allclose(a_g, b_g)
 
-    b_lp = tier_b.lowpass_filter(ds, dim="time", cutoff=0.1)["x"].values
+    b_lp = tier_b.lowpass_filter(da, dim="time", cutoff=0.1).values
     a_lp = ia.lowpass_filter(x, axis=-1, cutoff=0.1)
     np.testing.assert_allclose(a_lp, b_lp)
 
 
 def test_interpolate_smooth_tier_c_matches_tier_b() -> None:
-    """Tier C ``Operator`` output equals Tier B function output."""
+    """Tier C ``Operator`` output equals Tier B function output applied to a DataArray."""
     from xrtoolz.interpolate._src import smooth as tier_b
     from xrtoolz.interpolate.operators import (
         GaussianSmooth,
@@ -239,15 +239,15 @@ def test_interpolate_smooth_tier_c_matches_tier_b() -> None:
 
     np.testing.assert_allclose(
         MovingAverage("time", window=5)(ds)["x"].values,
-        tier_b.moving_average(ds, dim="time", window=5)["x"].values,
+        tier_b.moving_average(ds["x"], dim="time", window=5).values,
     )
     np.testing.assert_allclose(
         GaussianSmooth("time", sigma=2.0)(ds)["x"].values,
-        tier_b.gaussian_smooth(ds, dim="time", sigma=2.0)["x"].values,
+        tier_b.gaussian_smooth(ds["x"], dim="time", sigma=2.0).values,
     )
     np.testing.assert_allclose(
         LowpassFilter("time", cutoff=0.1)(ds)["x"].values,
-        tier_b.lowpass_filter(ds, dim="time", cutoff=0.1)["x"].values,
+        tier_b.lowpass_filter(ds["x"], dim="time", cutoff=0.1).values,
     )
 
 

--- a/tests/test_viz_validation.py
+++ b/tests/test_viz_validation.py
@@ -322,17 +322,15 @@ def _psd_fixtures():
 
     iso = power_spectrum(truth, dim=("lon", "lat"), isotropic=True).mean("time")
     iso_score = psd_score(
-        pred.to_dataset(name="zos"),
-        truth.to_dataset(name="zos"),
-        "zos",
+        pred,
+        truth,
         psd_dims=("lon", "lat"),
         isotropic=True,
     ).mean("time")
     st = power_spectrum(truth, dim=("lon", "time")).mean("lat")
     st_score = psd_score(
-        pred.to_dataset(name="zos"),
-        truth.to_dataset(name="zos"),
-        "zos",
+        pred,
+        truth,
         psd_dims=("lon", "time"),
         avg_dims=("lat",),
         isotropic=False,

--- a/uv.lock
+++ b/uv.lock
@@ -3232,7 +3232,7 @@ wheels = [
 
 [[package]]
 name = "xrtoolz"
-version = "0.0.7"
+version = "0.0.8"
 source = { editable = "." }
 dependencies = [
     { name = "cartopy" },


### PR DESCRIPTION
Implements **PR β** from [`docs/design/xarray-native-primitives.md`](docs/design/xarray-native-primitives.md): Layer-0 primitives across the metrics and interpolate modules now take positional `DataArray` inputs and keyword-only configuration. The `Dataset` + `variable=` selector pattern moves up into Layer-1 `Operator._apply`.

## Summary

**Metrics primitives flipped** (`metrics/_src/`):
- `pixel.{mse,rmse,nrmse,mae,bias,correlation,r2_score}(pred, ref, *, dim)`
- `spectral.{psd_error,psd_score}(pred, ref, *, psd_dims, …)`, `wavelet_psd_score(pred, ref, scales, *, …)`
- `composite.{rmse_skill_scores,psd_score_spacetime}(pred, ref, *, …)`
- `structural.{ssim,gradient_difference,phase_shift_error}(pred, ref, *, dim)`
- `segmented_psd.along_track_psd_score(pred, ref, *, lon, lat, time, …)` — two-variable selector tidied
- `distributional.{crps_ensemble,energy_distance,wasserstein_1}` — DataArray-positional
- `probabilistic.{spread_skill_ratio,rank_histogram,ensemble_coverage,reliability_curve}` — DataArray-positional

**Interpolate primitives flipped** (`interpolate/_src/`):
- `smooth.{moving_average,gaussian_smooth,gaussian_smooth_masked,lowpass_filter,fir_filter}(da, *, dim, …)` — DataArray-in / DataArray-out
- `resample.resample_time(da, *, freq, method, …)` — DataArray-only

The Dataset-loop helper (`_apply_along_dim` in `smooth.py`) extracts into the operator layer via a new shared helper `_map_over_dataset_or_dataarray` in `interpolate/operators.py`, so operators still accept either a Dataset (with per-variable loop) or a DataArray. `geo._src.along_track.bandpass_wavelength` was a direct primitive caller and now performs the Dataset loop locally.

## Stays untouched

- `spectral.evaluate_by_frequency_band` / `band_limited_rmse` — they orchestrate an inner `Operator` (the `metric=` kwarg) so they live on the composition side, not the primitive side.
- `composite.psd_score_spacetime` summary path — unchanged numerical logic, just flipped signature.
- `dm.dm_test` — already array-positional; no Dataset to flip.
- Every operator constructor — `RMSE(variable="x", dims=...)`, `GaussianSmooth(dim=, sigma=)`, etc. unchanged. Anyone going through the Operator API sees no break.

## Architecture note

This is "PR β" of the three-PR sequence in the design doc. PR α (DataTree dispatch) shipped in #206. PR γ (transforms + geo single-field cleanup) remains.

A meaningful chunk of the diff is structural: primitives sheared down to one job (math on DataArrays) and operators picked up the Dataset plumbing. Net LOC is roughly flat — the +590 / -554 reflects movement rather than new code.

## Breaking changes

Direct callers of the Layer-0 functions in the `_src/` modules see breakage:

```python
# Before
rmse(ds_pred, ds_ref, "ssh", "time")
gaussian_smooth(ds, dim="time", sigma=2.0)

# After
rmse(ds_pred["ssh"], ds_ref["ssh"], dim="time")
gaussian_smooth(ds["ssh"], dim="time", sigma=2.0)   # one variable
# or, for the Dataset-loop behaviour:
GaussianSmooth(dim="time", sigma=2.0)(ds)
```

Per the design doc, "noone is using my lib except me" — no deprecation shims planned.

## Test plan

- [x] 1,248 passing / 19 skipped / **3 failures** (all pre-existing on `main` — `scikit-image` missing).
- [x] `ruff check .` + `ruff format --check .` clean.
- [x] `ty check src/xrtoolz` — no new diagnostics (fixed an existing one via `arr_a`/`arr_b` rename to avoid DataArray → ndarray rebinding in `distributional.py`).
- [x] Design doc updated to mark PR β complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)