### PR TITLE
feat!: flip transforms + geo single-field primitives to DataArray-positional (PR γ)

### DIFF
--- a/docs/design/xarray-native-primitives.md
+++ b/docs/design/xarray-native-primitives.md
@@ -1,6 +1,6 @@
 ---
-status: in-progress
-version: 0.1.1
+status: complete
+version: 0.2.0
 ---
 
 # Xarray-Native Primitives — Two-Layer Public Contract
@@ -24,7 +24,61 @@ version: 0.1.1
 > intentionally stays Dataset-flavoured (it composes an inner
 > Operator), and `metrics/_src/dm.dm_test` stays array-positional
 > (no Dataset to flip). Operator constructor signatures are
-> unchanged. PR γ remains to be done.
+> unchanged.
+>
+> **PR γ is now complete.** The remaining Dataset-flavoured Layer-0
+> primitives are flipped to DataArray-positional with keyword-only
+> configuration:
+>
+> - `transforms/_src/coord_remap.py`: `remap_axis(da, *, source_dim,
+>   target_coords, ...)` and `to_phase(da, *, time_dim, period, n_bins)`
+>   are now DataArray-in / DataArray-out; the per-variable Dataset loop
+>   and non-numeric guard moved into `RemapAxis._apply` and
+>   `ToPhase._apply` in `interpolate/operators.py`. The vertical presets
+>   (`ToSigma`, `FromSigma`, `ToIsopycnal`, `ToPressureLevels`,
+>   `ToHeight`) inherit `RemapAxis._apply` and pick up the loop for
+>   free.
+> - `transforms/_src/encoders/coord_time.py`: `time_rescale`,
+>   `time_unrescale`, `encode_time_ordinal` are DataArray-in /
+>   DataArray-out; `encode_time_cyclical` is DataArray-in /
+>   Dataset-out (multi-output primitive shape per the design doc
+>   "structured multi-output" pattern). The operators
+>   (`TimeRescale`, `TimeUnrescale`, `EncodeTimeCyclical`,
+>   `EncodeTimeOrdinal`) select `ds[self.time]` before calling the
+>   primitive and merge the result back into the Dataset.
+> - `transforms/_src/fourier.py`: `rotary_spectrum(u, v, *, dim,
+>   avg_dims)` takes the two velocity DataArrays positionally; a new
+>   Layer-1 `RotarySpectrum(u, v, dim)` operator wraps it.
+> - `geo/_src/along_track.py`: `bandpass_wavelength(da, *, dim, ..., lon,
+>   lat, ...)` is DataArray-positional, with `lon` and `lat` now passed
+>   as `DataArray | None` (used for spacing inference) rather than as
+>   variable-name strings. The `BandpassWavelength` operator keeps the
+>   `lon: str` / `lat: str` constructor and does the Dataset selection
+>   (including per-variable loop, non-numeric pass-through, and the
+>   misspelled-`dim` guard) in `_apply`.
+>
+> Deliberate non-flips in PR γ:
+>
+> - The other Fourier primitives in `transforms/_src/fourier.py`
+>   (`power_spectrum`, `cross_spectrum`, `coherence`, `stft`,
+>   `ke_spectral_flux`, `enstrophy_spectral_flux`, `integral_scale`,
+>   `fit_spectral_slope`, `compensated_spectrum`,
+>   `drop_negative_frequencies`) were already DataArray-positional and
+>   needed no change.
+> - The DCT / DST and wavelet primitives in
+>   `transforms/_src/{dct,wavelet}.py` were already DataArray-first
+>   and are unchanged.
+> - The basis encoders in `transforms/_src/encoders/basis.py`
+>   (`cyclical_encode`, `fourier_features`, `random_fourier_features`,
+>   `positional_encoding`) consume raw `ndarray` for backward
+>   compatibility with their Operator wrappers and are out of scope —
+>   the Operator layer already does the DataArray plumbing.
+> - The transforms `morphology` / `decompose` / `sklearn_op` modules
+>   are stateful-estimator or coord/attr utilities (not pure Layer-0
+>   primitives) and don't fit the flip contract.
+>
+> Operator constructor signatures across all three PRs are
+> unchanged.
 
 A follow-on refactor to D11 (revised). Flips every primitive in the
 package to an xarray-only public signature, keeping user-authored

--- a/src/xrtoolz/geo/_src/along_track.py
+++ b/src/xrtoolz/geo/_src/along_track.py
@@ -64,7 +64,7 @@ def _cutoff_from_wavelength(lambda_km: float, spacing_km: float) -> float:
 
 
 def bandpass_wavelength(
-    ds: xr.Dataset,
+    da: xr.DataArray,
     *,
     dim: str,
     lambda_min_km: float | None = None,
@@ -73,36 +73,37 @@ def bandpass_wavelength(
     method: str = "lanczos",
     num_taps: int | None = None,
     attenuation_db: float | None = None,
-    lon: str = "lon",
-    lat: str = "lat",
-) -> xr.Dataset:
-    """Filter an along-track dataset using wavelength cutoffs in kilometres.
+    lon: xr.DataArray | None = None,
+    lat: xr.DataArray | None = None,
+) -> xr.DataArray:
+    """Filter an along-track DataArray using wavelength cutoffs in kilometres.
+
+    Per the PR γ primitive-flip (``docs/design/xarray-native-primitives.md``),
+    this Layer-0 primitive operates on a single ``DataArray``. The
+    Layer-1 ``BandpassWavelength`` operator handles Dataset selection
+    (including per-variable iteration and string ``lon``/``lat`` name
+    lookup) and forwards the resulting DataArrays here.
 
     Args:
-        ds: Input dataset.
+        da: Input DataArray. Must carry ``dim`` and a numeric dtype.
         dim: Along-track dimension to filter.
         lambda_min_km: Short-wavelength edge in kilometres. With
             ``lambda_max_km`` this becomes the high-frequency band edge.
         lambda_max_km: Long-wavelength edge in kilometres. With
             ``lambda_min_km`` this becomes the low-frequency band edge.
         spacing_km: Optional along-track sample spacing. If omitted, it is
-            derived as the median WGS-84 spacing from ``ds[lon]`` / ``ds[lat]``.
+            derived as the median WGS-84 spacing from ``lon`` / ``lat``.
         method: FIR window family, ``"lanczos"`` or ``"kaiser"``.
         num_taps: Optional odd FIR tap count.
         attenuation_db: Kaiser attenuation target in decibels.
-        lon: Longitude variable name used when deriving spacing.
-        lat: Latitude variable name used when deriving spacing.
+        lon: 1-D longitude DataArray along ``dim``, used to derive
+            ``spacing_km`` when it is not supplied explicitly.
+        lat: 1-D latitude DataArray along ``dim``, used to derive
+            ``spacing_km`` when it is not supplied explicitly.
 
     Returns:
-        Dataset filtered along ``dim``. Variables without ``dim`` or with
-        non-numeric dtype pass through unchanged.
+        DataArray filtered along ``dim``, same shape as ``da``.
     """
-    if dim not in ds.dims:
-        # The previous Dataset-flavoured ``fir_filter(ds, ...)`` raised on a
-        # missing dim; the new per-variable loop would otherwise pass every
-        # variable through unchanged when ``dim`` is misspelled — a quiet
-        # no-op that's worse than a clear failure for downstream metrics.
-        raise ValueError(f"dim {dim!r} not in Dataset dims {tuple(ds.dims)}")
     if lambda_min_km is None and lambda_max_km is None:
         raise ValueError("at least one of lambda_min_km or lambda_max_km is required")
     if (
@@ -114,19 +115,24 @@ def bandpass_wavelength(
             f"lambda_min_km must be < lambda_max_km; got {lambda_min_km} >= "
             f"{lambda_max_km}"
         )
+    if dim not in da.dims:
+        raise ValueError(f"dim {dim!r} not in DataArray dims {tuple(da.dims)}")
     if spacing_km is None:
+        if lon is None or lat is None:
+            raise ValueError(
+                "spacing_km must be provided when lon / lat DataArrays are not "
+                "supplied for spacing inference"
+            )
         # Restrict spacing inference to the filter dim only; otherwise a
         # 2-D coord (multi-track grid) would mix unrelated endpoints into
         # the median.
-        lon_da = ds[lon]
-        lat_da = ds[lat]
-        if lon_da.dims != (dim,) or lat_da.dims != (dim,):
+        if lon.dims != (dim,) or lat.dims != (dim,):
             raise ValueError(
-                f"Cannot infer spacing: {lon!r}/{lat!r} are not 1-D along "
-                f"{dim!r} (got dims {lon_da.dims} / {lat_da.dims}). Pass "
+                "Cannot infer spacing: lon/lat are not 1-D along "
+                f"{dim!r} (got dims {lon.dims} / {lat.dims}). Pass "
                 "spacing_km explicitly."
             )
-        spacing_km = median_dx_km(lon_da.values, lat_da.values)
+        spacing_km = median_dx_km(lon.values, lat.values)
     if spacing_km <= 0:
         raise ValueError(f"spacing_km must be > 0, got {spacing_km}")
 
@@ -149,24 +155,15 @@ def bandpass_wavelength(
             _cutoff_from_wavelength(lambda_min_km, spacing_km),
         )
 
-    # ``fir_filter`` is DataArray-only after the PR β primitive flip. Loop
-    # over numeric data variables that carry the filter dim and pass other
-    # variables through unchanged.
-    out_vars: dict[str, xr.DataArray] = {}
-    for name, da in ds.data_vars.items():
-        if dim not in da.dims or not np.issubdtype(da.dtype, np.number):
-            out_vars[str(name)] = da
-            continue
-        out_vars[str(name)] = fir_filter(
-            da,
-            dim=dim,
-            cutoff=cutoff,
-            method=method,
-            btype=btype,
-            num_taps=num_taps,
-            attenuation_db=attenuation_db,
-        )
-    return xr.Dataset(out_vars, coords=ds.coords, attrs=dict(ds.attrs))
+    return fir_filter(
+        da,
+        dim=dim,
+        cutoff=cutoff,
+        method=method,
+        btype=btype,
+        num_taps=num_taps,
+        attenuation_db=attenuation_db,
+    )
 
 
 __all__ = ["bandpass_wavelength", "median_dx_km"]

--- a/src/xrtoolz/geo/operators.py
+++ b/src/xrtoolz/geo/operators.py
@@ -17,6 +17,7 @@ import warnings
 from collections.abc import Sequence
 from typing import Any, Literal
 
+import numpy as np
 import regionmask
 import xarray as xr
 
@@ -508,18 +509,53 @@ class BandpassWavelength(Operator):
         self.lat = lat
 
     def _apply(self, ds):
-        return _along_track.bandpass_wavelength(
-            ds,
-            dim=self.dim,
-            lambda_min_km=self.lambda_min_km,
-            lambda_max_km=self.lambda_max_km,
-            spacing_km=self.spacing_km,
-            method=self.method,
-            num_taps=self.num_taps,
-            attenuation_db=self.attenuation_db,
-            lon=self.lon,
-            lat=self.lat,
-        )
+        # Resolve the lon/lat ride-along DataArrays once. They are only
+        # needed when ``spacing_km`` is omitted, but doing the lookup
+        # here keeps the loop body small.
+        lon_da: xr.DataArray | None = None
+        lat_da: xr.DataArray | None = None
+        if self.spacing_km is None and isinstance(ds, xr.Dataset):
+            lon_da = ds[self.lon]
+            lat_da = ds[self.lat]
+        elif self.spacing_km is None and isinstance(ds, xr.DataArray):
+            # DataArray inputs only carry coords, not arbitrary
+            # variables; pull lon/lat from there.
+            if self.lon in ds.coords:
+                lon_da = ds.coords[self.lon]
+            if self.lat in ds.coords:
+                lat_da = ds.coords[self.lat]
+
+        def _fn(da: xr.DataArray) -> xr.DataArray:
+            return _along_track.bandpass_wavelength(
+                da,
+                dim=self.dim,
+                lambda_min_km=self.lambda_min_km,
+                lambda_max_km=self.lambda_max_km,
+                spacing_km=self.spacing_km,
+                method=self.method,
+                num_taps=self.num_taps,
+                attenuation_db=self.attenuation_db,
+                lon=lon_da,
+                lat=lat_da,
+            )
+
+        if isinstance(ds, xr.DataArray):
+            return _fn(ds)
+
+        if self.dim not in ds.dims:
+            # The pre-flip Dataset-flavoured primitive raised on a missing
+            # dim; preserve that behaviour at the Operator boundary so a
+            # misspelled ``dim`` doesn't silently pass every variable
+            # through unchanged.
+            raise ValueError(f"dim {self.dim!r} not in Dataset dims {tuple(ds.dims)}")
+
+        out_vars: dict[str, xr.DataArray] = {}
+        for name, da in ds.data_vars.items():
+            if self.dim not in da.dims or not np.issubdtype(da.dtype, np.number):
+                out_vars[str(name)] = da
+                continue
+            out_vars[str(name)] = _fn(da)
+        return xr.Dataset(out_vars, coords=ds.coords, attrs=dict(ds.attrs))
 
     def get_config(self) -> dict[str, Any]:
         return {

--- a/src/xrtoolz/interpolate/operators.py
+++ b/src/xrtoolz/interpolate/operators.py
@@ -1372,13 +1372,50 @@ class RemapAxis(Operator):
 
     def _apply(self, ds):
         target = self._target_da if self._target_da is not None else self._target_values
-        return _coord_remap.remap_axis(
-            ds,
-            source_dim=self.source_axis,
-            target_coords=target,
-            target_name=self.target_name,
-            method=self.method,
+
+        def _fn(da: xr.DataArray) -> xr.DataArray:
+            return _coord_remap.remap_axis(
+                da,
+                source_dim=self.source_axis,
+                target_coords=target,
+                target_name=self.target_name,
+                method=self.method,
+            )
+
+        if isinstance(ds, xr.DataArray):
+            return _fn(ds)
+
+        if self.source_axis not in ds.dims:
+            raise ValueError(
+                f"source_dim {self.source_axis!r} not in Dataset dims {tuple(ds.dims)}"
+            )
+        new_name = self._resolve_target_name()
+        tgt_values = self._target_values
+        out_vars: dict[str, xr.DataArray] = {}
+        for name, da in ds.data_vars.items():
+            if self.source_axis not in da.dims:
+                # Variable doesn't depend on the source axis — pass through.
+                out_vars[str(name)] = da
+                continue
+            if not np.issubdtype(da.dtype, np.number):
+                # A non-numeric variable that depends on source_axis cannot be
+                # interpolated; passing it through would leave the output with a
+                # phantom source_axis (and possibly incompatible sizes).
+                raise TypeError(
+                    f"variable {name!r} carries source_dim {self.source_axis!r} "
+                    f"but has non-numeric dtype {da.dtype}; drop or convert it "
+                    "before calling remap_axis"
+                )
+            out_vars[str(name)] = _fn(da)
+        base_coords = {
+            cname: c
+            for cname, c in ds.coords.items()
+            if self.source_axis not in c.dims and cname != self.source_axis
+        }
+        base_coords[new_name] = xr.DataArray(
+            tgt_values, dims=(new_name,), name=new_name
         )
+        return xr.Dataset(out_vars, coords=base_coords, attrs=dict(ds.attrs))
 
     def get_config(self) -> dict[str, Any]:
         return {
@@ -1504,13 +1541,48 @@ class ToPhase(Operator):
         self.epoch = float(epoch)
 
     def _apply(self, ds):
-        return _coord_remap.to_phase(
-            ds,
-            time_dim=self.time_dim,
-            period=self.period,
-            n_bins=self.n_bins,
-            epoch=self.epoch,
-        )
+        def _fn(da: xr.DataArray) -> xr.DataArray:
+            return _coord_remap.to_phase(
+                da,
+                time_dim=self.time_dim,
+                period=self.period,
+                n_bins=self.n_bins,
+                epoch=self.epoch,
+            )
+
+        if isinstance(ds, xr.DataArray):
+            return _fn(ds)
+
+        if self.time_dim not in ds.dims:
+            raise ValueError(
+                f"time_dim {self.time_dim!r} not in Dataset dims {tuple(ds.dims)}"
+            )
+        if self.time_dim not in ds.coords:
+            raise ValueError(
+                f"Dataset must carry a coordinate named {self.time_dim!r} "
+                "to compute phase"
+            )
+        edges = np.linspace(0.0, 1.0, self.n_bins + 1)
+        centers = 0.5 * (edges[:-1] + edges[1:])
+        out_vars: dict[str, xr.DataArray] = {}
+        for name, da in ds.data_vars.items():
+            if self.time_dim not in da.dims:
+                out_vars[str(name)] = da
+                continue
+            if not np.issubdtype(da.dtype, np.number):
+                raise TypeError(
+                    f"variable {name!r} carries time_dim {self.time_dim!r} but "
+                    f"has non-numeric dtype {da.dtype}; drop or convert it "
+                    "before calling to_phase"
+                )
+            out_vars[str(name)] = _fn(da)
+        base_coords = {
+            cname: c
+            for cname, c in ds.coords.items()
+            if self.time_dim not in c.dims and cname != self.time_dim
+        }
+        base_coords["phase"] = xr.DataArray(centers, dims=("phase",), name="phase")
+        return xr.Dataset(out_vars, coords=base_coords, attrs=dict(ds.attrs))
 
     def compute_output_signature(self, input_signature: Signature) -> Signature:
         dims = {}

--- a/src/xrtoolz/transforms/_src/coord_remap.py
+++ b/src/xrtoolz/transforms/_src/coord_remap.py
@@ -142,11 +142,12 @@ def to_phase(
     counts = np.zeros((n_bins, flat.shape[1]), dtype=float)
     # A sample is valid only if its time coord is finite AND every data
     # value is finite. Excluding NaN-time rows keeps stale rows out of
-    # the phase means (P2 review).
+    # the phase means (P2 review). ``np.isfinite`` handles integer
+    # dtypes (treated as all-finite) where ``np.isnan`` would raise.
     valid_value = (
-        ~np.isnan(flat)
+        np.isfinite(flat)
         if not is_complex
-        else (~np.isnan(flat.real) & ~np.isnan(flat.imag))
+        else (np.isfinite(flat.real) & np.isfinite(flat.imag))
     )
     valid = finite_t[:, None] & valid_value
     for b in range(n_bins):

--- a/src/xrtoolz/transforms/_src/coord_remap.py
+++ b/src/xrtoolz/transforms/_src/coord_remap.py
@@ -1,13 +1,16 @@
-"""Coordinate-axis remapping on xarray Datasets.
+"""Coordinate-axis remapping on xarray DataArrays.
 
-The generic primitive is :func:`remap_axis`: given a source dimension and
-a 1D target coordinate vector, every numeric variable that carries the
-source dim is interpolated onto the target axis along that dim.
+Per the PR γ primitive-flip (``docs/design/xarray-native-primitives.md``),
+the Layer-0 primitives in this module are DataArray-in / DataArray-out:
+one variable goes in, one variable comes out. The Dataset selection /
+per-variable loop lives in the Layer-1 ``Operator`` wrappers at
+:mod:`xrtoolz.interpolate.operators` (``RemapAxis``, ``ToPhase``, and
+the vertical presets).
 
-Vertical / temporal presets (``ToSigma``, ``FromSigma``,
-``ToIsopycnal``, ``ToPressureLevels``, ``ToHeight``, ``ToPhase``) live
-as :class:`Operator` subclasses in :mod:`xrtoolz.interpolate.operators`;
-they parametrise the generic operator with conventional dim/coord names.
+The generic primitive is :func:`remap_axis`: given a source dimension
+and a 1D target coordinate vector, the DataArray is interpolated onto
+the target axis along that dim. :func:`to_phase` folds a time axis
+onto a phase axis by binning + averaging.
 """
 
 from __future__ import annotations
@@ -20,29 +23,36 @@ from xrtoolz.utils._src.finite import _finite_mask
 
 
 def remap_axis(
-    ds: xr.Dataset,
+    da: xr.DataArray,
     *,
     source_dim: str,
     target_coords: xr.DataArray | np.ndarray,
     target_name: str | None = None,
     method: str = "linear",
-) -> xr.Dataset:
-    """Remap every variable carrying ``source_dim`` onto ``target_coords``.
+) -> xr.DataArray:
+    """Remap ``da`` along ``source_dim`` onto ``target_coords``.
 
     If ``target_coords`` is a :class:`xr.DataArray` and ``target_name``
     is None, the new dim name is taken from ``target_coords.name``;
     otherwise ``target_name`` (or ``source_dim``) is used.
 
     Targets outside the source range produce NaN (no extrapolation).
+    The Layer-1 ``RemapAxis`` operator handles Dataset selection /
+    per-variable looping.
     """
-    if source_dim not in ds.dims:
+    if source_dim not in da.dims:
         raise ValueError(
-            f"source_dim {source_dim!r} not in Dataset dims {tuple(ds.dims)}"
+            f"source_dim {source_dim!r} not in DataArray dims {tuple(da.dims)}"
         )
-    if source_dim not in ds.coords:
+    if source_dim not in da.coords:
         raise ValueError(
-            f"Dataset must carry a coordinate named {source_dim!r} "
+            f"DataArray must carry a coordinate named {source_dim!r} "
             "for the source axis values"
+        )
+    if not np.issubdtype(da.dtype, np.number):
+        raise TypeError(
+            f"remap_axis requires numeric data; got dtype {da.dtype}. "
+            "Drop or convert the variable before calling remap_axis."
         )
 
     if isinstance(target_coords, xr.DataArray):
@@ -52,156 +62,122 @@ def remap_axis(
         new_name = target_name or source_dim
         tgt = np.asarray(target_coords, dtype=float)
 
-    src = np.asarray(ds[source_dim].values, dtype=float)
+    src = np.asarray(da[source_dim].values, dtype=float)
 
-    out_vars: dict[str, xr.DataArray] = {}
-    for name, da in ds.data_vars.items():
-        if source_dim not in da.dims:
-            # Variable doesn't depend on the source axis — pass through.
-            out_vars[str(name)] = da
-            continue
-        if not np.issubdtype(da.dtype, np.number):
-            # A non-numeric variable that depends on source_dim cannot be
-            # interpolated; passing it through would leave the output with a
-            # phantom source_dim axis (and possibly incompatible sizes).
-            raise TypeError(
-                f"variable {name!r} carries source_dim {source_dim!r} but has "
-                f"non-numeric dtype {da.dtype}; drop or convert it before "
-                "calling remap_axis"
-            )
-        axis = da.get_axis_num(source_dim)
-        new_values = _array.remap_axis(
-            da.values,
-            axis=axis,
-            source_coords=src,
-            target_coords=tgt,
-            method=method,
-        )
-        new_dims = tuple(new_name if d == source_dim else d for d in da.dims)
-        new_coords = {
-            cname: c
-            for cname, c in da.coords.items()
-            if source_dim not in c.dims and cname != source_dim
-        }
-        new_coords[new_name] = xr.DataArray(tgt, dims=(new_name,), name=new_name)
-        out_vars[str(name)] = xr.DataArray(
-            new_values,
-            dims=new_dims,
-            coords=new_coords,
-            attrs=dict(da.attrs),
-            name=da.name,
-        )
-
-    base_coords = {
+    axis = da.get_axis_num(source_dim)
+    new_values = _array.remap_axis(
+        da.values,
+        axis=axis,
+        source_coords=src,
+        target_coords=tgt,
+        method=method,
+    )
+    new_dims = tuple(new_name if d == source_dim else d for d in da.dims)
+    new_coords = {
         cname: c
-        for cname, c in ds.coords.items()
+        for cname, c in da.coords.items()
         if source_dim not in c.dims and cname != source_dim
     }
-    base_coords[new_name] = xr.DataArray(tgt, dims=(new_name,), name=new_name)
-    return xr.Dataset(out_vars, coords=base_coords, attrs=dict(ds.attrs))
+    new_coords[new_name] = xr.DataArray(tgt, dims=(new_name,), name=new_name)
+    return xr.DataArray(
+        new_values,
+        dims=new_dims,
+        coords=new_coords,
+        attrs=dict(da.attrs),
+        name=da.name,
+    )
 
 
 def to_phase(
-    ds: xr.Dataset,
+    da: xr.DataArray,
     *,
     time_dim: str,
     period: float,
     n_bins: int,
     epoch: float = 0.0,
-) -> xr.Dataset:
+) -> xr.DataArray:
     """Fold ``time_dim`` onto a phase axis by binning + averaging.
 
     The time coordinate must be numeric in the same units as ``period``.
     Phase is computed as ``((t - epoch) / period) mod 1`` and binned
     into ``n_bins`` evenly-spaced bins on ``[0, 1)``. Output carries
     a ``"phase"`` dim with coordinate values at bin centers.
+
+    The Layer-1 ``ToPhase`` operator handles Dataset selection /
+    per-variable looping.
     """
-    if time_dim not in ds.dims:
-        raise ValueError(f"time_dim {time_dim!r} not in Dataset dims {tuple(ds.dims)}")
-    if time_dim not in ds.coords:
+    if time_dim not in da.dims:
         raise ValueError(
-            f"Dataset must carry a coordinate named {time_dim!r} to compute phase"
+            f"time_dim {time_dim!r} not in DataArray dims {tuple(da.dims)}"
+        )
+    if time_dim not in da.coords:
+        raise ValueError(
+            f"DataArray must carry a coordinate named {time_dim!r} to compute phase"
         )
     if period <= 0:
         raise ValueError(f"period must be > 0, got {period}")
     if n_bins < 1:
         raise ValueError(f"n_bins must be >= 1, got {n_bins}")
+    if not np.issubdtype(da.dtype, np.number):
+        raise TypeError(
+            f"to_phase requires numeric data; got dtype {da.dtype}. "
+            "Drop or convert the variable before calling to_phase."
+        )
 
-    t = np.asarray(ds[time_dim].values, dtype=float)
+    t = np.asarray(da[time_dim].values, dtype=float)
     finite_t = _finite_mask(t)
     phase = np.where(finite_t, ((t - epoch) / period) % 1.0, 0.0)
     edges = np.linspace(0.0, 1.0, n_bins + 1)
     centers = 0.5 * (edges[:-1] + edges[1:])
     bin_idx = np.clip(np.searchsorted(edges, phase, side="right") - 1, 0, n_bins - 1)
 
-    out_vars: dict[str, xr.DataArray] = {}
-    for name, da in ds.data_vars.items():
-        if time_dim not in da.dims:
-            out_vars[str(name)] = da
+    axis = da.get_axis_num(time_dim)
+    moved = np.moveaxis(da.values, axis, 0)
+    flat = moved.reshape(moved.shape[0], -1)
+    # Use a complex accumulator if the data is complex so the imaginary
+    # part isn't dropped (P1 review).
+    is_complex = np.iscomplexobj(flat)
+    acc_dtype = np.complex128 if is_complex else float
+    sums = np.zeros((n_bins, flat.shape[1]), dtype=acc_dtype)
+    counts = np.zeros((n_bins, flat.shape[1]), dtype=float)
+    # A sample is valid only if its time coord is finite AND every data
+    # value is finite. Excluding NaN-time rows keeps stale rows out of
+    # the phase means (P2 review).
+    valid_value = (
+        ~np.isnan(flat)
+        if not is_complex
+        else (~np.isnan(flat.real) & ~np.isnan(flat.imag))
+    )
+    valid = finite_t[:, None] & valid_value
+    for b in range(n_bins):
+        m = (bin_idx == b) & finite_t
+        if not m.any():
             continue
-        if not np.issubdtype(da.dtype, np.number):
-            raise TypeError(
-                f"variable {name!r} carries time_dim {time_dim!r} but has "
-                f"non-numeric dtype {da.dtype}; drop or convert it before "
-                "calling to_phase"
-            )
-        axis = da.get_axis_num(time_dim)
-        moved = np.moveaxis(da.values, axis, 0)
-        flat = moved.reshape(moved.shape[0], -1)
-        # Use a complex accumulator if the data is complex so the
-        # imaginary part isn't dropped (P1 review).
-        is_complex = np.iscomplexobj(flat)
-        acc_dtype = np.complex128 if is_complex else float
-        sums = np.zeros((n_bins, flat.shape[1]), dtype=acc_dtype)
-        counts = np.zeros((n_bins, flat.shape[1]), dtype=float)
-        # A sample is valid only if its time coord is finite AND every
-        # data value is finite. Excluding NaN-time rows keeps stale rows
-        # out of the phase means (P2 review).
-        valid_value = (
-            ~np.isnan(flat)
-            if not is_complex
-            else (~np.isnan(flat.real) & ~np.isnan(flat.imag))
-        )
-        valid = finite_t[:, None] & valid_value
-        for b in range(n_bins):
-            m = (bin_idx == b) & finite_t
-            if not m.any():
-                continue
-            sub = flat[m]
-            sub_valid = valid[m]
-            zero = acc_dtype(0)
-            sums[b] = np.where(sub_valid, sub, zero).sum(axis=0)
-            counts[b] = sub_valid.sum(axis=0)
-        with np.errstate(invalid="ignore"):
-            nan_fill = (np.nan + 0j) if is_complex else np.nan
-            mean = np.where(
-                counts > 0, sums / np.where(counts > 0, counts, 1.0), nan_fill
-            )
-        out_shape = (n_bins, *moved.shape[1:])
-        new_values = mean.reshape(out_shape)
-        new_values = np.moveaxis(new_values, 0, axis)
-        new_dims = tuple("phase" if d == time_dim else d for d in da.dims)
-        new_coords = {
-            cname: c
-            for cname, c in da.coords.items()
-            if time_dim not in c.dims and cname != time_dim
-        }
-        new_coords["phase"] = xr.DataArray(centers, dims=("phase",), name="phase")
-        out_vars[str(name)] = xr.DataArray(
-            new_values,
-            dims=new_dims,
-            coords=new_coords,
-            attrs=dict(da.attrs),
-            name=da.name,
-        )
-
-    base_coords = {
+        sub = flat[m]
+        sub_valid = valid[m]
+        zero = acc_dtype(0)
+        sums[b] = np.where(sub_valid, sub, zero).sum(axis=0)
+        counts[b] = sub_valid.sum(axis=0)
+    with np.errstate(invalid="ignore"):
+        nan_fill = (np.nan + 0j) if is_complex else np.nan
+        mean = np.where(counts > 0, sums / np.where(counts > 0, counts, 1.0), nan_fill)
+    out_shape = (n_bins, *moved.shape[1:])
+    new_values = mean.reshape(out_shape)
+    new_values = np.moveaxis(new_values, 0, axis)
+    new_dims = tuple("phase" if d == time_dim else d for d in da.dims)
+    new_coords = {
         cname: c
-        for cname, c in ds.coords.items()
+        for cname, c in da.coords.items()
         if time_dim not in c.dims and cname != time_dim
     }
-    base_coords["phase"] = xr.DataArray(centers, dims=("phase",), name="phase")
-    return xr.Dataset(out_vars, coords=base_coords, attrs=dict(ds.attrs))
+    new_coords["phase"] = xr.DataArray(centers, dims=("phase",), name="phase")
+    return xr.DataArray(
+        new_values,
+        dims=new_dims,
+        coords=new_coords,
+        attrs=dict(da.attrs),
+        name=da.name,
+    )
 
 
 __all__ = ["remap_axis", "to_phase"]

--- a/src/xrtoolz/transforms/_src/encoders/coord_time.py
+++ b/src/xrtoolz/transforms/_src/encoders/coord_time.py
@@ -1,4 +1,14 @@
-"""Coordinate-time encoders — rescaling and periodic time-component encodings."""
+"""Coordinate-time encoders — rescaling and periodic time-component encodings.
+
+Per the PR γ primitive-flip (``docs/design/xarray-native-primitives.md``),
+the Layer-0 primitives in this module take a single positional
+``DataArray`` (the time coordinate / variable) and return either a
+``DataArray`` (``time_rescale``, ``time_unrescale``,
+``encode_time_ordinal``) or a ``Dataset`` of derived variables
+(``encode_time_cyclical``). The Dataset assignment / merge lives in the
+Layer-1 ``TimeRescale``, ``TimeUnrescale``, ``EncodeTimeCyclical``,
+``EncodeTimeOrdinal`` operators in :mod:`xrtoolz.transforms.operators`.
+"""
 
 from __future__ import annotations
 
@@ -12,12 +22,12 @@ from xrtoolz.transforms._src.encoders.basis import cyclical_encode
 
 
 def time_rescale(
-    ds: xr.Dataset,
+    time: xr.DataArray,
+    *,
     freq_dt: float = 1.0,
     freq_unit: str = "s",
     t0: str | np.datetime64 | None = None,
-    time: str = "time",
-) -> xr.Dataset:
+) -> xr.DataArray:
     """Rescale a ``datetime64`` time axis to a float offset.
 
     ``t' = (t - t_0) / freq_dt``, where ``freq_dt`` is expressed in
@@ -25,44 +35,48 @@ def time_rescale(
     that :func:`time_unrescale` can round-trip back to ``datetime64``.
 
     Args:
-        ds: Input dataset with a ``time`` coordinate.
+        time: Time coordinate / variable to rescale.
         freq_dt: Size of the time step in ``freq_unit`` units.
         freq_unit: Pandas timedelta unit (``"s"``, ``"m"``, ``"h"``,
             ``"D"``, ...).
-        t0: Reference time. Defaults to ``ds[time].min()``.
-        time: Name of the time coordinate.
+        t0: Reference time. Defaults to ``time.min()``.
 
     Returns:
-        Copy of ``ds`` with ``time`` replaced by a ``float32`` offset.
+        DataArray of ``float32`` offsets, with ``units`` / ``freq`` /
+        ``t0`` attrs attached for :func:`time_unrescale`.
     """
-    ds = ds.copy()
     delta = pd.Timedelta(freq_dt, unit=freq_unit)
     delta_ns = np.int64(delta.asm8.astype("timedelta64[ns]").astype(np.int64))
 
     if t0 is None:
-        t0_val = np.datetime64(ds[time].min().values, "ns")
+        t0_val = np.datetime64(time.min().values, "ns")
     else:
         t0_val = np.datetime64(t0, "ns")
 
     td_ns = (
-        (ds[time].values.astype("datetime64[ns]") - t0_val)
+        (time.values.astype("datetime64[ns]") - t0_val)
         .astype("timedelta64[ns]")
         .astype(np.int64)
     )
     rescaled = (td_ns.astype(np.float64) / float(delta_ns)).astype(np.float32)
-    ds = ds.assign_coords({time: rescaled})
-    ds[time].attrs.update(
-        units=freq_unit,
-        freq=float(freq_dt),
-        t0=str(t0_val),
+    out = xr.DataArray(
+        rescaled,
+        dims=time.dims,
+        coords={cname: c for cname, c in time.coords.items() if cname != time.name},
+        name=time.name,
+        attrs={
+            **dict(time.attrs),
+            "units": freq_unit,
+            "freq": float(freq_dt),
+            "t0": str(t0_val),
+        },
     )
-    return ds
+    return out
 
 
-def time_unrescale(ds: xr.Dataset, time: str = "time") -> xr.Dataset:
+def time_unrescale(time: xr.DataArray) -> xr.DataArray:
     """Inverse of :func:`time_rescale` using its stored attrs."""
-    ds = ds.copy()
-    attrs = ds[time].attrs
+    attrs = time.attrs
     if "t0" not in attrs or "freq" not in attrs or "units" not in attrs:
         raise ValueError(
             "time coord is missing t0/freq/units attrs — rescale with "
@@ -71,30 +85,37 @@ def time_unrescale(ds: xr.Dataset, time: str = "time") -> xr.Dataset:
     delta = pd.Timedelta(attrs["freq"], unit=attrs["units"])
     t0 = np.datetime64(attrs["t0"], "ns")
     delta_ns = np.int64(delta.asm8.astype("timedelta64[ns]").astype(np.int64))
-    offsets = (ds[time].values.astype(np.float64) * delta_ns).astype("timedelta64[ns]")
-    ds = ds.assign_coords({time: t0 + offsets})
-    ds[time].attrs = {}
-    return ds
+    offsets = (time.values.astype(np.float64) * delta_ns).astype("timedelta64[ns]")
+    restored = t0 + offsets
+    return xr.DataArray(
+        restored,
+        dims=time.dims,
+        coords={cname: c for cname, c in time.coords.items() if cname != time.name},
+        name=time.name,
+        attrs={},
+    )
 
 
 def encode_time_cyclical(
-    ds: xr.Dataset,
+    time: xr.DataArray,
+    *,
     components: Sequence[str] = ("dayofyear", "hour"),
-    time: str = "time",
 ) -> xr.Dataset:
-    """Attach sin/cos encodings of datetime components as new variables.
+    """Sin/cos encodings of datetime components as a Dataset of new variables.
 
     For each ``component`` in ``components`` (any name accepted by
-    xarray's ``.dt`` accessor), two coordinates are added:
-    ``{component}_sin`` and ``{component}_cos``.
+    xarray's ``.dt`` accessor), two variables are produced:
+    ``{component}_sin`` and ``{component}_cos``. The Layer-1
+    ``EncodeTimeCyclical`` operator merges these into the input Dataset
+    as new coordinates.
 
     Args:
-        ds: Input dataset with a ``time`` coordinate.
+        time: Time coordinate / variable.
         components: Iterable of datetime attributes to encode.
-        time: Name of the time coordinate.
 
     Returns:
-        Dataset with the requested encodings attached.
+        Dataset whose data variables are the requested sin/cos pairs,
+        each carrying the same dims as ``time``.
     """
     periods = {
         "dayofyear": 366.0,
@@ -105,36 +126,50 @@ def encode_time_cyclical(
         "second": 60.0,
         "weekday": 7.0,
     }
-    ds = ds.copy()
+    out_vars: dict[str, xr.DataArray] = {}
     for name in components:
         if name not in periods:
             raise ValueError(
                 f"Unknown time component {name!r}; known: {sorted(periods)}."
             )
-        values = getattr(ds[time].dt, name).values.astype(float)
+        values = getattr(time.dt, name).values.astype(float)
         sin, cos = cyclical_encode(values, period=periods[name])
-        ds = ds.assign_coords({f"{name}_sin": (time, sin), f"{name}_cos": (time, cos)})
-    return ds
+        out_vars[f"{name}_sin"] = xr.DataArray(sin, dims=time.dims)
+        out_vars[f"{name}_cos"] = xr.DataArray(cos, dims=time.dims)
+    return xr.Dataset(out_vars)
 
 
 def encode_time_ordinal(
-    ds: xr.Dataset,
+    time: xr.DataArray,
+    *,
     reference_date: str | np.datetime64 | None = None,
-    time: str = "time",
     unit: str = "D",
-) -> xr.Dataset:
-    """Attach an ordinal float-day encoding of the time coordinate.
+) -> xr.DataArray:
+    """Ordinal float encoding of a time coordinate.
 
-    Adds a ``{time}_ordinal`` coord to ``ds``.
+    Args:
+        time: Time coordinate / variable.
+        reference_date: Reference time. Defaults to ``time.min()``.
+        unit: Pandas timedelta unit used to scale the offset.
+
+    Returns:
+        DataArray of ordinal floats with the same dims as ``time``.
+        The Layer-1 ``EncodeTimeOrdinal`` operator attaches this as a
+        ``{time.name}_ordinal`` coordinate on the input Dataset.
     """
     ref = (
-        np.datetime64(ds[time].min().values)
+        np.datetime64(time.min().values)
         if reference_date is None
         else np.datetime64(reference_date)
     )
     delta = pd.Timedelta(1, unit=unit)
-    ordinal = ((ds[time].values - ref) / delta).astype(np.float64)
-    return ds.assign_coords({f"{time}_ordinal": (time, ordinal)})
+    ordinal = ((time.values - ref) / delta).astype(np.float64)
+    return xr.DataArray(
+        ordinal,
+        dims=time.dims,
+        coords={cname: c for cname, c in time.coords.items() if cname != time.name},
+        name=f"{time.name}_ordinal" if time.name is not None else "time_ordinal",
+    )
 
 
 __all__ = [

--- a/src/xrtoolz/transforms/_src/encoders/coord_time.py
+++ b/src/xrtoolz/transforms/_src/encoders/coord_time.py
@@ -134,9 +134,11 @@ def encode_time_cyclical(
             )
         values = getattr(time.dt, name).values.astype(float)
         sin, cos = cyclical_encode(values, period=periods[name])
-        out_vars[f"{name}_sin"] = xr.DataArray(sin, dims=time.dims)
-        out_vars[f"{name}_cos"] = xr.DataArray(cos, dims=time.dims)
-    return xr.Dataset(out_vars)
+        out_vars[f"{name}_sin"] = xr.DataArray(sin, dims=time.dims, coords=time.coords)
+        out_vars[f"{name}_cos"] = xr.DataArray(cos, dims=time.dims, coords=time.coords)
+    # Carry the source time coords on the output Dataset so direct
+    # callers can still do label-based selection / alignment.
+    return xr.Dataset(out_vars, coords=time.coords)
 
 
 def encode_time_ordinal(
@@ -164,10 +166,12 @@ def encode_time_ordinal(
     )
     delta = pd.Timedelta(1, unit=unit)
     ordinal = ((time.values - ref) / delta).astype(np.float64)
+    # Keep every input coord (including the source timestamp coord at
+    # ``time.name``) so direct callers can still ``out.sel(time=...)``.
     return xr.DataArray(
         ordinal,
         dims=time.dims,
-        coords={cname: c for cname, c in time.coords.items() if cname != time.name},
+        coords=time.coords,
         name=f"{time.name}_ordinal" if time.name is not None else "time_ordinal",
     )
 

--- a/src/xrtoolz/transforms/_src/fourier.py
+++ b/src/xrtoolz/transforms/_src/fourier.py
@@ -479,10 +479,9 @@ def coherence(
 
 
 def rotary_spectrum(
-    ds: xr.Dataset,
+    u: xr.DataArray,
+    v: xr.DataArray,
     *,
-    u_var: str,
-    v_var: str,
     dim: str,
     avg_dims: str | Sequence[str] | None = None,
 ) -> xr.Dataset:
@@ -496,9 +495,8 @@ def rotary_spectrum(
     Polarization is NaN where total rotary power is negligible.
 
     Args:
-        ds: Dataset containing horizontal velocity components.
-        u_var: Zonal/eastward velocity variable.
-        v_var: Meridional/northward velocity variable.
+        u: Zonal/eastward velocity DataArray.
+        v: Meridional/northward velocity DataArray on the same grid as ``u``.
         dim: Dimension to Fourier transform.
         avg_dims: Optional dimension or dimensions to average in each output.
 
@@ -506,22 +504,21 @@ def rotary_spectrum(
         Dataset with ``psd_ccw``, ``psd_cw``, and ``polarization`` where
         ``polarization = (psd_cw - psd_ccw) / (psd_cw + psd_ccw)``.
     """
-    if dim not in ds[u_var].dims or dim not in ds[v_var].dims:
+    if dim not in u.dims or dim not in v.dims:
         raise ValueError(
-            f"dim={dim!r} must be present on both {u_var!r} and {v_var!r}."
+            f"dim={dim!r} must be present on both u (dims={u.dims}) and "
+            f"v (dims={v.dims})."
         )
 
-    w = ds[u_var] + 1j * ds[v_var]
+    w = u + 1j * v
     # Rectangular window + mean-only detrending keeps the dx / n density scaling
     # Parseval-consistent for variance.
     spec = xrft.fft(w, dim=[dim], window=None, detrend="constant", true_amplitude=False)
     freq_dim = f"freq_{dim}"
-    # Datasets can legally have dims without explicit coord variables;
+    # DataArrays can legally have dims without explicit coord variables;
     # fall back to unit spacing in that case rather than KeyError-ing.
-    coord = ds[dim] if dim in ds.coords else None
-    density_scale = (_coord_spacing(coord) if coord is not None else 1.0) / ds.sizes[
-        dim
-    ]
+    coord = u[dim] if dim in u.coords else None
+    density_scale = (_coord_spacing(coord) if coord is not None else 1.0) / u.sizes[dim]
     psd = (np.abs(spec) ** 2) * density_scale
 
     psd_ccw = psd.where(psd[freq_dim] > 0.0, drop=True).rename({freq_dim: "wavenumber"})

--- a/src/xrtoolz/transforms/operators.py
+++ b/src/xrtoolz/transforms/operators.py
@@ -591,9 +591,16 @@ class EncodeTimeCyclical(Operator):
         self.time = time
 
     def _apply(self, ds: xr.Dataset) -> xr.Dataset:
-        return _coord_time.encode_time_cyclical(
-            ds, components=self.components, time=self.time
+        encoded = _coord_time.encode_time_cyclical(
+            ds[self.time], components=self.components
         )
+        # The primitive returns a Dataset of sin/cos variables on the
+        # time dim; attach them as coords on the original Dataset to
+        # preserve the prior (pre-flip) ``encode_time_cyclical`` shape.
+        new_coords = {
+            name: (self.time, da.values) for name, da in encoded.data_vars.items()
+        }
+        return ds.assign_coords(new_coords)
 
     def get_config(self) -> dict[str, Any]:
         return {"components": list(self.components), "time": self.time}
@@ -613,12 +620,12 @@ class EncodeTimeOrdinal(Operator):
         self.unit = unit
 
     def _apply(self, ds: xr.Dataset) -> xr.Dataset:
-        return _coord_time.encode_time_ordinal(
-            ds,
+        ordinal = _coord_time.encode_time_ordinal(
+            ds[self.time],
             reference_date=self.reference_date,
-            time=self.time,
             unit=self.unit,
         )
+        return ds.assign_coords({f"{self.time}_ordinal": (self.time, ordinal.values)})
 
     def get_config(self) -> dict[str, Any]:
         return {
@@ -644,13 +651,15 @@ class TimeRescale(Operator):
         self.time = time
 
     def _apply(self, ds: xr.Dataset) -> xr.Dataset:
-        return _coord_time.time_rescale(
-            ds,
+        rescaled = _coord_time.time_rescale(
+            ds[self.time],
             freq_dt=self.freq_dt,
             freq_unit=self.freq_unit,
             t0=self.t0,
-            time=self.time,
         )
+        ds = ds.assign_coords({self.time: rescaled.values})
+        ds[self.time].attrs.update(dict(rescaled.attrs))
+        return ds
 
     def get_config(self) -> dict[str, Any]:
         return {
@@ -668,7 +677,10 @@ class TimeUnrescale(Operator):
         self.time = time
 
     def _apply(self, ds: xr.Dataset) -> xr.Dataset:
-        return _coord_time.time_unrescale(ds, time=self.time)
+        restored = _coord_time.time_unrescale(ds[self.time])
+        ds = ds.assign_coords({self.time: restored.values})
+        ds[self.time].attrs = {}
+        return ds
 
     def get_config(self) -> dict[str, Any]:
         return {"time": self.time}

--- a/src/xrtoolz/transforms/operators.py
+++ b/src/xrtoolz/transforms/operators.py
@@ -276,6 +276,56 @@ class EnstrophySpectralFlux(Operator):
         }
 
 
+class RotarySpectrum(Operator):
+    """Rotary power spectrum from ``ds[u]`` / ``ds[v]`` along ``dim``.
+
+    The operator selects the named velocity variables from the input
+    Dataset and calls :func:`rotary_spectrum` on the resulting
+    DataArrays.
+
+    Args:
+        u: Name of the zonal velocity variable in the input Dataset.
+        v: Name of the meridional velocity variable in the input Dataset.
+        dim: Dimension to Fourier transform.
+        avg_dims: Optional dimension or dimensions to average in each
+            output.
+    """
+
+    def __init__(
+        self,
+        u: str,
+        v: str,
+        dim: str,
+        *,
+        avg_dims: str | Sequence[str] | None = None,
+    ) -> None:
+        self.u = u
+        self.v = v
+        self.dim = dim
+        self.avg_dims = avg_dims
+
+    def _apply(self, ds: xr.Dataset) -> xr.Dataset:
+        return _fourier.rotary_spectrum(
+            ds[self.u],
+            ds[self.v],
+            dim=self.dim,
+            avg_dims=self.avg_dims,
+        )
+
+    def get_config(self) -> dict[str, Any]:
+        avg_dims = (
+            list(self.avg_dims)
+            if self.avg_dims is not None and not isinstance(self.avg_dims, str)
+            else self.avg_dims
+        )
+        return {
+            "u": self.u,
+            "v": self.v,
+            "dim": self.dim,
+            "avg_dims": avg_dims,
+        }
+
+
 class STFT(Operator):
     """Short-time Fourier transform of ``ds[variable]`` along ``dim``."""
 
@@ -702,6 +752,7 @@ __all__ = [
     "PositionalEncoding",
     "PowerSpectrum",
     "RandomFourierFeatures",
+    "RotarySpectrum",
     "TimeRescale",
     "TimeUnrescale",
 ]

--- a/src/xrtoolz/transforms/operators.py
+++ b/src/xrtoolz/transforms/operators.py
@@ -644,13 +644,11 @@ class EncodeTimeCyclical(Operator):
         encoded = _coord_time.encode_time_cyclical(
             ds[self.time], components=self.components
         )
-        # The primitive returns a Dataset of sin/cos variables on the
-        # time dim; attach them as coords on the original Dataset to
-        # preserve the prior (pre-flip) ``encode_time_cyclical`` shape.
-        new_coords = {
-            name: (self.time, da.values) for name, da in encoded.data_vars.items()
-        }
-        return ds.assign_coords(new_coords)
+        # The primitive returns a Dataset of sin/cos DataArrays carrying
+        # ``ds[self.time].dims``; pass them through as DataArrays so
+        # ``assign_coords`` reads their dims directly (this handles
+        # multi-dim / auxiliary time coords too).
+        return ds.assign_coords({name: encoded[name] for name in encoded.data_vars})
 
     def get_config(self) -> dict[str, Any]:
         return {"components": list(self.components), "time": self.time}
@@ -675,7 +673,10 @@ class EncodeTimeOrdinal(Operator):
             reference_date=self.reference_date,
             unit=self.unit,
         )
-        return ds.assign_coords({f"{self.time}_ordinal": (self.time, ordinal.values)})
+        # Pass the DataArray directly so its dims (which may be
+        # multi-dim or auxiliary) are honoured rather than hardcoding
+        # ``(self.time,)``.
+        return ds.assign_coords({f"{self.time}_ordinal": ordinal})
 
     def get_config(self) -> dict[str, Any]:
         return {
@@ -707,7 +708,11 @@ class TimeRescale(Operator):
             freq_unit=self.freq_unit,
             t0=self.t0,
         )
-        ds = ds.assign_coords({self.time: rescaled.values})
+        # Replace the time coord values while keeping its existing dims —
+        # ``ds[self.time].dims`` covers the 1-D dimension-coord case as
+        # well as multi-dim / auxiliary time variables.
+        time_dims = ds[self.time].dims
+        ds = ds.assign_coords({self.time: (time_dims, rescaled.values)})
         ds[self.time].attrs.update(dict(rescaled.attrs))
         return ds
 
@@ -728,7 +733,11 @@ class TimeUnrescale(Operator):
 
     def _apply(self, ds: xr.Dataset) -> xr.Dataset:
         restored = _coord_time.time_unrescale(ds[self.time])
-        ds = ds.assign_coords({self.time: restored.values})
+        # Preserve the original time variable's dimensionality (handles
+        # multi-dim / auxiliary time coords) rather than hardcoding
+        # ``(self.time,)``.
+        time_dims = ds[self.time].dims
+        ds = ds.assign_coords({self.time: (time_dims, restored.values)})
         ds[self.time].attrs = {}
         return ds
 

--- a/tests/test_geo_along_track.py
+++ b/tests/test_geo_along_track.py
@@ -46,14 +46,14 @@ def test_bandpass_wavelength_translates_cutoffs(monkeypatch):
     monkeypatch.setattr(along_track, "fir_filter", fake_fir_filter)
 
     out = along_track.bandpass_wavelength(
-        ds,
+        ds["sla"],
         dim="num_lines",
         lambda_min_km=20.0,
         lambda_max_km=100.0,
         spacing_km=5.0,
     )
 
-    assert isinstance(out, type(ds))
+    assert isinstance(out, xr.DataArray)
     assert calls["btype"] == "bandpass"
     assert calls["cutoff"] == pytest.approx((0.1, 0.5))
 
@@ -64,10 +64,10 @@ def test_bandpass_wavelength_lambda_min_only_is_low_pass(monkeypatch):
     ds = _track_dataset()
     calls: dict[str, object] = {}
     monkeypatch.setattr(
-        along_track, "fir_filter", lambda ds, **k: (calls.update(k), ds)[1]
+        along_track, "fir_filter", lambda da, **k: (calls.update(k), da)[1]
     )
     along_track.bandpass_wavelength(
-        ds, dim="num_lines", lambda_min_km=20.0, spacing_km=5.0
+        ds["sla"], dim="num_lines", lambda_min_km=20.0, spacing_km=5.0
     )
     assert calls["btype"] == "low"
     assert calls["cutoff"] == pytest.approx(0.5)
@@ -79,10 +79,10 @@ def test_bandpass_wavelength_lambda_max_only_is_high_pass(monkeypatch):
     ds = _track_dataset()
     calls: dict[str, object] = {}
     monkeypatch.setattr(
-        along_track, "fir_filter", lambda ds, **k: (calls.update(k), ds)[1]
+        along_track, "fir_filter", lambda da, **k: (calls.update(k), da)[1]
     )
     along_track.bandpass_wavelength(
-        ds, dim="num_lines", lambda_max_km=100.0, spacing_km=5.0
+        ds["sla"], dim="num_lines", lambda_max_km=100.0, spacing_km=5.0
     )
     assert calls["btype"] == "high"
     assert calls["cutoff"] == pytest.approx(0.1)
@@ -90,7 +90,11 @@ def test_bandpass_wavelength_lambda_max_only_is_high_pass(monkeypatch):
 
 def test_bandpass_wavelength_raises_on_multidim_lon_lat_without_spacing():
     """Multi-track / 2-D coords would mix endpoints in the median, so
-    spacing inference must refuse and ask for ``spacing_km`` explicitly."""
+    spacing inference must refuse and ask for ``spacing_km`` explicitly.
+
+    Exercised at the Operator boundary now — the operator looks up the
+    lon/lat DataArrays from the Dataset before calling the primitive.
+    """
     n = 16
     ds = xr.Dataset(
         {"sla": (("track", "num_lines"), np.zeros((2, n)))},
@@ -102,18 +106,30 @@ def test_bandpass_wavelength_raises_on_multidim_lon_lat_without_spacing():
         },
     )
     with pytest.raises(ValueError, match="not 1-D along"):
-        bandpass_wavelength(ds, dim="num_lines", lambda_min_km=20.0)
+        BandpassWavelength(dim="num_lines", lambda_min_km=20.0)(ds)
 
 
-def test_bandpass_wavelength_raises_on_misspelled_dim_with_explicit_spacing():
-    """Regression: a misspelled ``dim`` used to silently pass every variable
-    through after the PR β primitive flip (every var lacked the bad dim so
-    the loop continued); now it raises like the original Dataset-flavoured
-    ``fir_filter`` did."""
+def test_bandpass_wavelength_operator_raises_on_misspelled_dim():
+    """Regression: a misspelled ``dim`` used to silently pass every
+    variable through after the PR β primitive flip. With PR γ the
+    primitive is DataArray-only, but the Operator still enforces the
+    Dataset dim check so callers get a clear failure rather than a
+    no-op pass-through."""
     ds = _track_dataset()
     with pytest.raises(ValueError, match="not in Dataset dims"):
+        BandpassWavelength(
+            dim="num_linez",  # typo
+            lambda_min_km=20.0,
+            spacing_km=5.0,
+        )(ds)
+
+
+def test_bandpass_wavelength_primitive_raises_on_misspelled_dim():
+    """The DataArray-only primitive also raises on a missing ``dim``."""
+    ds = _track_dataset()
+    with pytest.raises(ValueError, match="not in DataArray dims"):
         bandpass_wavelength(
-            ds,
+            ds["sla"],
             dim="num_linez",  # typo
             lambda_min_km=20.0,
             spacing_km=5.0,
@@ -124,7 +140,7 @@ def test_bandpass_wavelength_raises_below_nyquist():
     ds = _track_dataset()
     with pytest.raises(ValueError, match="Nyquist"):
         bandpass_wavelength(
-            ds,
+            ds["sla"],
             dim="num_lines",
             lambda_min_km=8.0,
             spacing_km=5.0,
@@ -134,10 +150,10 @@ def test_bandpass_wavelength_raises_below_nyquist():
 def test_bandpass_wavelength_validates_bounds():
     ds = _track_dataset()
     with pytest.raises(ValueError, match="at least one"):
-        bandpass_wavelength(ds, dim="num_lines", spacing_km=5.0)
+        bandpass_wavelength(ds["sla"], dim="num_lines", spacing_km=5.0)
     with pytest.raises(ValueError, match="lambda_min_km must be <"):
         bandpass_wavelength(
-            ds,
+            ds["sla"],
             dim="num_lines",
             lambda_min_km=100.0,
             lambda_max_km=20.0,
@@ -145,20 +161,49 @@ def test_bandpass_wavelength_validates_bounds():
         )
 
 
-def test_bandpass_wavelength_passes_through_non_numeric_and_no_dim():
+def test_bandpass_wavelength_operator_passes_through_non_numeric_and_no_dim():
+    """The Dataset pass-through / per-variable loop now lives on the
+    Operator wrapper. Non-numeric variables and variables that don't
+    carry the filter dim pass through unchanged."""
     ds = _track_dataset()
-    out = bandpass_wavelength(
-        ds,
+    out = BandpassWavelength(
         dim="num_lines",
         lambda_min_km=20.0,
         lambda_max_km=100.0,
         spacing_km=5.0,
         num_taps=15,
-    )
+    )(ds)
 
     np.testing.assert_array_equal(out["label"].values, ds["label"].values)
     assert float(out["static"]) == 1.0
     assert out["sla"].shape == ds["sla"].shape
+
+
+def test_bandpass_wavelength_primitive_infers_spacing_from_dataarrays():
+    """Regression: the DataArray-positional primitive accepts lon/lat
+    DataArrays for spacing inference (previously it received variable-name
+    strings)."""
+    n = 64
+    x = np.arange(n)
+    da = xr.DataArray(
+        np.sin(2 * np.pi * x / 16),
+        dims=("num_lines",),
+        coords={
+            "num_lines": x,
+            "lon": (("num_lines",), 0.05 * x),
+            "lat": (("num_lines",), np.zeros(n)),
+        },
+        name="sla",
+    )
+    out = bandpass_wavelength(
+        da,
+        dim="num_lines",
+        lambda_min_km=20.0,
+        lon=da.coords["lon"],
+        lat=da.coords["lat"],
+        num_taps=15,
+    )
+    assert out.shape == da.shape
 
 
 def test_bandpass_wavelength_operator_config_round_trip():
@@ -187,7 +232,9 @@ def test_bandpass_wavelength_operator_config_round_trip():
     assert BandpassWavelength(**cfg).get_config() == cfg
 
 
-def test_bandpass_wavelength_default_lon_lat_lookup():
+def test_bandpass_wavelength_operator_default_lon_lat_lookup():
+    """The ``BandpassWavelength`` operator resolves ``lon`` / ``lat``
+    variable names from the Dataset before calling the primitive."""
     n = 64
     x = np.arange(n)
     ds = xr.Dataset(
@@ -198,10 +245,9 @@ def test_bandpass_wavelength_default_lon_lat_lookup():
             "lat": (("num_lines",), np.zeros(n)),
         },
     )
-    out = bandpass_wavelength(
-        ds,
+    out = BandpassWavelength(
         dim="num_lines",
         lambda_min_km=20.0,
         num_taps=15,
-    )
+    )(ds)
     assert out["sla"].shape == ds["sla"].shape

--- a/tests/test_geo_extended.py
+++ b/tests/test_geo_extended.py
@@ -487,20 +487,20 @@ def test_positional_encoding_includes_input_by_default():
 
 
 def test_time_rescale_round_trip(ds_grid_daily):
-    rescaled = time_rescale(ds_grid_daily, freq_dt=1, freq_unit="D")
-    assert np.issubdtype(rescaled.time.dtype, np.floating)
+    rescaled = time_rescale(ds_grid_daily["time"], freq_dt=1, freq_unit="D")
+    assert np.issubdtype(rescaled.dtype, np.floating)
     restored = time_unrescale(rescaled)
     # Daily cadence with the min as t0 -> restored times equal the originals.
     np.testing.assert_array_equal(
-        restored.time.values.astype("datetime64[ns]"),
+        restored.values.astype("datetime64[ns]"),
         ds_grid_daily.time.values.astype("datetime64[ns]"),
     )
 
 
 def test_encode_time_cyclical_adds_paired_coords(ds_grid_daily):
-    out = encode_time_cyclical(ds_grid_daily, components=["dayofyear"])
-    assert "dayofyear_sin" in out.coords
-    assert "dayofyear_cos" in out.coords
+    out = encode_time_cyclical(ds_grid_daily["time"], components=["dayofyear"])
+    assert "dayofyear_sin" in out.data_vars
+    assert "dayofyear_cos" in out.data_vars
     np.testing.assert_allclose(
         out["dayofyear_sin"].values ** 2 + out["dayofyear_cos"].values ** 2,
         np.ones(ds_grid_daily.sizes["time"]),
@@ -509,8 +509,8 @@ def test_encode_time_cyclical_adds_paired_coords(ds_grid_daily):
 
 
 def test_encode_time_ordinal_is_monotone(ds_grid_daily):
-    out = encode_time_ordinal(ds_grid_daily)
-    values = out["time_ordinal"].values
+    out = encode_time_ordinal(ds_grid_daily["time"])
+    values = out.values
     assert (np.diff(values) > 0).all()
 
 

--- a/tests/test_interpolate_coord_remap.py
+++ b/tests/test_interpolate_coord_remap.py
@@ -127,18 +127,18 @@ def ds_profile():
 def test_tier_b_remap_axis_replaces_dim(ds_profile):
     new_z = np.linspace(0.0, 100.0, 11)
     out = remap_axis(
-        ds_profile,
+        ds_profile["T"],
         source_dim="depth",
         target_coords=new_z,
     )
     assert "depth" in out.dims
     assert out.sizes["depth"] == 11
-    np.testing.assert_allclose(out["T"].values[:, 0], 20.0 - 0.1 * new_z)
+    np.testing.assert_allclose(out.values[:, 0], 20.0 - 0.1 * new_z)
 
 
 def test_tier_b_remap_axis_renames_via_target_name(ds_profile):
     out = remap_axis(
-        ds_profile,
+        ds_profile["T"],
         source_dim="depth",
         target_coords=np.linspace(0.0, 100.0, 11),
         target_name="z_new",
@@ -149,13 +149,17 @@ def test_tier_b_remap_axis_renames_via_target_name(ds_profile):
 
 def test_tier_b_remap_axis_uses_dataarray_name(ds_profile):
     target = xr.DataArray(np.linspace(0.0, 100.0, 11), dims=("z2",), name="z2")
-    out = remap_axis(ds_profile, source_dim="depth", target_coords=target)
+    out = remap_axis(ds_profile["T"], source_dim="depth", target_coords=target)
     assert "z2" in out.dims
 
 
 def test_tier_b_unknown_source_dim_raises(ds_profile):
     with pytest.raises(ValueError):
-        remap_axis(ds_profile, source_dim="bogus", target_coords=np.array([0.0, 1.0]))
+        remap_axis(
+            ds_profile["T"],
+            source_dim="bogus",
+            target_coords=np.array([0.0, 1.0]),
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -170,23 +174,25 @@ def test_to_phase_recovers_diurnal_sinusoid():
     n_per_day = 48  # half-hourly
     t = np.arange(n_days * n_per_day) * (period / n_per_day)
     signal = np.sin(2 * np.pi * t / period)
-    ds = xr.Dataset({"x": (("time",), signal)}, coords={"time": t})
-    out = to_phase(ds, time_dim="time", period=period, n_bins=24)
+    da = xr.DataArray(signal, dims=("time",), coords={"time": t}, name="x")
+    out = to_phase(da, time_dim="time", period=period, n_bins=24)
 
     assert out.sizes["phase"] == 24
     phases = out["phase"].values
     expected = np.sin(2 * np.pi * phases)
-    np.testing.assert_allclose(out["x"].values, expected, atol=0.05)
+    np.testing.assert_allclose(out.values, expected, atol=0.05)
 
 
 def test_to_phase_invalid_args_raise():
-    ds = xr.Dataset({"x": (("time",), np.zeros(10))}, coords={"time": np.arange(10)})
+    da = xr.DataArray(
+        np.zeros(10), dims=("time",), coords={"time": np.arange(10)}, name="x"
+    )
     with pytest.raises(ValueError):
-        to_phase(ds, time_dim="time", period=0.0, n_bins=8)
+        to_phase(da, time_dim="time", period=0.0, n_bins=8)
     with pytest.raises(ValueError):
-        to_phase(ds, time_dim="time", period=1.0, n_bins=0)
+        to_phase(da, time_dim="time", period=1.0, n_bins=0)
     with pytest.raises(ValueError):
-        to_phase(ds, time_dim="bogus", period=1.0, n_bins=8)
+        to_phase(da, time_dim="bogus", period=1.0, n_bins=8)
 
 
 # ---------------------------------------------------------------------------
@@ -240,7 +246,7 @@ def test_remap_axis_operator_matches_function(ds_profile):
     op = RemapAxis("depth", new_z)
     np.testing.assert_allclose(
         op(ds_profile)["T"].values,
-        remap_axis(ds_profile, source_dim="depth", target_coords=new_z)["T"].values,
+        remap_axis(ds_profile["T"], source_dim="depth", target_coords=new_z).values,
     )
 
 
@@ -252,7 +258,7 @@ def test_to_phase_operator_matches_function():
     op = ToPhase("time", period=period, n_bins=12)
     np.testing.assert_allclose(
         op(ds)["x"].values,
-        to_phase(ds, time_dim="time", period=period, n_bins=12)["x"].values,
+        to_phase(ds["x"], time_dim="time", period=period, n_bins=12).values,
     )
 
 
@@ -276,8 +282,12 @@ def test_vertical_presets_default_dim_names():
     assert "height" in out_h.dims
 
 
-def test_remap_axis_rejects_non_numeric_var_with_source_dim():
-    """A non-numeric variable carrying source_dim must raise (review feedback)."""
+def test_remap_axis_operator_rejects_non_numeric_var_with_source_dim():
+    """A non-numeric variable carrying source_dim must raise at the operator boundary.
+
+    After the PR γ primitive flip, the Dataset loop / non-numeric guard
+    lives on ``RemapAxis._apply``; the primitive itself is DataArray-only.
+    """
     z = np.linspace(0.0, 100.0, 5)
     ds = xr.Dataset(
         {
@@ -286,15 +296,12 @@ def test_remap_axis_rejects_non_numeric_var_with_source_dim():
         },
         coords={"depth": z},
     )
+    op = RemapAxis("depth", np.linspace(0.0, 100.0, 11))
     with pytest.raises(TypeError, match="non-numeric"):
-        remap_axis(
-            ds,
-            source_dim="depth",
-            target_coords=np.linspace(0.0, 100.0, 11),
-        )
+        op(ds)
 
 
-def test_remap_axis_passes_through_non_dim_non_numeric_var():
+def test_remap_axis_operator_passes_through_non_dim_non_numeric_var():
     z = np.linspace(0.0, 100.0, 5)
     ds = xr.Dataset(
         {
@@ -303,18 +310,20 @@ def test_remap_axis_passes_through_non_dim_non_numeric_var():
         },
         coords={"depth": z},
     )
-    out = remap_axis(ds, source_dim="depth", target_coords=np.linspace(0.0, 100.0, 11))
+    op = RemapAxis("depth", np.linspace(0.0, 100.0, 11))
+    out = op(ds)
     assert str(out["label"].values) == "site_42"
 
 
-def test_to_phase_requires_time_coord():
-    """Dataset must carry a coordinate named time_dim, not just a dimension."""
-    ds = xr.Dataset({"x": (("time",), np.zeros(10))})  # time has no coord
+def test_to_phase_primitive_requires_time_coord():
+    """DataArray must carry a coordinate named time_dim, not just a dimension."""
+    da = xr.DataArray(np.zeros(10), dims=("time",), name="x")  # no time coord
     with pytest.raises(ValueError, match="coordinate named"):
-        to_phase(ds, time_dim="time", period=1.0, n_bins=8)
+        to_phase(da, time_dim="time", period=1.0, n_bins=8)
 
 
-def test_to_phase_rejects_non_numeric_var_with_time_dim():
+def test_to_phase_operator_rejects_non_numeric_var_with_time_dim():
+    """Operator boundary handles non-numeric Dataset variables after the flip."""
     t = np.arange(10, dtype=float)
     ds = xr.Dataset(
         {
@@ -323,8 +332,9 @@ def test_to_phase_rejects_non_numeric_var_with_time_dim():
         },
         coords={"time": t},
     )
+    op = ToPhase("time", period=1.0, n_bins=8)
     with pytest.raises(TypeError, match="non-numeric"):
-        to_phase(ds, time_dim="time", period=1.0, n_bins=8)
+        op(ds)
 
 
 def test_array_remap_preserves_complex_dtype():
@@ -375,12 +385,12 @@ def test_to_phase_preserves_complex_signal():
     n = n_per_period * 30
     t = np.arange(n, dtype=float) * (period / n_per_period)
     z = np.exp(1j * 2 * np.pi * t / period)
-    ds = xr.Dataset({"z": (("time",), z)}, coords={"time": t})
-    out = to_phase(ds, time_dim="time", period=period, n_bins=24)
-    assert np.iscomplexobj(out["z"].values)
+    da = xr.DataArray(z, dims=("time",), coords={"time": t}, name="z")
+    out = to_phase(da, time_dim="time", period=period, n_bins=24)
+    assert np.iscomplexobj(out.values)
     phases = out["phase"].values
     expected = np.exp(1j * 2 * np.pi * phases)
-    np.testing.assert_allclose(out["z"].values, expected, atol=0.05)
+    np.testing.assert_allclose(out.values, expected, atol=0.05)
 
 
 def test_to_phase_drops_nan_time_samples():
@@ -390,9 +400,9 @@ def test_to_phase_drops_nan_time_samples():
     # Bin 0 should average (10, 20); bin 1 (60, 70). The NaN-time sample
     # has value 1000 — if it leaked into a bin, the mean would explode.
     values = np.array([10.0, 20.0, 1000.0, 60.0, 70.0])
-    ds = xr.Dataset({"x": (("time",), values)}, coords={"time": t})
-    out = to_phase(ds, time_dim="time", period=period, n_bins=2)
-    np.testing.assert_allclose(out["x"].values, [15.0, 65.0])
+    da = xr.DataArray(values, dims=("time",), coords={"time": t}, name="x")
+    out = to_phase(da, time_dim="time", period=period, n_bins=2)
+    np.testing.assert_allclose(out.values, [15.0, 65.0])
 
 
 def test_remap_axis_get_config_is_serializable():

--- a/tests/test_interpolate_coord_remap.py
+++ b/tests/test_interpolate_coord_remap.py
@@ -405,6 +405,18 @@ def test_to_phase_drops_nan_time_samples():
     np.testing.assert_allclose(out.values, [15.0, 65.0])
 
 
+def test_to_phase_accepts_integer_dtype_input():
+    """Regression: ``to_phase`` used ``np.isnan`` for the finite check,
+    which raises ``TypeError`` on integer arrays. ``np.isfinite`` treats
+    integer dtypes as all-finite and is the documented contract."""
+    period = 1.0
+    t = np.array([0.1, 0.2, 0.6, 0.7])
+    values = np.array([10, 20, 60, 70], dtype=np.int64)
+    da = xr.DataArray(values, dims=("time",), coords={"time": t}, name="x")
+    out = to_phase(da, time_dim="time", period=period, n_bins=2)
+    np.testing.assert_allclose(out.values, [15.0, 65.0])
+
+
 def test_remap_axis_get_config_is_serializable():
     op = RemapAxis("depth", np.array([0.0, 50.0, 100.0]), target_name="z")
     cfg = op.get_config()

--- a/tests/test_tier_contract.py
+++ b/tests/test_tier_contract.py
@@ -264,7 +264,7 @@ def test_interpolate_coord_remap_tier_b_matches_tier_a() -> None:
         {"f": (("depth", "x"), field)},
         coords={"depth": src, "x": np.arange(4)},
     )
-    b_out = tier_b.remap_axis(ds, source_dim="depth", target_coords=tgt)["f"].values
+    b_out = tier_b.remap_axis(ds["f"], source_dim="depth", target_coords=tgt).values
     a_out = ia.remap_axis(field, axis=0, source_coords=src, target_coords=tgt)
     np.testing.assert_allclose(a_out, b_out)
 
@@ -284,5 +284,5 @@ def test_interpolate_coord_remap_tier_c_matches_tier_b() -> None:
     )
     np.testing.assert_allclose(
         RemapAxis("depth", tgt)(ds)["f"].values,
-        tier_b.remap_axis(ds, source_dim="depth", target_coords=tgt)["f"].values,
+        tier_b.remap_axis(ds["f"], source_dim="depth", target_coords=tgt).values,
     )

--- a/tests/transforms/test_encoder_operators.py
+++ b/tests/transforms/test_encoder_operators.py
@@ -17,7 +17,6 @@ from xrtoolz.transforms.encoders import (
     positional_encoding,
     random_fourier_features,
     time_rescale,
-    time_unrescale,
 )
 from xrtoolz.transforms.operators import (
     CyclicalEncode,
@@ -119,15 +118,20 @@ def test_positional_encoding_parity(ds_scalar: xr.Dataset) -> None:
 def test_encode_time_cyclical_parity(ds_time: xr.Dataset) -> None:
     op = EncodeTimeCyclical(components=("hour", "dayofyear"))
     out = op(ds_time)
-    expected = encode_time_cyclical(ds_time, components=("hour", "dayofyear"))
-    xr.testing.assert_identical(out, expected)
+    # After the PR γ flip the primitive returns a Dataset of the new
+    # sin/cos variables only; the operator attaches them as coords on
+    # the input Dataset. Check the values match what the primitive
+    # produced for each component.
+    encoded = encode_time_cyclical(ds_time["time"], components=("hour", "dayofyear"))
+    for name in ("hour_sin", "hour_cos", "dayofyear_sin", "dayofyear_cos"):
+        np.testing.assert_array_equal(out.coords[name].values, encoded[name].values)
 
 
 def test_encode_time_ordinal_parity(ds_time: xr.Dataset) -> None:
     op = EncodeTimeOrdinal(unit="h")
     out = op(ds_time)
-    expected = encode_time_ordinal(ds_time, unit="h")
-    xr.testing.assert_identical(out, expected)
+    expected = encode_time_ordinal(ds_time["time"], unit="h")
+    np.testing.assert_array_equal(out.coords["time_ordinal"].values, expected.values)
 
 
 def test_time_rescale_unrescale_round_trip(ds_time: xr.Dataset) -> None:
@@ -135,7 +139,7 @@ def test_time_rescale_unrescale_round_trip(ds_time: xr.Dataset) -> None:
     unrescale = TimeUnrescale()
     rescaled = rescale(ds_time)
     np.testing.assert_array_equal(
-        time_rescale(ds_time, freq_dt=6.0, freq_unit="h")["time"].values,
+        time_rescale(ds_time["time"], freq_dt=6.0, freq_unit="h").values,
         rescaled["time"].values,
     )
     restored = unrescale(rescaled)
@@ -143,9 +147,6 @@ def test_time_rescale_unrescale_round_trip(ds_time: xr.Dataset) -> None:
         restored["time"].astype("datetime64[ns]").astype(np.int64),
         ds_time["time"].astype("datetime64[ns]").astype(np.int64),
     )
-    # And via direct round-trip:
-    direct = time_unrescale(time_rescale(ds_time, freq_dt=6.0, freq_unit="h"))
-    xr.testing.assert_identical(restored, direct)
 
 
 # ---------- get_config ----------------------------------------------------

--- a/tests/transforms/test_encoder_operators.py
+++ b/tests/transforms/test_encoder_operators.py
@@ -134,6 +134,53 @@ def test_encode_time_ordinal_parity(ds_time: xr.Dataset) -> None:
     np.testing.assert_array_equal(out.coords["time_ordinal"].values, expected.values)
 
 
+def test_encode_time_cyclical_primitive_preserves_time_coord(
+    ds_time: xr.Dataset,
+) -> None:
+    """Regression: direct callers of the primitive must retain the source
+    time coord so label-based selection still works on the encoded
+    output."""
+    out = encode_time_cyclical(ds_time["time"], components=("hour",))
+    assert "time" in out.coords
+    np.testing.assert_array_equal(out.coords["time"].values, ds_time["time"].values)
+    # Each sin/cos DataArray inside the Dataset carries the time coord
+    # too, so ``.sel(time=...)`` works on individual variables.
+    assert "time" in out["hour_sin"].coords
+
+
+def test_encode_time_ordinal_primitive_preserves_time_coord(
+    ds_time: xr.Dataset,
+) -> None:
+    """Regression: ``encode_time_ordinal`` used to drop the source time
+    coord, breaking label-based alignment for direct callers."""
+    out = encode_time_ordinal(ds_time["time"], unit="h")
+    assert "time" in out.coords
+    np.testing.assert_array_equal(out.coords["time"].values, ds_time["time"].values)
+
+
+def test_encode_time_ordinal_operator_handles_aux_time_coord() -> None:
+    """Regression: when the time variable is an auxiliary 2-D coord (its
+    own ``dims`` is not just ``(self.time,)``), the operator must build
+    the output coord with the source variable's dims rather than
+    hardcoding ``(self.time,)``."""
+    # ``valid_time`` is a 2-D auxiliary coord on ``(forecast, lead)``;
+    # there is no top-level ``valid_time`` dimension.
+    forecast = np.array(["2020-01-01", "2020-01-02"], dtype="datetime64[ns]")
+    lead = pd.timedelta_range("0h", periods=3, freq="6h")
+    valid_time = forecast[:, None] + lead.to_numpy()[None, :]
+    ds = xr.Dataset(
+        {"x": (("forecast", "lead"), np.ones((2, 3)))},
+        coords={
+            "forecast": forecast,
+            "lead": lead,
+            "valid_time": (("forecast", "lead"), valid_time),
+        },
+    )
+    op = EncodeTimeOrdinal(time="valid_time", unit="h")
+    out = op(ds)
+    assert out.coords["valid_time_ordinal"].dims == ("forecast", "lead")
+
+
 def test_time_rescale_unrescale_round_trip(ds_time: xr.Dataset) -> None:
     rescale = TimeRescale(freq_dt=6.0, freq_unit="h")
     unrescale = TimeUnrescale()

--- a/tests/transforms/test_fourier.py
+++ b/tests/transforms/test_fourier.py
@@ -141,9 +141,8 @@ def _rotary_fixture(*, rotation_direction: float = 1.0) -> xr.Dataset:
 
 
 def test_rotary_spectrum_ccw_signal_peaks_positive_wavenumber():
-    out = rotary_spectrum(
-        _rotary_fixture(rotation_direction=1.0), u_var="u", v_var="v", dim="x"
-    )
+    ds = _rotary_fixture(rotation_direction=1.0)
+    out = rotary_spectrum(ds["u"], ds["v"], dim="x")
     k = 3.0 / 64.0
     assert float(out["psd_ccw"].idxmax("wavenumber")) == pytest.approx(k)
     assert float(out["psd_cw"].sel(wavenumber=k)) == pytest.approx(0.0, abs=1e-12)
@@ -151,9 +150,8 @@ def test_rotary_spectrum_ccw_signal_peaks_positive_wavenumber():
 
 
 def test_rotary_spectrum_cw_signal_has_positive_polarization():
-    out = rotary_spectrum(
-        _rotary_fixture(rotation_direction=-1.0), u_var="u", v_var="v", dim="x"
-    )
+    ds = _rotary_fixture(rotation_direction=-1.0)
+    out = rotary_spectrum(ds["u"], ds["v"], dim="x")
     k = 3.0 / 64.0
     assert float(out["psd_cw"].idxmax("wavenumber")) == pytest.approx(k)
     assert float(out["polarization"].sel(wavenumber=k)) == pytest.approx(1.0)
@@ -162,14 +160,14 @@ def test_rotary_spectrum_cw_signal_has_positive_polarization():
 def test_rotary_spectrum_real_only_signal_is_unpolarized():
     ds = _rotary_fixture(rotation_direction=1.0)
     ds["v"] = xr.zeros_like(ds["v"])
-    out = rotary_spectrum(ds, u_var="u", v_var="v", dim="x")
+    out = rotary_spectrum(ds["u"], ds["v"], dim="x")
     k = 3.0 / 64.0
     assert float(out["polarization"].sel(wavenumber=k)) == pytest.approx(0.0, abs=1e-12)
 
 
 def test_rotary_spectrum_parseval_matches_velocity_variance():
     ds = _rotary_fixture(rotation_direction=1.0)
-    out = rotary_spectrum(ds, u_var="u", v_var="v", dim="x")
+    out = rotary_spectrum(ds["u"], ds["v"], dim="x")
     dk = float(out["wavenumber"].diff("wavenumber").median())
     spectral_variance = float((out["psd_cw"] + out["psd_ccw"]).sum() * dk)
     component_variance = float(ds["u"].var("x") + ds["v"].var("x"))
@@ -180,7 +178,7 @@ def test_rotary_spectrum_avg_dims_reduce_outputs():
     ds = _rotary_fixture(rotation_direction=1.0).expand_dims(lat=[0.0, 1.0])
     ds["u"] = ds["u"] * xr.DataArray([1.0, 2.0], dims="lat", coords={"lat": ds["lat"]})
     ds["v"] = ds["v"] * xr.DataArray([1.0, 2.0], dims="lat", coords={"lat": ds["lat"]})
-    out = rotary_spectrum(ds, u_var="u", v_var="v", dim="x", avg_dims=("lat",))
+    out = rotary_spectrum(ds["u"], ds["v"], dim="x", avg_dims=("lat",))
     assert out["psd_ccw"].dims == ("wavenumber",)
     assert out["psd_cw"].dims == ("wavenumber",)
     assert out["polarization"].dims == ("wavenumber",)
@@ -198,7 +196,7 @@ def test_rotary_spectrum_handles_dim_without_explicit_coord():
         },
     )
     assert "x" not in ds.coords
-    out = rotary_spectrum(ds, u_var="u", v_var="v", dim="x")
+    out = rotary_spectrum(ds["u"], ds["v"], dim="x")
     assert out["psd_ccw"].dims == ("wavenumber",)
 
 
@@ -207,9 +205,21 @@ def test_rotary_spectrum_preserves_nyquist_bin_for_even_length_inputs():
     only; the outer-join on wavenumber must keep that bin so total
     rotary power is variance-consistent."""
     ds = _rotary_fixture(rotation_direction=1.0)
-    out = rotary_spectrum(ds, u_var="u", v_var="v", dim="x")
+    out = rotary_spectrum(ds["u"], ds["v"], dim="x")
     nyquist = 0.5 / 1.0  # spacing = 1
     assert nyquist in out["wavenumber"].values
+
+
+def test_rotary_spectrum_operator_matches_primitive():
+    """The new ``RotarySpectrum`` operator must match the primitive on
+    the same data, with the operator doing the Dataset selection."""
+    from xrtoolz.transforms.operators import RotarySpectrum
+
+    ds = _rotary_fixture(rotation_direction=1.0)
+    op_out = RotarySpectrum("u", "v", "x")(ds)
+    fn_out = rotary_spectrum(ds["u"], ds["v"], dim="x")
+    np.testing.assert_allclose(op_out["psd_ccw"].values, fn_out["psd_ccw"].values)
+    np.testing.assert_allclose(op_out["psd_cw"].values, fn_out["psd_cw"].values)
 
 
 def test_ke_spectral_flux_conserves_transfer(taylor_green_vortex_uv):


### PR DESCRIPTION
Final PR in the [`xarray-native-primitives`](docs/design/xarray-native-primitives.md) sequence — closes out the design. PRs α (#206) and β (#208) landed the DataTree dispatch and the metrics/interpolate primitive flip; this one finishes the remaining Dataset-flavoured primitives in `transforms` and the lone Dataset-flavoured `geo` helper.

## Summary

**Transforms primitives flipped** (`transforms/_src/`):
- `coord_remap.py`: `remap_axis(da, *, source_dim, target_coords, ...)` and `to_phase(da, *, time_dim, period, n_bins)` are DataArray-in / DataArray-out. The vertical-coord presets (`ToSigma`, `FromSigma`, `ToIsopycnal`, `ToPressureLevels`, `ToHeight`) inherit `RemapAxis._apply` and pick up the Dataset loop for free.
- `encoders/coord_time.py`: `time_rescale`, `time_unrescale`, `encode_time_ordinal` are DataArray-in / DataArray-out. `encode_time_cyclical` is DataArray-in / Dataset-out (multi-output primitive shape per the design doc's "structured multi-output" pattern).
- `fourier.py::rotary_spectrum(u, v, *, dim, avg_dims)` takes two velocity DataArrays positionally. A new Layer-1 `RotarySpectrum(u, v, dim)` Operator wraps it — it didn't exist before this PR.

**Geo primitive flipped** (`geo/_src/`):
- `along_track.py::bandpass_wavelength(da, *, dim, ..., lon, lat)` — single DataArray in, with `lon` / `lat` now optional `DataArray` ride-along inputs (used for WGS-84 spacing inference). The per-variable Dataset loop, non-numeric pass-through, and dim-validation now live on `BandpassWavelength._apply` in `geo/operators.py`.

## Stays untouched

- `transforms/_src/{dct,wavelet,morphology,decompose,sklearn_op}.py` — already DataArray-first or stateful (estimator-style).
- `transforms/_src/array_*.py` numpy kernels — pure ndarray, no flip needed.
- `transforms/_src/encoders/{basis,coord_space}.py` — pure numpy.

Every operator constructor signature is unchanged.

## Design doc

`docs/design/xarray-native-primitives.md` now marks the contract complete (`status: complete`, `version: 0.2.0`). The implementation-status note lists the PR γ modules and the deliberate non-flips.

## Test plan

- [x] 1,253 passing / 19 skipped / 3 failures — same pre-existing `scikit-image` optional-dep failures as PRs α and β. None are introduced by this PR.
- [x] `ruff check .` + `ruff format --check .` clean.
- [x] `ty check src/xrtoolz` — same baseline diagnostic count as `main`.
- [x] New regression: `tests/test_geo_along_track.py::test_bandpass_wavelength_primitive_infers_spacing_from_dataarrays` pins the new lon/lat-as-DataArray spacing inference path; the dim-misspelling and multidim-lon/lat error paths move to `BandpassWavelength` operator tests.

## Diff size

14 files changed, +656 / -359 (net +297). A meaningful share of the +297 is the new `RotarySpectrum` operator plus regression tests; the primitive flips themselves are mostly structural movement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)