### PR TITLE
feat(metrics): instance-segmentation matching + AP / F1

### DIFF
--- a/src/xrtoolz/metrics/__init__.py
+++ b/src/xrtoolz/metrics/__init__.py
@@ -26,6 +26,16 @@ from xrtoolz.metrics._src.distributional import (
 )
 from xrtoolz.metrics._src.dm import dm_test
 from xrtoolz.metrics._src.forecast import SkillByLeadTime, skill_by_lead_time
+from xrtoolz.metrics._src.instance import (
+    AveragePrecisionMatched,
+    InstanceF1AtIoU,
+    InstanceMatcher,
+    MaskIoU,
+    average_precision_matched,
+    instance_f1_at_iou,
+    mask_iou_matrix,
+    match_instances,
+)
 from xrtoolz.metrics._src.leaderboard import rank_methods
 from xrtoolz.metrics._src.masked import MaskedMetric, masked_metric
 from xrtoolz.metrics._src.multiscale import (
@@ -117,6 +127,7 @@ __all__ = [
     "NRMSE",
     "RMSE",
     "SSIM",
+    "AveragePrecisionMatched",
     "BandLimitedRMSE",
     "Bias",
     "BinnedResiduals2D",
@@ -130,6 +141,9 @@ __all__ = [
     "FrequencyBandSkill",
     "GeostrophicBalanceError",
     "GradientDifference",
+    "InstanceF1AtIoU",
+    "InstanceMatcher",
+    "MaskIoU",
     "MaskedMetric",
     "NRMSEScore",
     "PSDScore",
@@ -145,6 +159,7 @@ __all__ = [
     "Wasserstein1",
     "WaveletPSDScore",
     "along_track_psd_score",
+    "average_precision_matched",
     "band_limited_rmse",
     "bias",
     "bin_residuals_2d",
@@ -162,8 +177,11 @@ __all__ = [
     "find_intercept_2D",
     "geostrophic_balance_error",
     "gradient_difference",
+    "instance_f1_at_iou",
     "mae",
+    "mask_iou_matrix",
     "masked_metric",
+    "match_instances",
     "mse",
     "normalize_regions",
     "nrmse",

--- a/src/xrtoolz/metrics/_src/instance.py
+++ b/src/xrtoolz/metrics/_src/instance.py
@@ -1,0 +1,354 @@
+"""Instance-segmentation evaluation metrics.
+
+Greedy score-sorted matching of predicted instance masks to reference
+instance masks via mask-IoU, then VOC-style 11-point Average Precision
+plus instance-level precision / recall / F1. Adapted from
+Pérez Carrasco et al. (2026) — ``metrics_instance_segmentation``
+(``compute_overlaps_masks``, ``compute_matches``,
+``compute_ap_with_df_safe``).
+
+Inputs are mask stacks shaped ``(N, H, W)``. Predicted and reference
+stacks may carry different ``N`` (no constraint that a prediction exist
+for every reference, or vice versa). The matcher accepts an optional
+``scores`` array of length ``N_pred``; when omitted, predictions are
+ranked by mask area (largest first).
+
+These operators are **additive** — they do not overlap the
+``ProbabilityOfDetection`` / ``IntersectionOverUnion`` / etc. name
+reservations in :mod:`xrtoolz.metrics._src.object`, which remain
+``NotImplementedError`` stubs pending the V5 epic and a future detector /
+matcher framework.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import xarray as xr
+
+from xrtoolz._operator import Operator
+
+
+def _as_3d_bool(masks: xr.DataArray | np.ndarray, *, name: str) -> np.ndarray:
+    """Coerce a carrier to a 3-D boolean ``(N, H, W)`` ndarray."""
+    arr = np.asarray(masks)
+    if arr.ndim != 3:
+        raise ValueError(
+            f"{name} must be a (N, H, W) mask stack, got shape {arr.shape}"
+        )
+    return arr.astype(bool, copy=False)
+
+
+def mask_iou_matrix(
+    pred_masks: xr.DataArray | np.ndarray,
+    ref_masks: xr.DataArray | np.ndarray,
+) -> np.ndarray:
+    """Pairwise mask-IoU matrix between two ``(N, H, W)`` stacks.
+
+    Returns a dense ``(N_pred, N_ref)`` float matrix of mask
+    intersection-over-union values in ``[0, 1]``. Empty masks contribute
+    zero IoU.
+    """
+    pred = _as_3d_bool(pred_masks, name="pred_masks")
+    ref = _as_3d_bool(ref_masks, name="ref_masks")
+    if pred.shape[1:] != ref.shape[1:]:
+        raise ValueError(
+            f"pred/ref spatial shapes do not match: {pred.shape[1:]} vs {ref.shape[1:]}"
+        )
+    n_p, n_r = pred.shape[0], ref.shape[0]
+    if n_p == 0 or n_r == 0:
+        return np.zeros((n_p, n_r), dtype=np.float64)
+    flat_pred = pred.reshape(n_p, -1).astype(np.int64)
+    flat_ref = ref.reshape(n_r, -1).astype(np.int64)
+    # ``inter[i, j] = sum(pred_i AND ref_j)`` computed via boolean matmul
+    # over int64. For typical N ~ 1e2-1e3 and HW ~ 1e6 this is the cheap path.
+    inter = flat_pred @ flat_ref.T
+    area_p = flat_pred.sum(axis=1, keepdims=True)
+    area_r = flat_ref.sum(axis=1, keepdims=True).T
+    union = area_p + area_r - inter
+    with np.errstate(divide="ignore", invalid="ignore"):
+        iou = np.where(union > 0, inter / union, 0.0)
+    return iou.astype(np.float64, copy=False)
+
+
+def match_instances(
+    pred_masks: xr.DataArray | np.ndarray,
+    ref_masks: xr.DataArray | np.ndarray,
+    *,
+    scores: np.ndarray | None = None,
+    iou_threshold: float = 0.5,
+) -> dict[str, Any]:
+    """Greedy score-sorted matcher.
+
+    Predictions are sorted by score (descending; ties broken by input
+    order). Each prediction takes the best unmatched reference whose
+    mask-IoU clears ``iou_threshold``.
+
+    Returns a dict with:
+
+    - ``pred_match``: int array of length ``N_pred``; the matched
+      reference index or ``-1``.
+    - ``ref_match``: int array of length ``N_ref``; the matched
+      prediction index or ``-1``.
+    - ``ious``: full IoU matrix from :func:`mask_iou_matrix`.
+    - ``tp`` / ``fp`` / ``fn``: scalar counts.
+    """
+    if not 0.0 < iou_threshold <= 1.0:
+        raise ValueError("iou_threshold must be in (0, 1]")
+    ious = mask_iou_matrix(pred_masks, ref_masks)
+    n_p, n_r = ious.shape
+
+    if scores is None:
+        # Rank by area so the matcher is well-defined without external
+        # scores; the paper uses detector confidence here.
+        pred = _as_3d_bool(pred_masks, name="pred_masks")
+        rank_key = -pred.reshape(n_p, -1).sum(axis=1).astype(np.float64)
+    else:
+        scores_arr = np.asarray(scores, dtype=float)
+        if scores_arr.shape != (n_p,):
+            raise ValueError(
+                f"scores length {scores_arr.shape} does not match pred count ({n_p})"
+            )
+        rank_key = -scores_arr
+    order = np.argsort(rank_key, kind="stable")
+
+    pred_match = -np.ones(n_p, dtype=np.int64)
+    ref_match = -np.ones(n_r, dtype=np.int64)
+    for idx in order:
+        i = int(idx)
+        # Best reference for this prediction; the paper sorts references
+        # by IoU desc and walks until it hits one that clears the gate
+        # and is unmatched.
+        cand = np.argsort(-ious[i], kind="stable")
+        for jdx in cand:
+            j = int(jdx)
+            if ious[i, j] < iou_threshold:
+                break
+            if ref_match[j] != -1:
+                continue
+            pred_match[i] = j
+            ref_match[j] = i
+            break
+
+    tp = int((pred_match >= 0).sum())
+    fp = int((pred_match < 0).sum())
+    fn = int((ref_match < 0).sum())
+    return {
+        "pred_match": pred_match,
+        "ref_match": ref_match,
+        "ious": ious,
+        "tp": tp,
+        "fp": fp,
+        "fn": fn,
+    }
+
+
+def instance_f1_at_iou(
+    pred_masks: xr.DataArray | np.ndarray,
+    ref_masks: xr.DataArray | np.ndarray,
+    *,
+    scores: np.ndarray | None = None,
+    iou_threshold: float = 0.5,
+) -> dict[str, float]:
+    """Precision / recall / F1 from instance-level greedy matching at a
+    single IoU threshold."""
+    match = match_instances(
+        pred_masks, ref_masks, scores=scores, iou_threshold=iou_threshold
+    )
+    tp, fp, fn = match["tp"], match["fp"], match["fn"]
+    precision = tp / (tp + fp) if (tp + fp) > 0 else 0.0
+    recall = tp / (tp + fn) if (tp + fn) > 0 else 0.0
+    if precision + recall == 0:
+        f1 = 0.0
+    else:
+        f1 = 2.0 * precision * recall / (precision + recall)
+    return {
+        "precision": float(precision),
+        "recall": float(recall),
+        "f1": float(f1),
+        "tp": float(tp),
+        "fp": float(fp),
+        "fn": float(fn),
+    }
+
+
+def average_precision_matched(
+    pred_masks: xr.DataArray | np.ndarray,
+    ref_masks: xr.DataArray | np.ndarray,
+    *,
+    scores: np.ndarray | None = None,
+    iou_threshold: float = 0.5,
+) -> float:
+    """VOC-style Average Precision at a single IoU threshold.
+
+    Mirrors Pérez Carrasco et al. (2026), ``compute_ap_with_df_safe``:
+    walk predictions in score-descending order, accumulate
+    ``precision[k]`` and ``recall[k]``, enforce monotone-decreasing
+    precision, and integrate the precision/recall curve. Returns ``0.0``
+    when there are no references; ``0.0`` when there are no predictions.
+    """
+    pred = _as_3d_bool(pred_masks, name="pred_masks")
+    ref = _as_3d_bool(ref_masks, name="ref_masks")
+    n_p, n_r = pred.shape[0], ref.shape[0]
+    if n_r == 0 or n_p == 0:
+        return 0.0
+    match = match_instances(pred, ref, scores=scores, iou_threshold=iou_threshold)
+    pred_match = match["pred_match"]
+
+    if scores is None:
+        rank_key = -pred.reshape(n_p, -1).sum(axis=1).astype(np.float64)
+    else:
+        rank_key = -np.asarray(scores, dtype=float)
+    order = np.argsort(rank_key, kind="stable")
+    ordered_hits = (pred_match[order] >= 0).astype(np.float64)
+    cum_tp = np.cumsum(ordered_hits)
+    precisions = cum_tp / np.arange(1, n_p + 1, dtype=np.float64)
+    recalls = cum_tp / float(n_r)
+
+    # Pad endpoints and enforce monotonicity, per VOC.
+    precisions = np.concatenate([[0.0], precisions, [0.0]])
+    recalls = np.concatenate([[0.0], recalls, [1.0]])
+    for i in range(len(precisions) - 2, -1, -1):
+        precisions[i] = max(precisions[i], precisions[i + 1])
+
+    changes = np.where(recalls[1:] != recalls[:-1])[0] + 1
+    return float(
+        np.sum((recalls[changes] - recalls[changes - 1]) * precisions[changes])
+    )
+
+
+# ---------- Operators ----------------------------------------------------
+
+
+class MaskIoU(Operator):
+    """Pairwise mask-IoU matrix between two ``(N, H, W)`` stacks."""
+
+    def _apply(
+        self,
+        pred_masks: xr.DataArray | np.ndarray,
+        ref_masks: xr.DataArray | np.ndarray,
+    ) -> np.ndarray:
+        return mask_iou_matrix(pred_masks, ref_masks)
+
+    def get_config(self) -> dict[str, Any]:
+        return {}
+
+
+class InstanceMatcher(Operator):
+    """Greedy IoU matching between predicted and reference mask stacks.
+
+    Args:
+        iou_threshold: Minimum IoU for a (pred, ref) pair to count as a
+            match. Defaults to ``0.5`` (Pascal-VOC convention; the paper
+            uses ``0.1`` for the much sparser MethaneSAT plume regime).
+        scores: Optional length-``N_pred`` array of per-prediction
+            scores. When ``None``, predictions are ranked by area.
+    """
+
+    def __init__(
+        self,
+        *,
+        iou_threshold: float = 0.5,
+        scores: np.ndarray | None = None,
+    ) -> None:
+        if not 0.0 < iou_threshold <= 1.0:
+            raise ValueError("iou_threshold must be in (0, 1]")
+        self.iou_threshold = float(iou_threshold)
+        self.scores = None if scores is None else np.asarray(scores, dtype=float)
+
+    def _apply(
+        self,
+        pred_masks: xr.DataArray | np.ndarray,
+        ref_masks: xr.DataArray | np.ndarray,
+    ) -> dict[str, Any]:
+        return match_instances(
+            pred_masks,
+            ref_masks,
+            scores=self.scores,
+            iou_threshold=self.iou_threshold,
+        )
+
+    def get_config(self) -> dict[str, Any]:
+        return {
+            "iou_threshold": self.iou_threshold,
+            "scores": None if self.scores is None else self.scores.tolist(),
+        }
+
+
+class InstanceF1AtIoU(Operator):
+    """Instance precision / recall / F1 at a single IoU threshold."""
+
+    def __init__(
+        self,
+        *,
+        iou_threshold: float = 0.5,
+        scores: np.ndarray | None = None,
+    ) -> None:
+        if not 0.0 < iou_threshold <= 1.0:
+            raise ValueError("iou_threshold must be in (0, 1]")
+        self.iou_threshold = float(iou_threshold)
+        self.scores = None if scores is None else np.asarray(scores, dtype=float)
+
+    def _apply(
+        self,
+        pred_masks: xr.DataArray | np.ndarray,
+        ref_masks: xr.DataArray | np.ndarray,
+    ) -> dict[str, float]:
+        return instance_f1_at_iou(
+            pred_masks,
+            ref_masks,
+            scores=self.scores,
+            iou_threshold=self.iou_threshold,
+        )
+
+    def get_config(self) -> dict[str, Any]:
+        return {
+            "iou_threshold": self.iou_threshold,
+            "scores": None if self.scores is None else self.scores.tolist(),
+        }
+
+
+class AveragePrecisionMatched(Operator):
+    """VOC-style Average Precision at a single IoU threshold."""
+
+    def __init__(
+        self,
+        *,
+        iou_threshold: float = 0.5,
+        scores: np.ndarray | None = None,
+    ) -> None:
+        if not 0.0 < iou_threshold <= 1.0:
+            raise ValueError("iou_threshold must be in (0, 1]")
+        self.iou_threshold = float(iou_threshold)
+        self.scores = None if scores is None else np.asarray(scores, dtype=float)
+
+    def _apply(
+        self,
+        pred_masks: xr.DataArray | np.ndarray,
+        ref_masks: xr.DataArray | np.ndarray,
+    ) -> float:
+        return average_precision_matched(
+            pred_masks,
+            ref_masks,
+            scores=self.scores,
+            iou_threshold=self.iou_threshold,
+        )
+
+    def get_config(self) -> dict[str, Any]:
+        return {
+            "iou_threshold": self.iou_threshold,
+            "scores": None if self.scores is None else self.scores.tolist(),
+        }
+
+
+__all__ = [
+    "AveragePrecisionMatched",
+    "InstanceF1AtIoU",
+    "InstanceMatcher",
+    "MaskIoU",
+    "average_precision_matched",
+    "instance_f1_at_iou",
+    "mask_iou_matrix",
+    "match_instances",
+]

--- a/src/xrtoolz/metrics/operators.py
+++ b/src/xrtoolz/metrics/operators.py
@@ -11,6 +11,12 @@ from xrtoolz.metrics._src.distributional import (
     Wasserstein1,
 )
 from xrtoolz.metrics._src.forecast import SkillByLeadTime
+from xrtoolz.metrics._src.instance import (
+    AveragePrecisionMatched,
+    InstanceF1AtIoU,
+    InstanceMatcher,
+    MaskIoU,
+)
 from xrtoolz.metrics._src.masked import MaskedMetric
 from xrtoolz.metrics._src.multiscale import EvaluateByRegion
 from xrtoolz.metrics._src.physical import (
@@ -58,6 +64,7 @@ __all__ = [
     "NRMSE",
     "RMSE",
     "SSIM",
+    "AveragePrecisionMatched",
     "BandLimitedRMSE",
     "Bias",
     "BinnedResiduals2D",
@@ -71,6 +78,9 @@ __all__ = [
     "FrequencyBandSkill",
     "GeostrophicBalanceError",
     "GradientDifference",
+    "InstanceF1AtIoU",
+    "InstanceMatcher",
+    "MaskIoU",
     "MaskedMetric",
     "NRMSEScore",
     "PSDScore",

--- a/tests/test_metrics_instance.py
+++ b/tests/test_metrics_instance.py
@@ -1,0 +1,198 @@
+"""Tests for instance-segmentation evaluation metrics."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from xrtoolz.metrics import (
+    AveragePrecisionMatched,
+    InstanceF1AtIoU,
+    InstanceMatcher,
+    MaskIoU,
+    average_precision_matched,
+    instance_f1_at_iou,
+    mask_iou_matrix,
+    match_instances,
+)
+
+
+def _stack_box(boxes, shape=(20, 20)) -> np.ndarray:
+    """Build a (N, H, W) boolean mask stack from ``(y0, y1, x0, x1)`` boxes."""
+    out = np.zeros((len(boxes), *shape), dtype=bool)
+    for i, (y0, y1, x0, x1) in enumerate(boxes):
+        out[i, y0:y1, x0:x1] = True
+    return out
+
+
+def test_mask_iou_matrix_matches_hand_computed_overlap() -> None:
+    pred = _stack_box([(0, 5, 0, 5), (0, 5, 5, 10)])
+    ref = _stack_box([(0, 5, 0, 5), (10, 15, 10, 15)])
+
+    ious = mask_iou_matrix(pred, ref)
+    assert ious.shape == (2, 2)
+    assert ious[0, 0] == pytest.approx(1.0)  # exact match
+    assert ious[1, 1] == pytest.approx(0.0)
+    assert ious[0, 1] == pytest.approx(0.0)
+    assert ious[1, 0] == pytest.approx(0.0)
+
+
+def test_mask_iou_matrix_rejects_non_3d_input() -> None:
+    with pytest.raises(ValueError, match="N, H, W"):
+        mask_iou_matrix(np.ones((4, 4), dtype=bool), np.ones((1, 4, 4), dtype=bool))
+
+
+def test_mask_iou_matrix_rejects_shape_mismatch() -> None:
+    pred = _stack_box([(0, 5, 0, 5)], shape=(10, 10))
+    ref = _stack_box([(0, 5, 0, 5)], shape=(20, 20))
+    with pytest.raises(ValueError, match="spatial shapes"):
+        mask_iou_matrix(pred, ref)
+
+
+def test_mask_iou_matrix_empty_stacks_returns_zero_shape() -> None:
+    empty = np.zeros((0, 5, 5), dtype=bool)
+    ref = _stack_box([(0, 2, 0, 2)], shape=(5, 5))
+    assert mask_iou_matrix(empty, ref).shape == (0, 1)
+    assert mask_iou_matrix(ref, empty).shape == (1, 0)
+
+
+def test_match_instances_greedy_matches_exact_overlaps() -> None:
+    pred = _stack_box([(0, 5, 0, 5), (10, 15, 10, 15)])
+    ref = _stack_box([(10, 15, 10, 15), (0, 5, 0, 5)])
+
+    result = match_instances(pred, ref, iou_threshold=0.5)
+    assert result["tp"] == 2
+    assert result["fp"] == 0
+    assert result["fn"] == 0
+    # Each prediction should be matched to the spatially identical reference.
+    assert int(result["pred_match"][0]) == 1
+    assert int(result["pred_match"][1]) == 0
+
+
+def test_match_instances_score_order_breaks_ties() -> None:
+    pred = _stack_box([(0, 10, 0, 5), (0, 10, 0, 5)])  # two identical preds
+    ref = _stack_box([(0, 10, 0, 5)])  # one reference
+    # Higher-scored prediction (index 1) wins; the other becomes a false positive.
+    result = match_instances(pred, ref, scores=np.array([0.1, 0.9]), iou_threshold=0.5)
+    assert result["tp"] == 1
+    assert result["fp"] == 1
+    assert int(result["pred_match"][1]) == 0
+    assert int(result["pred_match"][0]) == -1
+
+
+def test_match_instances_falls_below_threshold() -> None:
+    pred = _stack_box([(0, 6, 0, 5)])  # 30 px
+    ref = _stack_box([(0, 5, 0, 5)])  # 25 px, IoU = 25/30 ~= 0.83
+    high = match_instances(pred, ref, iou_threshold=0.9)
+    assert high["tp"] == 0 and high["fn"] == 1
+    low = match_instances(pred, ref, iou_threshold=0.5)
+    assert low["tp"] == 1 and low["fn"] == 0
+
+
+def test_instance_f1_at_iou_perfect_match() -> None:
+    pred = _stack_box([(0, 5, 0, 5), (10, 15, 10, 15)])
+    ref = _stack_box([(0, 5, 0, 5), (10, 15, 10, 15)])
+    stats = instance_f1_at_iou(pred, ref, iou_threshold=0.5)
+    assert stats["precision"] == pytest.approx(1.0)
+    assert stats["recall"] == pytest.approx(1.0)
+    assert stats["f1"] == pytest.approx(1.0)
+
+
+def test_instance_f1_at_iou_partial_credit() -> None:
+    pred = _stack_box([(0, 5, 0, 5), (0, 5, 10, 15)])
+    ref = _stack_box([(0, 5, 0, 5), (10, 15, 0, 5), (10, 15, 10, 15)])
+    stats = instance_f1_at_iou(pred, ref, iou_threshold=0.5)
+    # 1 TP (first pred matches first ref), 1 FP (second pred has no match),
+    # 2 FN (two refs unmatched).
+    assert stats["tp"] == 1.0
+    assert stats["fp"] == 1.0
+    assert stats["fn"] == 2.0
+    assert stats["precision"] == pytest.approx(0.5)
+    assert stats["recall"] == pytest.approx(1.0 / 3.0)
+
+
+def test_average_precision_matched_is_one_for_perfect_ordering() -> None:
+    pred = _stack_box([(0, 5, 0, 5), (10, 15, 10, 15)])
+    ref = _stack_box([(0, 5, 0, 5), (10, 15, 10, 15)])
+    ap = average_precision_matched(
+        pred, ref, scores=np.array([0.9, 0.8]), iou_threshold=0.5
+    )
+    assert ap == pytest.approx(1.0)
+
+
+def test_average_precision_matched_drops_when_fp_outscores_tp() -> None:
+    pred = _stack_box(
+        [(0, 5, 0, 5), (15, 20, 15, 20)]
+    )  # pred 0 matches a ref, pred 1 is a FP
+    ref = _stack_box([(0, 5, 0, 5), (10, 15, 10, 15)])
+    # Order matters: low scores last -> hits in order. Place FP first to
+    # depress precision on the leading recall step.
+    ap = average_precision_matched(
+        pred, ref, scores=np.array([0.1, 0.9]), iou_threshold=0.5
+    )
+    # With FP first then TP, cumulative precision goes 0 -> 0.5; recall
+    # goes 0 -> 0.5. Integrated AP equals 0.25.
+    assert ap == pytest.approx(0.25)
+
+
+def test_average_precision_matched_zero_for_empty_ref_or_pred() -> None:
+    pred = _stack_box([(0, 5, 0, 5)])
+    empty = np.zeros((0, 20, 20), dtype=bool)
+    assert average_precision_matched(pred, empty, iou_threshold=0.5) == 0.0
+    assert average_precision_matched(empty, pred, iou_threshold=0.5) == 0.0
+
+
+def test_operators_wrap_pure_functions() -> None:
+    pred = _stack_box([(0, 5, 0, 5)])
+    ref = _stack_box([(0, 5, 0, 5)])
+    scores = np.array([0.9])
+
+    assert np.array_equal(MaskIoU()(pred, ref), mask_iou_matrix(pred, ref))
+
+    matcher = InstanceMatcher(iou_threshold=0.5, scores=scores)
+    direct = match_instances(pred, ref, scores=scores, iou_threshold=0.5)
+    out = matcher(pred, ref)
+    assert out["tp"] == direct["tp"]
+    assert np.array_equal(out["pred_match"], direct["pred_match"])
+
+    f1_op = InstanceF1AtIoU(iou_threshold=0.5, scores=scores)
+    assert f1_op(pred, ref) == instance_f1_at_iou(
+        pred, ref, scores=scores, iou_threshold=0.5
+    )
+
+    ap_op = AveragePrecisionMatched(iou_threshold=0.5, scores=scores)
+    assert ap_op(pred, ref) == average_precision_matched(
+        pred, ref, scores=scores, iou_threshold=0.5
+    )
+
+
+def test_operators_reject_invalid_iou_threshold() -> None:
+    for op_cls in (InstanceMatcher, InstanceF1AtIoU, AveragePrecisionMatched):
+        with pytest.raises(ValueError):
+            op_cls(iou_threshold=0.0)
+        with pytest.raises(ValueError):
+            op_cls(iou_threshold=1.5)
+
+
+def test_instance_metrics_do_not_collide_with_v5_object_stubs() -> None:
+    """The V5 object-metric stubs (ProbabilityOfDetection,
+    IntersectionOverUnion, etc.) still raise on construction — the new
+    instance metrics are additive and live under their own names.
+    """
+    from xrtoolz.metrics._src.object import (
+        CentroidDistance,
+        IntersectionOverUnion,
+        ProbabilityOfDetection,
+    )
+
+    for stub in (ProbabilityOfDetection, IntersectionOverUnion, CentroidDistance):
+        with pytest.raises(NotImplementedError):
+            stub()
+
+
+def test_operators_get_config_round_trip() -> None:
+    scores = np.array([0.7, 0.3])
+    cfg = InstanceMatcher(iou_threshold=0.25, scores=scores).get_config()
+    assert cfg == {"iou_threshold": 0.25, "scores": [0.7, 0.3]}
+    cfg_default = AveragePrecisionMatched(iou_threshold=0.5).get_config()
+    assert cfg_default == {"iou_threshold": 0.5, "scores": None}


### PR DESCRIPTION
## Summary

Adds mask-IoU based instance-segmentation metrics adapted from **Pérez Carrasco et al. (2026)**, *Plume Segmentation from MethaneSAT with Cross-Sensor Transfer Learning and Physics-Informed Postprocessing* ([arXiv:2605.24273](https://arxiv.org/abs/2605.24273); reference impl: `metrics_instance_segmentation.compute_overlaps_masks` / `compute_matches` / `compute_ap_with_df_safe` at [doi:10.7910/DVN/FR959H](https://doi.org/10.7910/DVN/FR959H)).

Companion to [jejjohnson/geotoolz#87](https://github.com/jejjohnson/geotoolz/pull/87), which adds the upstream postprocessing operators (proximity merge, mask-NMS, shape filter, plume stats). Together they cover the paper's scene-level pipeline end-to-end.

## New surface in `xrtoolz.metrics`

| Layer-0 function | Layer-1 operator | What it does |
|---|---|---|
| `mask_iou_matrix` | `MaskIoU` | Pairwise mask-IoU matrix between two `(N, H, W)` stacks. Vectorized via int64 matmul. |
| `match_instances` | `InstanceMatcher` | Greedy score-sorted (or area-sorted fallback) IoU matcher; returns TP/FP/FN + per-instance match arrays. |
| `instance_f1_at_iou` | `InstanceF1AtIoU` | Precision / recall / F1 from matched-pair counts at a single IoU threshold. |
| `average_precision_matched` | `AveragePrecisionMatched` | VOC-style AP with monotone-decreasing precision envelope. |

## Compatibility with the V5 object-metric reservations

The existing `metrics/_src/object.py` reserves long-form names (`ProbabilityOfDetection`, `IntersectionOverUnion`, `CentroidDistance`, …) as `_ObjectMetricStub` subclasses for the V5 detector/matcher epic. This PR is **strictly additive** — it does not touch those stubs, and a regression test (`test_instance_metrics_do_not_collide_with_v5_object_stubs`) guards that they still raise `NotImplementedError` on construction. The new instance metrics live under distinct names so V5 can land without API conflicts.

## Implementation notes

- Inputs are `(N, H, W)` boolean (or 0/1) stacks; predicted and reference stacks may carry different `N`.
- IoU matrix uses `flat_pred @ flat_ref.T` over int64 — fastest path for typical `N ~ 1e2-1e3`, `HW ~ 1e6`. Empty masks contribute zero IoU.
- The matcher follows the paper exactly: predictions sorted by score descending, then for each prediction the references are sorted by IoU descending and the first unmatched reference clearing the threshold is taken.
- AP integration matches Pascal VOC: pad endpoints, enforce monotone-decreasing precision, then sum `(recall[i] - recall[i-1]) * precision[i]` at recall change points.
- All operators accept `xr.DataArray` or `np.ndarray` (mask stacks are domain-agnostic; this avoids forcing xarray on callers who hand in raw numpy from a detector).

## Test plan

- [x] `uv run pytest -v` — 1350 passed, 1 skipped, no new failures.
- [x] `uv run --group lint ruff check .` — clean.
- [x] `uv run --group lint ruff format --check .` — clean.
- [x] `uv run --group typecheck ty check src/xrtoolz` — 82 pre-existing diagnostics unchanged, no new diagnostics from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)