### PR TITLE
feat!: flip basis encoders + dm_test to DataArray-native (PR δ)

### DIFF
--- a/docs/design/api/components.md
+++ b/docs/design/api/components.md
@@ -512,7 +512,12 @@ class JulianDate(Operator):
 
 ```python
 # transforms/encoders/basis.py — basis / feature expansions
-# Layer 0 — xarray
+# NOTE: the `ds: xr.Dataset, coords: list[str]` sketch below is the original
+# aspirational shape. The shipped Layer-0 primitives are DataArray-native
+# (`fourier_features(da, *, num_freqs, scale, feature_dim)` etc.) per the
+# xarray-native-primitives contract — see the note after this block and
+# `api/primitives.md`. The Dataset/variable plumbing lives in the Layer-1
+# operators.
 def fourier_features(ds: xr.Dataset, *, coords: list[str], num_freqs: int = 10, scale: float = 1.0) -> xr.Dataset: ...
 def random_fourier_features(ds: xr.Dataset, *, coords: list[str], num_features: int = 64, sigma: float = 1.0, seed: int = 0) -> xr.Dataset: ...
 def polynomial_features(ds: xr.Dataset, *, coords: list[str], degree: int = 2) -> xr.Dataset: ...

--- a/docs/design/api/primitives.md
+++ b/docs/design/api/primitives.md
@@ -111,15 +111,15 @@ def cartesian_to_lonlat(ds) -> xr.Dataset
 def lon_360_to_180(coord: np.ndarray) -> np.ndarray
 def lon_180_to_360(coord: np.ndarray) -> np.ndarray
 
-# Cyclical / positional encodings
-def cyclical_encode(values: np.ndarray, period: float) -> tuple[np.ndarray, np.ndarray]
-def fourier_features(values: np.ndarray, num_freqs: int, scale: float = 1.0) -> np.ndarray
-def random_fourier_features(values: np.ndarray, num_features: int, sigma: float = 1.0) -> np.ndarray
-def positional_encoding(values: np.ndarray, num_freqs: int, include_input: bool = True) -> np.ndarray
+# Cyclical / positional encodings (DataArray-native; feature encoders add a trailing feature_dim)
+def cyclical_encode(da: xr.DataArray, *, period: float) -> xr.Dataset  # sin / cos
+def fourier_features(da: xr.DataArray, *, num_freqs: int, scale: float = 1.0, feature_dim: str = "feature") -> xr.DataArray
+def random_fourier_features(da: xr.DataArray, *, num_features: int, sigma: float = 1.0, seed: int | None = None, input_dim: Hashable | None = None, feature_dim: str = "feature") -> xr.DataArray
+def positional_encoding(da: xr.DataArray, *, num_freqs: int, include_input: bool = True, feature_dim: str = "feature") -> xr.DataArray
 
-# Temporal encodings
-def encode_time_cyclical(ds, components=("dayofyear", "hour")) -> xr.Dataset
-def encode_time_ordinal(ds, reference_date=None) -> xr.Dataset
+# Temporal encodings (DataArray-native; take the time coordinate / variable)
+def encode_time_cyclical(time: xr.DataArray, *, components=("dayofyear", "hour")) -> xr.Dataset
+def encode_time_ordinal(time: xr.DataArray, *, reference_date=None, unit: str = "D") -> xr.DataArray
 ```
 
 ---

--- a/docs/design/xarray-native-primitives.md
+++ b/docs/design/xarray-native-primitives.md
@@ -1,6 +1,6 @@
 ---
 status: complete
-version: 0.2.0
+version: 0.3.0
 ---
 
 # Xarray-Native Primitives — Two-Layer Public Contract
@@ -70,14 +70,55 @@ version: 0.2.0
 >   and are unchanged.
 > - The basis encoders in `transforms/_src/encoders/basis.py`
 >   (`cyclical_encode`, `fourier_features`, `random_fourier_features`,
->   `positional_encoding`) consume raw `ndarray` for backward
->   compatibility with their Operator wrappers and are out of scope —
->   the Operator layer already does the DataArray plumbing.
+>   `positional_encoding`) consumed raw `ndarray` in PR γ — these are
+>   flipped in PR δ (see below).
 > - The transforms `morphology` / `decompose` / `sklearn_op` modules
 >   are stateful-estimator or coord/attr utilities (not pure Layer-0
 >   primitives) and don't fit the flip contract.
 >
-> Operator constructor signatures across all three PRs are
+> **PR δ is now complete.** The remaining `ndarray`-positional
+> primitives are flipped, and the previously deferred modules are
+> reconciled with the contract:
+>
+> - `transforms/_src/encoders/basis.py`: `cyclical_encode(da, *,
+>   period)` is DataArray-in / Dataset-out (`sin` / `cos` — the
+>   structured multi-output shape); `fourier_features`,
+>   `random_fourier_features`, and `positional_encoding` are
+>   DataArray-in / DataArray-out, each adding a trailing `feature_dim`
+>   via `xr.apply_ufunc`. `random_fourier_features` gains an
+>   `input_dim` keyword naming the channel axis to project from
+>   (replacing the old "auto-detect on `ndim`" behaviour). The numpy
+>   math is preserved verbatim as underscore-prefixed kernels
+>   (`_sin_cos`, `_fourier_features_array`,
+>   `_random_fourier_features_array`, `_positional_encoding_array`);
+>   `encode_time_cyclical` reuses `_sin_cos` directly. The
+>   `CyclicalEncode`, `FourierFeatures`, `RandomFourierFeatures`, and
+>   `PositionalEncoding` operators now select → call → `assign` instead
+>   of hand-plumbing dims off `da.values`.
+> - `metrics/_src/dm.py`: `dm_test(errors_a, errors_b, *, dim=None,
+>   ...)` is DataArray-positional and returns a `Dataset` with
+>   `statistic` / `p_value` (scalars when `dim is None`, otherwise
+>   reduced along `dim` and broadcast over the rest, via
+>   `xr.apply_ufunc`). The Newey–West / HLN math is preserved verbatim
+>   in the private `_dm_stat_pvalue` kernel. A new Layer-1
+>   `DieboldMariano(variable, *, dim, ...)` operator wraps it,
+>   selecting the error variable from two input Datasets.
+>
+> Reconciled non-flips (no code change — already contract-clean or a
+> deliberately different pattern):
+>
+> - `transforms/_src/morphology.py` already took a positional
+>   `DataArray` with keyword-only config (`remove_small_holes_2d(mask,
+>   *, area, lon, lat)`, etc.) and returned a `DataArray`; it conforms
+>   to the primitive contract as-is.
+> - `transforms/_src/decompose.py` (`pca` / `eof` / `ica` / `nmf` /
+>   `kmeans`) returns stateful `XarrayEstimator` objects (the
+>   split-object `fit` / `transform` pattern, D1/D2), and
+>   `transforms/_src/sklearn_op.py::SklearnOp` is itself a Layer-1
+>   `Operator`. Neither is a stateless Layer-0 primitive, so both are
+>   permanently exempt from the flip by the contract's own rules.
+>
+> Operator constructor signatures across all four PRs are
 > unchanged.
 
 A follow-on refactor to D11 (revised). Flips every primitive in the

--- a/src/xrtoolz/metrics/__init__.py
+++ b/src/xrtoolz/metrics/__init__.py
@@ -24,7 +24,7 @@ from xrtoolz.metrics._src.distributional import (
     energy_distance,
     wasserstein_1,
 )
-from xrtoolz.metrics._src.dm import dm_test
+from xrtoolz.metrics._src.dm import DieboldMariano, dm_test
 from xrtoolz.metrics._src.forecast import SkillByLeadTime, skill_by_lead_time
 from xrtoolz.metrics._src.instance import (
     AveragePrecisionMatched,
@@ -134,6 +134,7 @@ __all__ = [
     "CentroidDisplacement",
     "Correlation",
     "DensityInversionFraction",
+    "DieboldMariano",
     "DivergenceError",
     "EnergyDistance",
     "EnsembleCoverage",

--- a/src/xrtoolz/metrics/_src/dm.py
+++ b/src/xrtoolz/metrics/_src/dm.py
@@ -57,14 +57,14 @@ def dm_test(
         raise ValueError("alternative must be 'two-sided', 'less', or 'greater'.")
 
     if dim is None:
-        if errors_a.shape != errors_b.shape:
-            raise ValueError(
-                f"errors_a and errors_b must have matching shapes; got "
-                f"{errors_a.shape} and {errors_b.shape}."
-            )
+        # Flatten everything to a single paired sequence. Align first so
+        # mismatched coordinate labels or dimension orders are caught (or
+        # reconciled) by xarray rather than silently paired positionally.
+        aligned_a, aligned_b = xr.align(errors_a, errors_b, join="exact")
+        aligned_b = aligned_b.transpose(*aligned_a.dims)
         stat, p_value = _dm_stat_pvalue(
-            errors_a.values,
-            errors_b.values,
+            aligned_a.values,
+            aligned_b.values,
             h=h,
             alternative=alternative,
             power=power,
@@ -80,6 +80,9 @@ def dm_test(
         input_core_dims=[core, core],
         output_core_dims=[[], []],
         vectorize=True,
+        dask="parallelized",
+        output_dtypes=[float, float],
+        dask_gufunc_kwargs={"allow_rechunk": True},
         kwargs={
             "h": h,
             "alternative": alternative,

--- a/src/xrtoolz/metrics/_src/dm.py
+++ b/src/xrtoolz/metrics/_src/dm.py
@@ -2,39 +2,106 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+from typing import Any
+
 import numpy as np
-from numpy.typing import ArrayLike
+import xarray as xr
 from scipy import stats
+
+from xrtoolz._operator import Operator
+
+
+_ALTERNATIVES = {"two-sided", "less", "greater"}
 
 
 def dm_test(
-    errors_a: ArrayLike,
-    errors_b: ArrayLike,
+    errors_a: xr.DataArray,
+    errors_b: xr.DataArray,
     *,
+    dim: str | Sequence[str] | None = None,
     h: int = 1,
     alternative: str = "two-sided",
     power: float = 2.0,
     hln_correction: bool = True,
-) -> tuple[float, float]:
+) -> xr.Dataset:
     """Test equal predictive accuracy for two paired *error* sequences.
 
     The inputs are raw forecast errors (residuals); the loss function
     is ``|e|**power`` (defaults to squared error). Pass raw errors —
     do not pre-square or pre-abs them, or the transform will be
     applied twice.
+
+    Args:
+        errors_a: Forecast errors of method A.
+        errors_b: Forecast errors of method B, paired with ``errors_a``.
+        dim: Dimension(s) over which to compute the test. When ``None``
+            (default), the full array is flattened and a single scalar
+            statistic / p-value pair is returned. When given, the test
+            is computed independently along ``dim`` and broadcast over
+            the remaining dimensions.
+        h: Forecast horizon (Newey–West lag truncation is ``h - 1``).
+        alternative: ``"two-sided"``, ``"less"``, or ``"greater"``.
+        power: Loss exponent applied to ``|e|``.
+        hln_correction: Apply the Harvey–Leybourne–Newbold small-sample
+            correction and use the Student-t reference distribution.
+
+    Returns:
+        Dataset with ``statistic`` and ``p_value`` variables. Both are
+        scalars when ``dim`` is ``None``, otherwise DataArrays over the
+        non-reduced dimensions.
     """
     if h < 1:
         raise ValueError("h must be at least 1.")
-    if alternative not in {"two-sided", "less", "greater"}:
+    if alternative not in _ALTERNATIVES:
         raise ValueError("alternative must be 'two-sided', 'less', or 'greater'.")
 
+    if dim is None:
+        if errors_a.shape != errors_b.shape:
+            raise ValueError(
+                f"errors_a and errors_b must have matching shapes; got "
+                f"{errors_a.shape} and {errors_b.shape}."
+            )
+        stat, p_value = _dm_stat_pvalue(
+            errors_a.values,
+            errors_b.values,
+            h=h,
+            alternative=alternative,
+            power=power,
+            hln_correction=hln_correction,
+        )
+        return xr.Dataset({"statistic": stat, "p_value": p_value})
+
+    core = [dim] if isinstance(dim, str) else list(dim)
+    stat, p_value = xr.apply_ufunc(
+        _dm_stat_pvalue,
+        errors_a,
+        errors_b,
+        input_core_dims=[core, core],
+        output_core_dims=[[], []],
+        vectorize=True,
+        kwargs={
+            "h": h,
+            "alternative": alternative,
+            "power": power,
+            "hln_correction": hln_correction,
+        },
+    )
+    return xr.Dataset({"statistic": stat, "p_value": p_value})
+
+
+def _dm_stat_pvalue(
+    errors_a: np.ndarray,
+    errors_b: np.ndarray,
+    *,
+    h: int,
+    alternative: str,
+    power: float,
+    hln_correction: bool,
+) -> tuple[float, float]:
+    """Diebold–Mariano statistic / p-value for one paired error vector."""
     a = np.asarray(errors_a, dtype=float)
     b = np.asarray(errors_b, dtype=float)
-    if a.shape != b.shape:
-        raise ValueError(
-            f"errors_a and errors_b must have matching shapes; got {a.shape} and "
-            f"{b.shape}."
-        )
 
     d = np.abs(a.ravel()) ** power - np.abs(b.ravel()) ** power
     d = d[np.isfinite(d)]
@@ -78,4 +145,68 @@ def _p_value(stat: float, alternative: str, *, distribution) -> float:
     return float(distribution.cdf(stat))
 
 
-__all__ = ["dm_test"]
+class DieboldMariano(Operator):
+    """Layer-1 Diebold–Mariano test on a forecast-error variable.
+
+    Selects ``variable`` from two input Datasets of forecast *errors*
+    (residuals) and runs :func:`dm_test`, returning a Dataset with
+    ``statistic`` and ``p_value``.
+
+    Args:
+        variable: Error variable to select from each input Dataset.
+        dim: Dimension(s) to reduce. ``None`` flattens the full array.
+        h: Forecast horizon.
+        alternative: ``"two-sided"``, ``"less"``, or ``"greater"``.
+        power: Loss exponent applied to ``|e|``.
+        hln_correction: Apply the Harvey–Leybourne–Newbold correction.
+
+    Example:
+        >>> op = DieboldMariano("error", dim="time")
+        >>> result = op(ds_errors_a, ds_errors_b)
+        >>> result["statistic"], result["p_value"]
+    """
+
+    def __init__(
+        self,
+        variable: str,
+        *,
+        dim: str | Sequence[str] | None = None,
+        h: int = 1,
+        alternative: str = "two-sided",
+        power: float = 2.0,
+        hln_correction: bool = True,
+    ) -> None:
+        self.variable = variable
+        self.dim = dim
+        self.h = h
+        self.alternative = alternative
+        self.power = power
+        self.hln_correction = hln_correction
+
+    def _apply(self, ds_a: xr.Dataset, ds_b: xr.Dataset) -> xr.Dataset:
+        return dm_test(
+            ds_a[self.variable],
+            ds_b[self.variable],
+            dim=self.dim,
+            h=self.h,
+            alternative=self.alternative,
+            power=self.power,
+            hln_correction=self.hln_correction,
+        )
+
+    def get_config(self) -> dict[str, Any]:
+        if self.dim is None or isinstance(self.dim, str):
+            dim = self.dim
+        else:
+            dim = list(self.dim)
+        return {
+            "variable": self.variable,
+            "dim": dim,
+            "h": self.h,
+            "alternative": self.alternative,
+            "power": self.power,
+            "hln_correction": self.hln_correction,
+        }
+
+
+__all__ = ["DieboldMariano", "dm_test"]

--- a/src/xrtoolz/metrics/operators.py
+++ b/src/xrtoolz/metrics/operators.py
@@ -10,6 +10,7 @@ from xrtoolz.metrics._src.distributional import (
     EnergyDistance,
     Wasserstein1,
 )
+from xrtoolz.metrics._src.dm import DieboldMariano
 from xrtoolz.metrics._src.forecast import SkillByLeadTime
 from xrtoolz.metrics._src.instance import (
     AveragePrecisionMatched,
@@ -71,6 +72,7 @@ __all__ = [
     "CentroidDisplacement",
     "Correlation",
     "DensityInversionFraction",
+    "DieboldMariano",
     "DivergenceError",
     "EnergyDistance",
     "EnsembleCoverage",

--- a/src/xrtoolz/transforms/_src/encoders/basis.py
+++ b/src/xrtoolz/transforms/_src/encoders/basis.py
@@ -1,105 +1,207 @@
-"""Basis-function encoders — cyclical, Fourier, random Fourier, positional."""
+"""Basis-function encoders — cyclical, Fourier, random Fourier, positional.
+
+Per the xarray-native primitive contract
+(``docs/design/xarray-native-primitives.md``), the public Layer-0
+functions here take a positional :class:`xarray.DataArray` and return a
+:class:`xarray.DataArray` (or a :class:`xarray.Dataset` for the
+sin/cos multi-output :func:`cyclical_encode`). The feature-adding
+encoders introduce a new trailing ``feature_dim`` dimension. The numpy
+math is preserved verbatim as underscore-prefixed module-level kernels
+so internal callers (e.g.
+:func:`xrtoolz.transforms._src.encoders.coord_time.encode_time_cyclical`)
+can reuse it without round-tripping through xarray.
+"""
 
 from __future__ import annotations
 
-from typing import Any
+from collections.abc import Hashable
 
 import numpy as np
+import xarray as xr
 from numpy.typing import ArrayLike, NDArray
 
 
-def cyclical_encode(
-    values: ArrayLike,
-    period: float,
-) -> tuple[NDArray, NDArray]:
-    """Sin/cos embedding of a periodic variable.
+# ---------- numpy kernels --------------------------------------------------
 
-    Args:
-        values: Input values with period ``period``.
-        period: Period length (e.g. 365.25 for day-of-year, 24 for hour
-            of day, ``2 * np.pi`` for radians).
 
-    Returns:
-        ``(sin_component, cos_component)`` pair, each with the same
-        shape as ``values``.
-    """
+def _sin_cos(values: ArrayLike, period: float) -> tuple[NDArray, NDArray]:
+    """Sin/cos embedding of a periodic numpy array."""
     x = 2.0 * np.pi * np.asarray(values) / period
     return np.sin(x), np.cos(x)
 
 
-def fourier_features(
-    values: ArrayLike,
-    num_freqs: int,
-    scale: float = 1.0,
-) -> NDArray:
-    """Deterministic Fourier-feature encoding.
-
-    Returns an array of shape ``(..., 2 * num_freqs)`` whose columns
-    alternate ``sin(2^k * scale * x)`` and ``cos(2^k * scale * x)``.
-
-    Args:
-        values: Input array.
-        num_freqs: Number of frequency octaves to use.
-        scale: Base frequency.
-    """
-    values = np.asarray(values)
+def _fourier_features_array(values: NDArray, num_freqs: int, scale: float) -> NDArray:
+    """Deterministic Fourier features; appends a trailing feature axis."""
     freqs = (2.0 ** np.arange(num_freqs)) * scale
     angles = values[..., None] * freqs
     return np.concatenate([np.sin(angles), np.cos(angles)], axis=-1)
 
 
-def random_fourier_features(
-    values: ArrayLike,
+def _random_fourier_features_array(
+    values: NDArray,
     num_features: int,
-    sigma: float = 1.0,
-    seed: int | None = None,
+    sigma: float,
+    seed: int | None,
+    *,
+    projected: bool,
 ) -> NDArray:
-    """Random Fourier features in the style of Rahimi & Recht, 2007.
+    """Random Fourier features (Rahimi & Recht, 2007).
 
-    Approximates the RBF kernel feature map. Returns an array of shape
-    ``(..., num_features)``.
-
-    Args:
-        values: Input array with the feature dim as the last axis, or a
-            1-D scalar coordinate.
-        num_features: Output feature dimension (must be even).
-        sigma: Bandwidth of the underlying RBF kernel.
-        seed: Seed for the RNG used to draw the random frequencies.
+    When ``projected`` is ``True`` the trailing axis of ``values`` is the
+    ``d``-channel feature axis that is projected away; otherwise each
+    element is treated as a scalar feature (``d = 1``).
     """
-    if num_features % 2 != 0:
-        raise ValueError("num_features must be even.")
     values = np.asarray(values)
-    if values.ndim == 0:
-        values = values[None]
-    d = values.shape[-1] if values.ndim > 1 else 1
-    x = values if values.ndim > 1 else values[..., None]
-
+    if projected:
+        d = values.shape[-1]
+        x = values
+    else:
+        d = 1
+        x = values[..., None]
     rng = np.random.default_rng(seed)
     omega = rng.standard_normal((d, num_features // 2)) / sigma
     projection = x @ omega  # (..., num_features // 2)
     return np.concatenate([np.sin(projection), np.cos(projection)], axis=-1)
 
 
-def positional_encoding(
-    values: ArrayLike,
-    num_freqs: int,
-    include_input: bool = True,
+def _positional_encoding_array(
+    values: NDArray, num_freqs: int, include_input: bool
 ) -> NDArray:
-    """NeRF-style positional encoding.
-
-    Output shape is ``(..., (2 * num_freqs) + include_input)``.
-
-    Args:
-        values: Input array.
-        num_freqs: Number of octave frequencies.
-        include_input: If ``True``, concatenate the raw input as an
-            additional column.
-    """
-    encoded = fourier_features(values, num_freqs=num_freqs, scale=np.pi)
+    """NeRF-style positional encoding; appends a trailing feature axis."""
+    encoded = _fourier_features_array(values, num_freqs=num_freqs, scale=np.pi)
     if include_input:
         values = np.asarray(values)[..., None]
         return np.concatenate([values, encoded], axis=-1)
     return encoded
+
+
+# ---------- xarray-native primitives ---------------------------------------
+
+
+def cyclical_encode(da: xr.DataArray, *, period: float) -> xr.Dataset:
+    """Sin/cos embedding of a periodic variable.
+
+    Args:
+        da: Input values with period ``period``.
+        period: Period length (e.g. 365.25 for day-of-year, 24 for hour
+            of day, ``2 * np.pi`` for radians).
+
+    Returns:
+        Dataset with ``sin`` and ``cos`` data variables, each the same
+        shape as ``da``.
+    """
+    x = 2.0 * np.pi * da / period
+    return xr.Dataset({"sin": np.sin(x), "cos": np.cos(x)})
+
+
+def fourier_features(
+    da: xr.DataArray,
+    *,
+    num_freqs: int,
+    scale: float = 1.0,
+    feature_dim: str = "feature",
+) -> xr.DataArray:
+    """Deterministic Fourier-feature encoding.
+
+    Adds a trailing ``feature_dim`` of length ``2 * num_freqs`` whose
+    entries alternate ``sin(2^k * scale * x)`` and ``cos(2^k * scale * x)``.
+
+    Args:
+        da: Input DataArray.
+        num_freqs: Number of frequency octaves to use.
+        scale: Base frequency.
+        feature_dim: Name of the appended feature dimension.
+    """
+    return xr.apply_ufunc(
+        _fourier_features_array,
+        da,
+        input_core_dims=[[]],
+        output_core_dims=[[feature_dim]],
+        kwargs={"num_freqs": num_freqs, "scale": scale},
+        keep_attrs=True,
+        dask="parallelized",
+        dask_gufunc_kwargs={"output_sizes": {feature_dim: 2 * num_freqs}},
+        output_dtypes=[np.promote_types(da.dtype, np.float32)],
+    )
+
+
+def random_fourier_features(
+    da: xr.DataArray,
+    *,
+    num_features: int,
+    sigma: float = 1.0,
+    seed: int | None = None,
+    input_dim: Hashable | None = None,
+    feature_dim: str = "feature",
+) -> xr.DataArray:
+    """Random Fourier features in the style of Rahimi & Recht, 2007.
+
+    Approximates the RBF kernel feature map. Adds a trailing
+    ``feature_dim`` of length ``num_features``.
+
+    Args:
+        da: Input DataArray.
+        num_features: Output feature dimension (must be even).
+        sigma: Bandwidth of the underlying RBF kernel.
+        seed: Seed for the RNG used to draw the random frequencies.
+        input_dim: Optional existing dimension of ``da`` to treat as the
+            channel/feature axis to project from. When ``None`` each
+            element is a scalar feature (``d = 1``); when given, that
+            dimension is replaced by ``feature_dim``.
+        feature_dim: Name of the appended feature dimension.
+    """
+    if num_features % 2 != 0:
+        raise ValueError("num_features must be even.")
+    core_in = [[input_dim]] if input_dim is not None else [[]]
+    return xr.apply_ufunc(
+        _random_fourier_features_array,
+        da,
+        input_core_dims=core_in,
+        output_core_dims=[[feature_dim]],
+        kwargs={
+            "num_features": num_features,
+            "sigma": sigma,
+            "seed": seed,
+            "projected": input_dim is not None,
+        },
+        keep_attrs=True,
+        dask="parallelized",
+        dask_gufunc_kwargs={"output_sizes": {feature_dim: num_features}},
+        output_dtypes=[np.promote_types(da.dtype, np.float32)],
+    )
+
+
+def positional_encoding(
+    da: xr.DataArray,
+    *,
+    num_freqs: int,
+    include_input: bool = True,
+    feature_dim: str = "feature",
+) -> xr.DataArray:
+    """NeRF-style positional encoding.
+
+    Adds a trailing ``feature_dim`` of length
+    ``(2 * num_freqs) + include_input``.
+
+    Args:
+        da: Input DataArray.
+        num_freqs: Number of octave frequencies.
+        include_input: If ``True``, prepend the raw input as an
+            additional feature column.
+        feature_dim: Name of the appended feature dimension.
+    """
+    out_size = 2 * num_freqs + int(include_input)
+    return xr.apply_ufunc(
+        _positional_encoding_array,
+        da,
+        input_core_dims=[[]],
+        output_core_dims=[[feature_dim]],
+        kwargs={"num_freqs": num_freqs, "include_input": include_input},
+        keep_attrs=True,
+        dask="parallelized",
+        dask_gufunc_kwargs={"output_sizes": {feature_dim: out_size}},
+        output_dtypes=[np.promote_types(da.dtype, np.float32)],
+    )
 
 
 __all__ = [
@@ -108,7 +210,3 @@ __all__ = [
     "positional_encoding",
     "random_fourier_features",
 ]
-
-
-# Silence "unused import" lints for types only touched in annotations.
-_ANNOTATION_ONLY: tuple[Any, ...] = (ArrayLike, NDArray)

--- a/src/xrtoolz/transforms/_src/encoders/coord_time.py
+++ b/src/xrtoolz/transforms/_src/encoders/coord_time.py
@@ -18,7 +18,7 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
-from xrtoolz.transforms._src.encoders.basis import cyclical_encode
+from xrtoolz.transforms._src.encoders.basis import _sin_cos
 
 
 def time_rescale(
@@ -133,7 +133,7 @@ def encode_time_cyclical(
                 f"Unknown time component {name!r}; known: {sorted(periods)}."
             )
         values = getattr(time.dt, name).values.astype(float)
-        sin, cos = cyclical_encode(values, period=periods[name])
+        sin, cos = _sin_cos(values, periods[name])
         out_vars[f"{name}_sin"] = xr.DataArray(sin, dims=time.dims, coords=time.coords)
         out_vars[f"{name}_cos"] = xr.DataArray(cos, dims=time.dims, coords=time.coords)
     # Carry the source time coords on the output Dataset so direct

--- a/src/xrtoolz/transforms/operators.py
+++ b/src/xrtoolz/transforms/operators.py
@@ -486,12 +486,11 @@ class CyclicalEncode(Operator):
         self.period = float(period)
 
     def _apply(self, ds: xr.Dataset) -> xr.Dataset:
-        da = ds[self.variable]
-        sin, cos = _basis.cyclical_encode(da.values, period=self.period)
+        encoded = _basis.cyclical_encode(ds[self.variable], period=self.period)
         return ds.assign(
             {
-                f"{self.variable}_sin": (da.dims, sin),
-                f"{self.variable}_cos": (da.dims, cos),
+                f"{self.variable}_sin": encoded["sin"],
+                f"{self.variable}_cos": encoded["cos"],
             }
         )
 
@@ -522,12 +521,14 @@ class FourierFeatures(Operator):
         self.feature_dim = feature_dim
 
     def _apply(self, ds: xr.Dataset) -> xr.Dataset:
-        da = ds[self.variable]
         encoded = _basis.fourier_features(
-            da.values, num_freqs=self.num_freqs, scale=self.scale
+            ds[self.variable],
+            num_freqs=self.num_freqs,
+            scale=self.scale,
+            feature_dim=self.feature_dim,
         )
         name = self.output_name or f"{self.variable}_fourier"
-        return ds.assign({name: ((*da.dims, self.feature_dim), encoded)})
+        return ds.assign({name: encoded})
 
     def get_config(self) -> dict[str, Any]:
         return {
@@ -566,21 +567,20 @@ class RandomFourierFeatures(Operator):
                 "RandomFourierFeatures requires a non-scalar input variable; "
                 f"ds[{self.variable!r}] has ndim=0."
             )
+        # 1-D inputs append a feature axis; ≥ 2-D vector inputs project the
+        # trailing axis away via a (d, num_features/2) matrix, replacing it
+        # with the feature axis.
+        input_dim = None if da.ndim == 1 else da.dims[-1]
         encoded = _basis.random_fourier_features(
-            da.values,
+            da,
             num_features=self.num_features,
             sigma=self.sigma,
             seed=self.seed,
+            input_dim=input_dim,
+            feature_dim=self.feature_dim,
         )
         name = self.output_name or f"{self.variable}_rff"
-        # random_fourier_features appends a feature axis for 1-D inputs
-        # but *replaces* the trailing feature axis for ≥ 2-D vector
-        # inputs (it projects via a (d, num_features/2) matrix).
-        if da.ndim == 1:
-            out_dims = (*da.dims, self.feature_dim)
-        else:
-            out_dims = (*da.dims[:-1], self.feature_dim)
-        return ds.assign({name: (out_dims, encoded)})
+        return ds.assign({name: encoded})
 
     def get_config(self) -> dict[str, Any]:
         return {
@@ -612,12 +612,14 @@ class PositionalEncoding(Operator):
         self.feature_dim = feature_dim
 
     def _apply(self, ds: xr.Dataset) -> xr.Dataset:
-        da = ds[self.variable]
         encoded = _basis.positional_encoding(
-            da.values, num_freqs=self.num_freqs, include_input=self.include_input
+            ds[self.variable],
+            num_freqs=self.num_freqs,
+            include_input=self.include_input,
+            feature_dim=self.feature_dim,
         )
         name = self.output_name or f"{self.variable}_posenc"
-        return ds.assign({name: ((*da.dims, self.feature_dim), encoded)})
+        return ds.assign({name: encoded})
 
     def get_config(self) -> dict[str, Any]:
         return {

--- a/tests/test_geo_extended.py
+++ b/tests/test_geo_extended.py
@@ -457,33 +457,40 @@ def test_calc_latlon_adds_2d_coords():
 
 
 def test_cyclical_encode_unit_circle():
-    sin, cos = cyclical_encode(np.array([0.0, 0.25, 0.5, 0.75]), period=1.0)
-    np.testing.assert_allclose(sin**2 + cos**2, np.ones(4), atol=1e-10)
+    da = xr.DataArray(np.array([0.0, 0.25, 0.5, 0.75]), dims="x")
+    encoded = cyclical_encode(da, period=1.0)
+    np.testing.assert_allclose(
+        encoded["sin"].values ** 2 + encoded["cos"].values ** 2,
+        np.ones(4),
+        atol=1e-10,
+    )
 
 
 def test_fourier_features_shape():
-    vals = np.linspace(0.0, 1.0, 10)
+    vals = xr.DataArray(np.linspace(0.0, 1.0, 10), dims="x")
     out = fourier_features(vals, num_freqs=4)
+    assert out.dims == ("x", "feature")
     assert out.shape == (10, 8)
 
 
 def test_random_fourier_features_reproducible_with_seed():
-    vals = np.linspace(0.0, 1.0, 5)
+    vals = xr.DataArray(np.linspace(0.0, 1.0, 5), dims="x")
     a = random_fourier_features(vals, num_features=16, seed=123)
     b = random_fourier_features(vals, num_features=16, seed=123)
-    np.testing.assert_allclose(a, b)
+    xr.testing.assert_allclose(a, b)
 
 
 def test_random_fourier_features_rejects_odd():
     with pytest.raises(ValueError, match="even"):
-        random_fourier_features(np.array([0.0]), num_features=5)
+        random_fourier_features(xr.DataArray(np.array([0.0]), dims="x"), num_features=5)
 
 
 def test_positional_encoding_includes_input_by_default():
-    vals = np.array([0.1, 0.2, 0.3])
+    vals = xr.DataArray(np.array([0.1, 0.2, 0.3]), dims="x")
     out = positional_encoding(vals, num_freqs=2)
+    assert out.dims == ("x", "feature")
     assert out.shape == (3, 5)  # 2 * 2 + 1
-    np.testing.assert_allclose(out[:, 0], vals)
+    np.testing.assert_allclose(out.isel(feature=0).values, vals.values)
 
 
 def test_time_rescale_round_trip(ds_grid_daily):

--- a/tests/test_metrics_odc14.py
+++ b/tests/test_metrics_odc14.py
@@ -12,6 +12,7 @@ import xarray as xr
 from xrtoolz.geo.regimes import coastal_regions, eddy_regions, equatorial_regions
 from xrtoolz.metrics import (
     BinnedResiduals2D,
+    DieboldMariano,
     RegionScores,
     bin_residuals_2d,
     dm_test,
@@ -123,22 +124,26 @@ def test_eddy_regions_returns_two_class_dataarray() -> None:
 
 
 def test_dm_test_identical_and_skewed_losses() -> None:
-    losses = np.array([1.0, -2.0, 3.0, -4.0])
-    stat, p_value = dm_test(losses, losses)
-    np.testing.assert_allclose(stat, 0.0)
-    np.testing.assert_allclose(p_value, 1.0)
+    losses = xr.DataArray(np.array([1.0, -2.0, 3.0, -4.0]), dims="time")
+    out = dm_test(losses, losses)
+    np.testing.assert_allclose(out["statistic"].values, 0.0)
+    np.testing.assert_allclose(out["p_value"].values, 1.0)
 
-    stat, p_value = dm_test(np.arange(1.0, 7.0), np.ones(6), hln_correction=False)
-    assert stat > 0.0
-    assert p_value < 0.05
+    out = dm_test(
+        xr.DataArray(np.arange(1.0, 7.0), dims="time"),
+        xr.DataArray(np.ones(6), dims="time"),
+        hln_correction=False,
+    )
+    assert out["statistic"].values > 0.0
+    assert out["p_value"].values < 0.05
 
 
 def test_dm_test_hln_correction_changes_p_value() -> None:
-    a = np.array([2.0, 1.8, 2.2, 2.1, 1.9, 2.3])
-    b = np.array([1.0, 1.2, 0.8, 1.1, 0.9, 1.0])
+    a = xr.DataArray(np.array([2.0, 1.8, 2.2, 2.1, 1.9, 2.3]), dims="time")
+    b = xr.DataArray(np.array([1.0, 1.2, 0.8, 1.1, 0.9, 1.0]), dims="time")
 
-    _, p_hln = dm_test(a, b, h=2, hln_correction=True)
-    _, p_normal = dm_test(a, b, h=2, hln_correction=False)
+    p_hln = dm_test(a, b, h=2, hln_correction=True)["p_value"].values
+    p_normal = dm_test(a, b, h=2, hln_correction=False)["p_value"].values
 
     assert p_hln != p_normal
 
@@ -153,9 +158,47 @@ def test_dm_test_matches_statsmodels_hac_reference() -> None:
     cov = cov_hac(fit, nlags=1, use_correction=False)
     expected = float(fit.params[0] / np.sqrt(cov[0, 0]))
 
-    stat, _ = dm_test(a, b, h=2, hln_correction=False)
+    out = dm_test(
+        xr.DataArray(a, dims="time"),
+        xr.DataArray(b, dims="time"),
+        h=2,
+        hln_correction=False,
+    )
 
-    np.testing.assert_allclose(stat, expected, rtol=1e-6, atol=1e-6)
+    np.testing.assert_allclose(out["statistic"].values, expected, rtol=1e-6, atol=1e-6)
+
+
+def test_dm_test_dim_wise_broadcasts_over_remaining_dims() -> None:
+    rng = np.random.default_rng(0)
+    a = xr.DataArray(rng.standard_normal((3, 20)), dims=("site", "time"))
+    b = xr.DataArray(rng.standard_normal((3, 20)), dims=("site", "time"))
+
+    out = dm_test(a, b, dim="time")
+
+    assert out["statistic"].dims == ("site",)
+    assert out["p_value"].dims == ("site",)
+    # Each site matches the per-slice scalar computation.
+    for i in range(3):
+        scalar = dm_test(a.isel(site=i), b.isel(site=i))
+        np.testing.assert_allclose(
+            out["statistic"].isel(site=i).values, scalar["statistic"].values
+        )
+
+
+def test_dieboldmariano_operator_and_config_round_trip() -> None:
+    a = xr.DataArray(np.arange(1.0, 7.0), dims="time")
+    b = xr.DataArray(np.ones(6), dims="time")
+    ds_a = xr.Dataset({"error": a})
+    ds_b = xr.Dataset({"error": b})
+
+    op = DieboldMariano("error", hln_correction=False)
+    out = op(ds_a, ds_b)
+    expected = dm_test(a, b, hln_correction=False)
+    xr.testing.assert_allclose(out, expected)
+
+    cfg = op.get_config()
+    json.dumps(cfg)  # JSON-roundtrip-safe
+    xr.testing.assert_allclose(DieboldMariano(**cfg)(ds_a, ds_b), out)
 
 
 def test_operator_configs_round_trip() -> None:
@@ -206,9 +249,9 @@ def test_scores_by_region_count_is_zero_for_empty_region() -> None:
 
 def test_dm_test_accepts_errors_keyword_naming() -> None:
     """The renamed parameter names work as keyword args."""
-    e = np.array([0.5, -0.5, 0.5, -0.5, 0.5])
-    stat, _ = dm_test(errors_a=e, errors_b=e)
-    np.testing.assert_allclose(stat, 0.0)
+    e = xr.DataArray(np.array([0.5, -0.5, 0.5, -0.5, 0.5]), dims="time")
+    out = dm_test(errors_a=e, errors_b=e)
+    np.testing.assert_allclose(out["statistic"].values, 0.0)
 
 
 def _track_dataset() -> xr.Dataset:

--- a/tests/transforms/test_encoder_operators.py
+++ b/tests/transforms/test_encoder_operators.py
@@ -57,17 +57,17 @@ def ds_time() -> xr.Dataset:
 def test_cyclical_encode_parity(ds_scalar: xr.Dataset) -> None:
     op = CyclicalEncode(variable="angle", period=2 * np.pi)
     out = op(ds_scalar)
-    sin_e, cos_e = cyclical_encode(ds_scalar["angle"].values, period=2 * np.pi)
-    np.testing.assert_allclose(out["angle_sin"].values, sin_e)
-    np.testing.assert_allclose(out["angle_cos"].values, cos_e)
+    encoded = cyclical_encode(ds_scalar["angle"], period=2 * np.pi)
+    np.testing.assert_allclose(out["angle_sin"].values, encoded["sin"].values)
+    np.testing.assert_allclose(out["angle_cos"].values, encoded["cos"].values)
     assert "angle" in out  # original preserved
 
 
 def test_fourier_features_parity(ds_scalar: xr.Dataset) -> None:
     op = FourierFeatures(variable="angle", num_freqs=4, scale=2.0)
     out = op(ds_scalar)
-    expected = fourier_features(ds_scalar["angle"].values, num_freqs=4, scale=2.0)
-    np.testing.assert_allclose(out["angle_fourier"].values, expected)
+    expected = fourier_features(ds_scalar["angle"], num_freqs=4, scale=2.0)
+    np.testing.assert_allclose(out["angle_fourier"].values, expected.values)
     assert out["angle_fourier"].dims == ("sample", "feature")
     assert out.sizes["feature"] == 8
 
@@ -76,9 +76,9 @@ def test_random_fourier_features_parity(ds_scalar: xr.Dataset) -> None:
     op = RandomFourierFeatures(variable="angle", num_features=10, sigma=1.5, seed=42)
     out = op(ds_scalar)
     expected = random_fourier_features(
-        ds_scalar["angle"].values, num_features=10, sigma=1.5, seed=42
+        ds_scalar["angle"], num_features=10, sigma=1.5, seed=42
     )
-    np.testing.assert_allclose(out["angle_rff"].values, expected)
+    np.testing.assert_allclose(out["angle_rff"].values, expected.values)
     assert out["angle_rff"].dims == ("sample", "feature")
 
 
@@ -98,21 +98,19 @@ def test_random_fourier_features_replaces_trailing_axis_for_vector_input() -> No
     op = RandomFourierFeatures(variable="x", num_features=8, sigma=1.0, seed=1)
     out = op(ds)
     expected = random_fourier_features(
-        ds["x"].values, num_features=8, sigma=1.0, seed=1
+        ds["x"], num_features=8, sigma=1.0, seed=1, input_dim="channel"
     )
     # Output should be 2-D (sample, feature) — trailing channel axis replaced.
     assert out["x_rff"].dims == ("sample", "feature")
     assert out["x_rff"].shape == (6, 8)
-    np.testing.assert_allclose(out["x_rff"].values, expected)
+    np.testing.assert_allclose(out["x_rff"].values, expected.values)
 
 
 def test_positional_encoding_parity(ds_scalar: xr.Dataset) -> None:
     op = PositionalEncoding(variable="angle", num_freqs=3, include_input=True)
     out = op(ds_scalar)
-    expected = positional_encoding(
-        ds_scalar["angle"].values, num_freqs=3, include_input=True
-    )
-    np.testing.assert_allclose(out["angle_posenc"].values, expected)
+    expected = positional_encoding(ds_scalar["angle"], num_freqs=3, include_input=True)
+    np.testing.assert_allclose(out["angle_posenc"].values, expected.values)
 
 
 def test_encode_time_cyclical_parity(ds_time: xr.Dataset) -> None:


### PR DESCRIPTION
## Summary

Closes out the remaining `ndarray`-positional Layer-0 primitives that PRs α/β/γ deliberately deferred in the [`xarray-native-primitives`](docs/design/xarray-native-primitives.md) contract. After this PR every pure Layer-0 primitive in the package is DataArray-positional; the only Layer-0 functions still taking `ndarray` are gone.

Of the five modules the design doc flagged as "deliberate non-flips", only **two genuinely needed flipping** — the other three are either already contract-clean or a deliberately different pattern, and are documented as permanently exempt.

## Flipped to pure-xarray

**`transforms/_src/encoders/basis.py`**
- `cyclical_encode(da, *, period) -> Dataset` — `sin` / `cos` (the structured multi-output shape).
- `fourier_features`, `random_fourier_features`, `positional_encoding` are `DataArray` → `DataArray`, each adding a trailing `feature_dim` via `xr.apply_ufunc`.
- `random_fourier_features` gains an explicit `input_dim` keyword naming the channel axis to project from, replacing the old "auto-detect on `ndim`" behaviour.
- The numpy math is preserved verbatim as underscore-prefixed kernels (`_sin_cos`, `_fourier_features_array`, `_random_fourier_features_array`, `_positional_encoding_array`); `encode_time_cyclical` reuses `_sin_cos` directly (byte-identical output).
- The `CyclicalEncode` / `FourierFeatures` / `RandomFourierFeatures` / `PositionalEncoding` operators now select → call → `assign` instead of hand-plumbing dims off `da.values`.

**`metrics/_src/dm.py`**
- `dm_test(errors_a, errors_b, *, dim=None, ...) -> Dataset` with `statistic` / `p_value` — scalars when `dim is None`, otherwise reduced along `dim` and broadcast over the rest via `xr.apply_ufunc`. The Newey–West / HLN math is preserved verbatim in the private `_dm_stat_pvalue` kernel.
- New Layer-1 **`DieboldMariano(variable, *, dim, ...)`** operator, selecting the error variable from two input Datasets. Exported from `xrtoolz.metrics` and `xrtoolz.metrics.operators`.

## Reconciled non-flips (no code change)

- `transforms/_src/morphology.py` already took a positional `DataArray` with keyword-only config and returned a `DataArray` — it conforms as-is.
- `transforms/_src/decompose.py` (`pca`/`eof`/`ica`/`nmf`/`kmeans`) returns stateful `XarrayEstimator` objects (split-object `fit`/`transform`, D1/D2), and `sklearn_op.py::SklearnOp` is itself a Layer-1 `Operator`. Neither is a stateless Layer-0 primitive, so both are permanently exempt by the contract's own rules.

The design doc is updated to `0.3.0` with a PR δ note recording all of the above.

## Breaking changes

Layer-0 callers only — the Operator API (`CyclicalEncode(...)`, `FourierFeatures(...)`, etc.) is unchanged.

- `cyclical_encode(arr, period=...)` (→ `(sin, cos)` tuple) → `cyclical_encode(da, period=...)` (→ `Dataset`)
- `fourier_features(arr, ...)` / `positional_encoding(arr, ...)` / `random_fourier_features(arr, ...)` now take a `DataArray` and return a `DataArray` with a `feature_dim`
- `dm_test(errors_a, errors_b, ...)` (→ `(stat, p_value)` tuple) → returns a `Dataset(statistic, p_value)` and takes `DataArray` inputs

## Test plan

- [x] Affected tests rewritten to the new contract — **152 passed** across `tests/transforms/`, `tests/test_metrics_odc14.py`, `tests/test_geo_extended.py`, `tests/test_encoder_imports.py`.
- [x] New coverage: `dm_test` dim-wise broadcast path + `DieboldMariano` operator config round-trip.
- [x] Full suite: only the **9 pre-existing environment-related failures** (`find_intercept_2D`, `resolved_scale_2d`, `ssim`, `time_range`) — confirmed identical on the clean tree, none introduced here.
- [x] `ruff check .` + `ruff format --check .` clean.
- [x] `ty check src/xrtoolz` at the **82-diagnostic baseline** (no new diagnostics).

https://claude.ai/code/session_01RnCgeuvELHSZPQFEWZzkJJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RnCgeuvELHSZPQFEWZzkJJ)_