### PR TITLE
refactor(metrics,transforms): adopt einx in numpy kernels (PR 2/3)

### DIFF
--- a/src/xrtoolz/metrics/_src/distributional.py
+++ b/src/xrtoolz/metrics/_src/distributional.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import Any, cast
 
+import einx
 import numpy as np
 import xarray as xr
 import xskillscore as xs
@@ -111,8 +112,8 @@ def energy_distance(
     arr_b = da_b.transpose(sample_dim_b, ...).values  # (m, *rest)
     rest_shape = arr_a.shape[1:]
 
-    a_flat = arr_a.reshape(arr_a.shape[0], -1)  # (n, K)
-    b_flat = arr_b.reshape(arr_b.shape[0], -1)  # (m, K)
+    a_flat = einx.rearrange("n ... -> n (...)", arr_a)  # (n, K)
+    b_flat = einx.rearrange("n ... -> n (...)", arr_b)  # (m, K)
 
     # Per-pixel energy distance via scipy: O(n+m) per pixel rather than
     # O((n+m)^2), and uses the unbiased self-distance estimator (excludes
@@ -167,8 +168,8 @@ def wasserstein_1(
     arr_a = da_a.transpose(sample_dim_a, ...).values
     arr_b = da_b.transpose(sample_dim_b, ...).values
     rest_shape = arr_a.shape[1:]
-    a_flat = arr_a.reshape(arr_a.shape[0], -1)
-    b_flat = arr_b.reshape(arr_b.shape[0], -1)
+    a_flat = einx.rearrange("n ... -> n (...)", arr_a)
+    b_flat = einx.rearrange("n ... -> n (...)", arr_b)
 
     out_flat = np.array(
         [

--- a/src/xrtoolz/metrics/_src/distributional.py
+++ b/src/xrtoolz/metrics/_src/distributional.py
@@ -112,8 +112,8 @@ def energy_distance(
     arr_b = da_b.transpose(sample_dim_b, ...).values  # (m, *rest)
     rest_shape = arr_a.shape[1:]
 
-    a_flat = einx.rearrange("n ... -> n (...)", arr_a)  # (n, K)
-    b_flat = einx.rearrange("n ... -> n (...)", arr_b)  # (m, K)
+    a_flat = einx.id("n ... -> n (...)", arr_a)  # (n, K)
+    b_flat = einx.id("n ... -> n (...)", arr_b)  # (m, K)
 
     # Per-pixel energy distance via scipy: O(n+m) per pixel rather than
     # O((n+m)^2), and uses the unbiased self-distance estimator (excludes
@@ -168,8 +168,8 @@ def wasserstein_1(
     arr_a = da_a.transpose(sample_dim_a, ...).values
     arr_b = da_b.transpose(sample_dim_b, ...).values
     rest_shape = arr_a.shape[1:]
-    a_flat = einx.rearrange("n ... -> n (...)", arr_a)
-    b_flat = einx.rearrange("n ... -> n (...)", arr_b)
+    a_flat = einx.id("n ... -> n (...)", arr_a)
+    b_flat = einx.id("n ... -> n (...)", arr_b)
 
     out_flat = np.array(
         [

--- a/src/xrtoolz/metrics/_src/instance.py
+++ b/src/xrtoolz/metrics/_src/instance.py
@@ -60,8 +60,8 @@ def mask_iou_matrix(
     n_p, n_r = pred.shape[0], ref.shape[0]
     if n_p == 0 or n_r == 0:
         return np.zeros((n_p, n_r), dtype=np.float64)
-    flat_pred = einx.rearrange("n h w -> n (h w)", pred).astype(np.int64)
-    flat_ref = einx.rearrange("n h w -> n (h w)", ref).astype(np.int64)
+    flat_pred = einx.id("n h w -> n (h w)", pred).astype(np.int64)
+    flat_ref = einx.id("n h w -> n (h w)", ref).astype(np.int64)
     # ``inter[i, j] = sum(pred_i AND ref_j)`` computed via boolean matmul
     # over int64 (named: contract the flattened-pixel axis). For typical
     # N ~ 1e2-1e3 and HW ~ 1e6 this is the cheap path.

--- a/src/xrtoolz/metrics/_src/instance.py
+++ b/src/xrtoolz/metrics/_src/instance.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 from typing import Any
 
+import einx
 import numpy as np
 import xarray as xr
 
@@ -59,11 +60,12 @@ def mask_iou_matrix(
     n_p, n_r = pred.shape[0], ref.shape[0]
     if n_p == 0 or n_r == 0:
         return np.zeros((n_p, n_r), dtype=np.float64)
-    flat_pred = pred.reshape(n_p, -1).astype(np.int64)
-    flat_ref = ref.reshape(n_r, -1).astype(np.int64)
+    flat_pred = einx.rearrange("n h w -> n (h w)", pred).astype(np.int64)
+    flat_ref = einx.rearrange("n h w -> n (h w)", ref).astype(np.int64)
     # ``inter[i, j] = sum(pred_i AND ref_j)`` computed via boolean matmul
-    # over int64. For typical N ~ 1e2-1e3 and HW ~ 1e6 this is the cheap path.
-    inter = flat_pred @ flat_ref.T
+    # over int64 (named: contract the flattened-pixel axis). For typical
+    # N ~ 1e2-1e3 and HW ~ 1e6 this is the cheap path.
+    inter = einx.dot("pred pix, ref pix -> pred ref", flat_pred, flat_ref)
     area_p = flat_pred.sum(axis=1, keepdims=True)
     area_r = flat_ref.sum(axis=1, keepdims=True).T
     union = area_p + area_r - inter

--- a/src/xrtoolz/transforms/_src/encoders/basis.py
+++ b/src/xrtoolz/transforms/_src/encoders/basis.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from collections.abc import Hashable
 
+import einx
 import numpy as np
 import xarray as xr
 from numpy.typing import ArrayLike, NDArray
@@ -60,7 +61,8 @@ def _random_fourier_features_array(
         x = values[..., None]
     rng = np.random.default_rng(seed)
     omega = rng.standard_normal((d, num_features // 2)) / sigma
-    projection = x @ omega  # (..., num_features // 2)
+    # Contract the channel axis ``d`` into the random-feature axis ``f``.
+    projection = einx.dot("... d, d f -> ... f", x, omega)  # (..., num_features // 2)
     return np.concatenate([np.sin(projection), np.cos(projection)], axis=-1)
 
 


### PR DESCRIPTION
## Summary

Follow-on to #218. Now that the `xrtoolz.einx` bridge and the einx core dependency have landed, this PR sweeps the **clarity-positive numpy-kernel sites** in core modules to use einx. Combines the planned PR 2 + PR 3 into one.

All changes are **numerics-identical** to the originals (verified against the prior implementations), and these are internal kernels — **no public signatures change**.

## Conversions

- **`metrics/_src/instance.py`** — IoU intersection counts via `einx.dot("pred pix, ref pix -> pred ref", flat_pred, flat_ref)` instead of `flat_pred @ flat_ref.T` (names the per-pixel contraction); mask flatten via `einx.rearrange("n h w -> n (h w)", ...)`.
- **`metrics/_src/distributional.py`** — sample-vs-rest flatten via `einx.rearrange("n ... -> n (...)", ...)` in `energy_distance` / `wasserstein_1`.
- **`transforms/_src/encoders/basis.py`** — random-Fourier projection via `einx.dot("... d, d f -> ... f", x, omega)` instead of `x @ omega` (names the channel→feature contraction).

## Scope — what was deliberately *not* converted

Per the agreed "where it adds clarity" scope:

- **Idiomatic label transposes** like `da.transpose("time","lat","lon")` — already label-based and dependency-free; einx would add indirection for zero gain.
- **Dynamic inverse-reshapes** back to a runtime `rest_shape` tuple (e.g. `out_flat.reshape(rest_shape)`) — no fixed einx pattern expresses a variable-rank target shape.
- **Tiny 1-D dot products** (`dm.py` Newey–West `np.dot`) — no clarity benefit.
- A few additional kernels (`structural.py` variable-rank reshapes, `coord_remap`/`_smooth` kernels) were left for a possible later pass; their reshapes are shape-juggling rather than contractions, so the clarity payoff is low.

## Test plan

- [x] `tests/test_metrics_instance.py`, distributional metric tests, encoder/RFF tests (`test_encoder_operators`, `test_geo_extended`), and `tests/einx/` — all green. The RFF **seed-reproducibility** test and the instance **IoU/matching** tests are the numeric guardrails (identical results ⇒ identical math).
- [x] Full suite: **9 failed** — the same pre-existing environment-only failures (`find_intercept_2D`, `resolved_scale_2d`, `psd_score_spacetime`, `ssim`, `time_range`); none introduced here (`structural.py`/`ssim` untouched).
- [x] `ruff check .` + `ruff format --check .` clean.
- [x] `ty check src/xrtoolz`: **93 diagnostics, 0 errors** (+8 *warnings* vs the post-#218 baseline of 85, all from einx's partially-typed `dot`/`rearrange` returns in the swept files). The typecheck CI job is warning-tolerant and passes.

https://claude.ai/code/session_01RnCgeuvELHSZPQFEWZzkJJ