### PR TITLE
refactor(utils): consolidate _coord_spacing into utils.spacing (cleanup sweep PR 2)

### DIFF
--- a/src/xrtoolz/geo/_src/wavelet.py
+++ b/src/xrtoolz/geo/_src/wavelet.py
@@ -7,12 +7,12 @@ import xarray as xr
 from scipy.fft import fft2, fftfreq, ifft2
 
 from xrtoolz.geo._src.wavelet_utils import (
-    _coord_spacing,
     _require_dims,
     _scale_values,
     build_coi_mask,
     scale_to_wavenumber,
 )
+from xrtoolz.utils._src.spacing import coord_spacing
 
 
 def morlet2_ft(
@@ -81,8 +81,8 @@ def cwt2(
     ydim, xdim = dim
     s = _as_scale_dataarray(s)
     _validate_cwt_input(da, s, dim=dim, ntheta=ntheta)
-    dy = _coord_spacing(da, ydim)
-    dx = _coord_spacing(da, xdim)
+    dy = coord_spacing(da, ydim)
+    dx = coord_spacing(da, xdim)
     arr = np.asarray(da.transpose(ydim, xdim).values)
     nan_mask = np.isnan(arr)
     if nan_mask.any():

--- a/src/xrtoolz/geo/_src/wavelet1d.py
+++ b/src/xrtoolz/geo/_src/wavelet1d.py
@@ -10,6 +10,8 @@ import xarray as xr
 from scipy.fft import fft, fftfreq, ifft
 from scipy.special import gammaincinv
 
+from xrtoolz.utils._src.spacing import coord_spacing
+
 
 Mother = Literal["morlet", "paul", "dog"]
 NullModel = Literal["red", "white"]
@@ -52,7 +54,7 @@ def cwt1d(
     """
     _require_dim(da, dim)
     _raise_if_chunked_along_dim(da, dim, "cwt1d")
-    dt = _coord_spacing(da, dim)
+    dt = coord_spacing(da, dim, require_coord=False)
     scale = _scale_grid(da.sizes[dim], dt=dt, s0=s0, dj=dj, j_max=j_max)
     mother_name = _normalize_mother(mother)
     param_value = _default_param(mother_name, param)
@@ -372,24 +374,6 @@ def _scale_grid(
     if j_stop < 0:
         raise ValueError("j_max must be non-negative for the chosen s0 and dt")
     return s0_value * 2.0 ** (np.arange(j_stop + 1, dtype=float) * dj)
-
-
-def _coord_spacing(da: xr.DataArray, dim: str) -> float:
-    if dim not in da.coords:
-        return 1.0
-    values = da[dim].values
-    if values.size < 2:
-        raise ValueError(f"dim {dim!r} must contain at least two samples")
-    if np.issubdtype(values.dtype, np.datetime64):
-        numeric = values.astype("datetime64[ns]").astype("int64").astype(float) / 1.0e9
-    else:
-        numeric = np.asarray(values, dtype=float)
-    diffs = np.diff(numeric)
-    if not np.allclose(diffs, diffs[0], rtol=1e-6, atol=1e-9):
-        raise ValueError(
-            f"coord {dim!r} is not uniformly spaced; resample before cwt1d."
-        )
-    return float(abs(diffs[0]))
 
 
 def _coi(

--- a/src/xrtoolz/geo/_src/wavelet_utils.py
+++ b/src/xrtoolz/geo/_src/wavelet_utils.py
@@ -6,6 +6,8 @@ import numpy as np
 import xarray as xr
 from scipy.ndimage import distance_transform_edt
 
+from xrtoolz.utils._src.spacing import coord_spacing
+
 
 def geometric_scales(
     s0: float,
@@ -78,8 +80,8 @@ def build_coi_mask(
     """
     ydim, xdim = dim
     _require_dims(da, dim)
-    dy = _coord_spacing(da, ydim)
-    dx = _coord_spacing(da, xdim)
+    dy = coord_spacing(da, ydim)
+    dx = coord_spacing(da, xdim)
     arr = np.asarray(da.transpose(ydim, xdim).values, dtype=float)
     valid = np.isfinite(arr)
 
@@ -112,25 +114,6 @@ def build_coi_mask(
         },
         name="coi_mask",
     )
-
-
-def _coord_spacing(da: xr.DataArray, dim: str) -> float:
-    """Validate a coordinate is uniform and return its absolute spacing."""
-    if dim not in da.coords:
-        raise ValueError(
-            f"dim {dim!r} has no coordinate; wavelet spectra require "
-            "uniform locally-Cartesian coordinates."
-        )
-    values = np.asarray(da[dim].values, dtype=float)
-    if values.size < 2:
-        raise ValueError(f"dim {dim!r} must contain at least two samples")
-    diffs = np.diff(values)
-    if not np.allclose(diffs, diffs[0], rtol=1e-6, atol=1e-9):
-        raise ValueError(
-            f"coord {dim!r} is not uniformly spaced; reproject/resample onto "
-            "a regular Cartesian grid before calling cwt2."
-        )
-    return float(abs(diffs[0]))
 
 
 def _scale_values(scales: xr.DataArray) -> np.ndarray:

--- a/src/xrtoolz/transforms/_src/fourier.py
+++ b/src/xrtoolz/transforms/_src/fourier.py
@@ -24,6 +24,8 @@ import numpy as np
 import xarray as xr
 import xrft
 
+from xrtoolz.utils._src.spacing import coord_spacing
+
 
 _DEFAULT_PSD_KWARGS: dict[str, Any] = {
     "scaling": "density",
@@ -516,9 +518,18 @@ def rotary_spectrum(
     spec = xrft.fft(w, dim=[dim], window=None, detrend="constant", true_amplitude=False)
     freq_dim = f"freq_{dim}"
     # DataArrays can legally have dims without explicit coord variables;
-    # fall back to unit spacing in that case rather than KeyError-ing.
-    coord = u[dim] if dim in u.coords else None
-    density_scale = (_coord_spacing(coord) if coord is not None else 1.0) / u.sizes[dim]
+    # fall back to unit spacing in that case rather than KeyError-ing. The
+    # density scaling tolerates non-uniform / singleton coords too.
+    density_scale = (
+        coord_spacing(
+            u,
+            dim,
+            require_coord=False,
+            require_min_samples=False,
+            require_uniform=False,
+        )
+        / u.sizes[dim]
+    )
     psd = (np.abs(spec) ** 2) * density_scale
 
     psd_ccw = psd.where(psd[freq_dim] > 0.0, drop=True).rename({freq_dim: "wavenumber"})
@@ -547,19 +558,6 @@ def rotary_spectrum(
         dims = [avg_dims] if isinstance(avg_dims, str) else list(avg_dims)
         out = out.mean(dim=dims)
     return out
-
-
-def _coord_spacing(coord: xr.DataArray) -> float:
-    if coord.size < 2:
-        # A singleton axis has no resolvable sample spacing; use unit spacing so
-        # callers still get deterministic density scaling.
-        return 1.0
-    values = np.asarray(coord.values)
-    if np.issubdtype(values.dtype, np.datetime64):
-        diffs = np.diff(values).astype("timedelta64[ns]").astype(float) / 1e9
-    else:
-        diffs = np.diff(values.astype(float))
-    return float(np.median(np.abs(diffs)))
 
 
 def _polarization_epsilon(da: xr.DataArray) -> float:

--- a/src/xrtoolz/utils/_src/spacing.py
+++ b/src/xrtoolz/utils/_src/spacing.py
@@ -1,0 +1,77 @@
+"""Coordinate sample-spacing helper shared across spectral / wavelet code.
+
+Centralises the ``_coord_spacing`` logic that was previously copied into
+the Fourier (:mod:`xrtoolz.transforms._src.fourier`) and wavelet
+(:mod:`xrtoolz.geo._src.wavelet_utils`,
+:mod:`xrtoolz.geo._src.wavelet1d`) modules. The three copies differed
+only in how strict they were about missing, singleton, and non-uniform
+coordinates; those differences are now expressed as flags.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import xarray as xr
+
+
+def coord_spacing(
+    da: xr.DataArray,
+    dim: str,
+    *,
+    require_coord: bool = True,
+    require_min_samples: bool = True,
+    require_uniform: bool = True,
+    fallback: float = 1.0,
+) -> float:
+    """Absolute sample spacing of the coordinate for ``dim``.
+
+    ``datetime64`` coordinates are measured in seconds.
+
+    Args:
+        da: Field carrying the coordinate.
+        dim: Dimension whose coordinate spacing is measured.
+        require_coord: When ``dim`` has no coordinate variable, raise
+            (``True``) or return ``fallback`` (``False``). xarray permits
+            dims without an explicit coordinate.
+        require_min_samples: When the coordinate has fewer than two
+            samples, raise (``True``) or return ``fallback`` (``False``).
+        require_uniform: When the spacing is non-uniform, raise (``True``)
+            or return the median ``|Δ|`` (``False``).
+        fallback: Spacing returned for the degenerate cases above whose
+            ``require_*`` flag is ``False``.
+
+    Returns:
+        The positive sample spacing.
+
+    Raises:
+        ValueError: per the ``require_*`` flags — missing coordinate,
+            fewer than two samples, or non-uniform spacing.
+    """
+    if dim not in da.coords:
+        if require_coord:
+            raise ValueError(
+                f"dim {dim!r} has no coordinate variable; cannot measure its "
+                "sample spacing."
+            )
+        return fallback
+
+    values = np.asarray(da[dim].values)
+    if values.size < 2:
+        if require_min_samples:
+            raise ValueError(f"coord {dim!r} must contain at least two samples.")
+        return fallback
+
+    if np.issubdtype(values.dtype, np.datetime64):
+        numeric = values.astype("datetime64[ns]").astype("int64").astype(float) / 1e9
+    else:
+        numeric = values.astype(float)
+
+    diffs = np.diff(numeric)
+    if require_uniform:
+        if not np.allclose(diffs, diffs[0], rtol=1e-6, atol=1e-9):
+            raise ValueError(
+                f"coord {dim!r} is not uniformly spaced; resample onto a regular "
+                "grid first."
+            )
+        return float(abs(diffs[0]))
+    return float(np.median(np.abs(diffs)))

--- a/tests/utils/test_spacing.py
+++ b/tests/utils/test_spacing.py
@@ -1,0 +1,69 @@
+"""Tests for the consolidated ``coord_spacing`` helper.
+
+Pins the three policy combinations the Fourier and wavelet modules rely
+on after their per-module ``_coord_spacing`` copies were unified.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from xrtoolz.utils._src.spacing import coord_spacing
+
+
+def _da(coord: list[float] | None) -> xr.DataArray:
+    n = 4 if coord is None else len(coord)
+    if coord is None:
+        return xr.DataArray(np.arange(n, dtype=float), dims="x")
+    return xr.DataArray(np.arange(n, dtype=float), dims="x", coords={"x": coord})
+
+
+def test_uniform_spacing():
+    assert coord_spacing(_da([0.0, 2.0, 4.0, 6.0]), "x") == 2.0
+
+
+def test_datetime_spacing_in_seconds():
+    times = np.array(["2020-01-01", "2020-01-02", "2020-01-03"], dtype="datetime64[ns]")
+    da = xr.DataArray([0.0, 1.0, 2.0], dims="t", coords={"t": times})
+    assert coord_spacing(da, "t") == 86400.0  # one day in seconds
+
+
+# ---- missing-coordinate policy (require_coord) -------------------------------
+
+
+def test_missing_coord_raises_by_default():
+    with pytest.raises(ValueError, match="no coordinate"):
+        coord_spacing(_da(None), "x")
+
+
+def test_missing_coord_falls_back_when_allowed():
+    assert coord_spacing(_da(None), "x", require_coord=False, fallback=1.0) == 1.0
+
+
+# ---- singleton policy (require_min_samples) ----------------------------------
+
+
+def test_singleton_raises_by_default():
+    da = xr.DataArray([1.0], dims="x", coords={"x": [0.0]})
+    with pytest.raises(ValueError, match="at least two samples"):
+        coord_spacing(da, "x")
+
+
+def test_singleton_falls_back_when_allowed():
+    da = xr.DataArray([1.0], dims="x", coords={"x": [0.0]})
+    assert coord_spacing(da, "x", require_min_samples=False, fallback=1.0) == 1.0
+
+
+# ---- uniformity policy (require_uniform) -------------------------------------
+
+
+def test_non_uniform_raises_when_required():
+    with pytest.raises(ValueError, match="uniformly spaced"):
+        coord_spacing(_da([0.0, 1.0, 5.0]), "x")
+
+
+def test_non_uniform_returns_median_when_tolerant():
+    # |Δ| = [1, 4] -> median 2.5
+    assert coord_spacing(_da([0.0, 1.0, 5.0]), "x", require_uniform=False) == 2.5


### PR DESCRIPTION
## What

Cleanup sweep **PR 2**. Consolidates the duplicated coordinate sample-spacing
logic. The audit found `_coord_spacing` implemented in three modules with
subtly different strictness — and it was actually **four** call sites
(`geo/wavelet.py` imported the `wavelet_utils` copy).

## The problem

| Site | missing coord | < 2 samples | non-uniform | datetime |
|---|---|---|---|---|
| `transforms/fourier` | → 1.0 | → 1.0 | median (tolerant) | yes |
| `geo/wavelet_utils` (+ `geo/wavelet`) | raise | raise | raise | no |
| `geo/wavelet1d` | → 1.0 | raise | raise | yes |

Three subtly different copies = a latent inconsistency bug magnet.

## The fix

One shared helper — `xrtoolz.utils._src.spacing.coord_spacing(da, dim)` — whose
differences are **explicit, orthogonal flags** (`require_coord`,
`require_min_samples`, `require_uniform`, `fallback`) plus unified `datetime64`
handling. Each call site maps to its **exact prior behaviour**:

- `fourier` density scaling → `require_*=False` (tolerant) + median;
- `wavelet` / `wavelet_utils` (cwt2) → strict defaults;
- `wavelet1d` (cwt1d) → `require_coord=False`, otherwise strict.

The non-uniform error keeps the `"uniformly spaced"` wording the existing
tests match. Adds `tests/utils/test_spacing.py` pinning every policy
combination (8 cases).

## Verification

| Check | Result |
|---|---|
| `pytest` (`--all-extras`) | **1402 passed** (incl. 8 new spacing tests); the 1 failure is the pre-existing `tzdata`/`US/Pacific` env gap in `tests/types` |
| `ruff check .` / `format` | passed |
| `ty check src/xrtoolz` | exit 0 |

No behaviour change. Independent of PR 1 (#228).

https://claude.ai/code/session_01BiceP8WMSTKWdkcLQ4vrqz

---
_Generated by [Claude Code](https://claude.ai/code/session_01BiceP8WMSTKWdkcLQ4vrqz)_