### PR TITLE
docs(ocn): docstrings for every ocn operator (cleanup sweep PR 3)

### DIFF
--- a/src/xrtoolz/ocn/operators.py
+++ b/src/xrtoolz/ocn/operators.py
@@ -1,4 +1,13 @@
-"""Layer-1 ``Operator`` wrappers around :mod:`xrtoolz.ocn._src`."""
+"""Layer-1 ``Operator`` wrappers around :mod:`xrtoolz.ocn._src`.
+
+Each operator is a thin, configurable adapter over a pure-function physics
+primitive: ``__init__`` captures the variable / coordinate names, and
+``_apply`` forwards the dataset to the primitive. Operators take an
+:class:`xarray.Dataset` and return it augmented with the computed
+diagnostic. See :mod:`xrtoolz.ocn._src.kinematics`,
+:mod:`xrtoolz.ocn._src.ssh`, and :mod:`xrtoolz.ocn._src.validation` for the
+underlying implementations.
+"""
 
 from __future__ import annotations
 
@@ -16,6 +25,18 @@ from xrtoolz.ocn._src import (
 
 
 class ValidateSSH(Operator):
+    """Validate and CF-normalise a sea-surface-height field.
+
+    Checks that ``variable`` is present and finite and applies the canonical
+    SSH metadata (standard name, units), raising on malformed input.
+
+    Args:
+        variable: Name of the sea-surface-height variable to validate.
+
+    Returns:
+        The input dataset with ``variable`` validated and CF-tagged.
+    """
+
     def __init__(self, variable: str = "ssh"):
         self.variable = variable
 
@@ -27,6 +48,19 @@ class ValidateSSH(Operator):
 
 
 class ValidateVelocity(Operator):
+    """Validate a horizontal velocity pair ``(u, v)``.
+
+    Ensures both components are present, finite, and consistently shaped, and
+    applies the canonical CF velocity metadata.
+
+    Args:
+        u: Name of the eastward (zonal) velocity variable.
+        v: Name of the northward (meridional) velocity variable.
+
+    Returns:
+        The input dataset with ``u`` and ``v`` validated and CF-tagged.
+    """
+
     def __init__(self, u: str = "u", v: str = "v"):
         self.u = u
         self.v = v
@@ -42,6 +76,23 @@ class ValidateVelocity(Operator):
 
 
 class CalculateSSHAlongtrack(Operator):
+    """Compose along-track SSH from its altimetry components.
+
+    Reconstructs sea-surface height as ``ssh = sla + mdt − lwe``: filtered
+    sea-level anomaly plus the mean dynamic topography, minus an optional
+    long-wavelength-error correction.
+
+    Args:
+        variable: Name of the output SSH variable to create.
+        sla: Name of the (filtered) sea-level-anomaly variable.
+        mdt: Name of the mean-dynamic-topography variable.
+        lwe: Name of the long-wavelength-error variable to subtract, or
+            ``None`` to skip the correction.
+
+    Returns:
+        The input dataset with the composed ``variable`` (SSH) added.
+    """
+
     def __init__(
         self,
         variable: str = "ssh",
@@ -76,6 +127,19 @@ class CalculateSSHAlongtrack(Operator):
 
 
 class Streamfunction(Operator):
+    """Geostrophic stream function ``ψ = (g / f₀) · η`` from SSH.
+
+    Args:
+        variable: Name of the sea-surface-height (η) variable.
+        g: Gravitational acceleration (m s⁻²). ``None`` uses the package
+            default.
+        f0: Reference Coriolis parameter (s⁻¹). ``None`` derives ``f`` from
+            latitude on the f-plane reference.
+
+    Returns:
+        The input dataset with a ``psi`` stream-function variable (m² s⁻¹).
+    """
+
     def __init__(
         self,
         variable: str = "ssh",
@@ -96,6 +160,19 @@ class Streamfunction(Operator):
 
 
 class GeostrophicVelocities(Operator):
+    """Geostrophic velocities ``(u_g, v_g)`` from a height field.
+
+    Computes ``u_g = −(g/f) ∂η/∂y`` and ``v_g = (g/f) ∂η/∂x`` on the
+    lon/lat sphere.
+
+    Args:
+        variable: Name of the sea-surface-height (η) variable.
+
+    Returns:
+        The input dataset with the geostrophic ``u`` and ``v`` velocity
+        variables (m s⁻¹).
+    """
+
     def __init__(self, variable: str = "ssh"):
         self.variable = variable
 
@@ -107,7 +184,12 @@ class GeostrophicVelocities(Operator):
 
 
 class _UVOperator(Operator):
-    """Shared init/config for operators that take ``u`` and ``v``."""
+    """Shared ``__init__`` / ``get_config`` for ``(u, v)`` velocity operators.
+
+    Args:
+        u: Name of the eastward (zonal) velocity variable.
+        v: Name of the northward (meridional) velocity variable.
+    """
 
     def __init__(self, u: str = "u", v: str = "v"):
         self.u = u
@@ -118,46 +200,138 @@ class _UVOperator(Operator):
 
 
 class KineticEnergy(_UVOperator):
+    """Kinetic energy ``KE = ½ (u² + v²)``.
+
+    Args:
+        u: Name of the eastward velocity variable.
+        v: Name of the northward velocity variable.
+
+    Returns:
+        The input dataset with a ``ke`` variable (m² s⁻²).
+    """
+
     def _apply(self, ds):
         return _kinematics.kinetic_energy(ds, u=self.u, v=self.v)
 
 
 class RelativeVorticity(_UVOperator):
+    """Relative (vertical) vorticity ``ζ = ∂v/∂x − ∂u/∂y``.
+
+    Args:
+        u: Name of the eastward velocity variable.
+        v: Name of the northward velocity variable.
+
+    Returns:
+        The input dataset with a ``vort_r`` variable (s⁻¹).
+    """
+
     def _apply(self, ds):
         return _kinematics.relative_vorticity(ds, u=self.u, v=self.v)
 
 
 class AbsoluteVorticity(_UVOperator):
+    """Absolute vorticity ``ζ_a = ζ + f`` (relative plus planetary).
+
+    Args:
+        u: Name of the eastward velocity variable.
+        v: Name of the northward velocity variable.
+
+    Returns:
+        The input dataset with a ``vort_a`` variable (s⁻¹).
+    """
+
     def _apply(self, ds):
         return _kinematics.absolute_vorticity(ds, u=self.u, v=self.v)
 
 
 class Divergence(_UVOperator):
+    """Horizontal divergence ``∇·u = ∂u/∂x + ∂v/∂y`` on the lon/lat sphere.
+
+    Args:
+        u: Name of the eastward velocity variable.
+        v: Name of the northward velocity variable.
+
+    Returns:
+        The input dataset with a ``div`` variable (s⁻¹).
+    """
+
     def _apply(self, ds):
         return _kinematics.divergence(ds, u=self.u, v=self.v)
 
 
 class ShearStrain(_UVOperator):
+    """Shear strain rate ``S_s = ∂v/∂x + ∂u/∂y``.
+
+    Args:
+        u: Name of the eastward velocity variable.
+        v: Name of the northward velocity variable.
+
+    Returns:
+        The input dataset with a ``shear_strain`` variable (s⁻¹).
+    """
+
     def _apply(self, ds):
         return _kinematics.shear_strain(ds, u=self.u, v=self.v)
 
 
 class TensorStrain(_UVOperator):
+    """Normal (tensor) strain rate ``S_n = ∂u/∂x − ∂v/∂y``.
+
+    Args:
+        u: Name of the eastward velocity variable.
+        v: Name of the northward velocity variable.
+
+    Returns:
+        The input dataset with a ``tensor_strain`` variable (s⁻¹).
+    """
+
     def _apply(self, ds):
         return _kinematics.tensor_strain(ds, u=self.u, v=self.v)
 
 
 class StrainMagnitude(_UVOperator):
+    """Total strain-rate magnitude ``√(S_n² + S_s²)``.
+
+    Args:
+        u: Name of the eastward velocity variable.
+        v: Name of the northward velocity variable.
+
+    Returns:
+        The input dataset with a ``strain`` variable (s⁻¹).
+    """
+
     def _apply(self, ds):
         return _kinematics.strain_magnitude(ds, u=self.u, v=self.v)
 
 
 class OkuboWeiss(_UVOperator):
+    """Okubo–Weiss parameter ``W = S_n² + S_s² − ζ²``.
+
+    Negative ``W`` marks vorticity-dominated (eddy-core) regions; positive
+    ``W`` marks strain-dominated regions.
+
+    Args:
+        u: Name of the eastward velocity variable.
+        v: Name of the northward velocity variable.
+
+    Returns:
+        The input dataset with an ``ow`` variable (s⁻²).
+    """
+
     def _apply(self, ds):
         return _kinematics.okubo_weiss(ds, u=self.u, v=self.v)
 
 
 class Enstrophy(Operator):
+    """Enstrophy ``½ ζ²`` from a relative-vorticity field.
+
+    Args:
+        variable: Name of the (relative) vorticity variable to square.
+
+    Returns:
+        The input dataset with an ``ens`` variable (s⁻²).
+    """
+
     def __init__(self, variable: str = "vort_r"):
         self.variable = variable
 
@@ -169,6 +343,19 @@ class Enstrophy(Operator):
 
 
 class CoriolisNormalized(Operator):
+    """Normalise a field by the Coriolis parameter ``f₀``.
+
+    Divides ``variable`` by ``f`` (e.g. to form the Rossby number ``ζ/f``).
+
+    Args:
+        variable: Name of the variable to normalise.
+        f0: Reference Coriolis parameter (s⁻¹). ``None`` derives ``f`` from
+            latitude.
+
+    Returns:
+        The input dataset with ``variable`` replaced by ``variable / f``.
+    """
+
     def __init__(self, variable: str, f0: float | None = None):
         self.variable = variable
         self.f0 = f0
@@ -181,6 +368,21 @@ class CoriolisNormalized(Operator):
 
 
 class AgeostrophicVelocities(Operator):
+    """Ageostrophic velocities ``(u_a, v_a) = (u, v) − u_g(η)``.
+
+    Subtracts the geostrophic velocities derived from ``variable`` (SSH)
+    from the total velocities.
+
+    Args:
+        variable: Name of the sea-surface-height (η) variable.
+        u: Name of the total eastward velocity variable.
+        v: Name of the total northward velocity variable.
+
+    Returns:
+        The input dataset with ``u_a`` and ``v_a`` ageostrophic-velocity
+        variables (m s⁻¹).
+    """
+
     def __init__(self, variable: str = "ssh", u: str = "u", v: str = "v"):
         self.variable = variable
         self.u = u
@@ -196,6 +398,19 @@ class AgeostrophicVelocities(Operator):
 
 
 class Advection(Operator):
+    """Horizontal tracer advection ``−u·∇c`` on the lon/lat sphere.
+
+    Args:
+        scalar: Name of the advected tracer variable ``c``.
+        components: Names of the velocity components ``(u, v)``.
+        dims: Spatial dimension names ``(lon, lat)`` the gradient is taken
+            over.
+
+    Returns:
+        The input dataset with a ``<scalar>_advection`` tendency variable
+        added.
+    """
+
     def __init__(
         self,
         scalar: str,
@@ -220,16 +435,56 @@ class Advection(Operator):
 
 
 class ShearVorticity(_UVOperator):
+    """Along-flow shear component of the relative vorticity.
+
+    The part of ``ζ`` due to cross-stream changes in flow speed (as opposed
+    to streamline curvature).
+
+    Args:
+        u: Name of the eastward velocity variable.
+        v: Name of the northward velocity variable.
+
+    Returns:
+        The input dataset with a ``vort_shear`` variable (s⁻¹).
+    """
+
     def _apply(self, ds):
         return _kinematics.shear_vorticity(ds, u=self.u, v=self.v)
 
 
 class CurvatureVorticity(_UVOperator):
+    """Cross-flow curvature component of the relative vorticity.
+
+    The part of ``ζ`` due to streamline curvature; ``vort_shear`` and
+    ``vort_curv`` sum to the relative vorticity ``vort_r``.
+
+    Args:
+        u: Name of the eastward velocity variable.
+        v: Name of the northward velocity variable.
+
+    Returns:
+        The input dataset with a ``vort_curv`` variable (s⁻¹).
+    """
+
     def _apply(self, ds):
         return _kinematics.curvature_vorticity(ds, u=self.u, v=self.v)
 
 
 class Frontogenesis(Operator):
+    """Petterssen 2-D kinematic frontogenesis of a scalar on the sphere.
+
+    The rate of change of the horizontal gradient magnitude of ``scalar``
+    following the flow; positive values indicate front sharpening.
+
+    Args:
+        scalar: Name of the tracer variable (e.g. temperature).
+        u: Name of the eastward velocity variable.
+        v: Name of the northward velocity variable.
+
+    Returns:
+        The input dataset with a ``<scalar>_frontogenesis`` variable.
+    """
+
     def __init__(self, scalar: str, u: str = "u", v: str = "v"):
         self.scalar = scalar
         self.u = u
@@ -243,6 +498,17 @@ class Frontogenesis(Operator):
 
 
 class PotentialVorticityBarotropic(Operator):
+    """Single-layer barotropic potential vorticity ``(ζ + f) / h``.
+
+    Args:
+        height: Name of the layer-thickness (h) variable.
+        u: Name of the eastward velocity variable.
+        v: Name of the northward velocity variable.
+
+    Returns:
+        The input dataset with a ``pv_barotropic`` variable (m⁻¹ s⁻¹).
+    """
+
     def __init__(self, height: str = "h", u: str = "u", v: str = "v"):
         self.height = height
         self.u = u
@@ -258,6 +524,18 @@ class PotentialVorticityBarotropic(Operator):
 
 
 class VelocityMagnitude(Operator):
+    """Velocity magnitude ``|U| = √(u² + v² [+ w²])``.
+
+    Args:
+        u: Name of the eastward velocity variable.
+        v: Name of the northward velocity variable.
+        w: Name of the vertical velocity variable, or ``None`` for the
+            horizontal-only magnitude.
+
+    Returns:
+        The input dataset with a ``speed`` variable (m s⁻¹).
+    """
+
     def __init__(self, u: str = "u", v: str = "v", w: str | None = None):
         self.u = u
         self.v = v
@@ -271,11 +549,31 @@ class VelocityMagnitude(Operator):
 
 
 class HorizontalVelocityMagnitude(_UVOperator):
+    """Horizontal current speed ``√(u² + v²)``.
+
+    Args:
+        u: Name of the eastward velocity variable.
+        v: Name of the northward velocity variable.
+
+    Returns:
+        The input dataset with a ``speed`` variable (m s⁻¹).
+    """
+
     def _apply(self, ds):
         return _kinematics.horizontal_velocity_magnitude(ds, u=self.u, v=self.v)
 
 
 class EddyKineticEnergy(Operator):
+    """Eddy kinetic energy ``EKE = ½ (u'² + v'²)`` from velocity anomalies.
+
+    Args:
+        u_anom: Name of the eastward velocity-anomaly variable ``u'``.
+        v_anom: Name of the northward velocity-anomaly variable ``v'``.
+
+    Returns:
+        The input dataset with an ``eke`` variable (m² s⁻²).
+    """
+
     def __init__(self, u_anom: str = "u_anom", v_anom: str = "v_anom"):
         self.u_anom = u_anom
         self.v_anom = v_anom
@@ -290,6 +588,21 @@ class EddyKineticEnergy(Operator):
 
 
 class BruntVaisalaFrequency(Operator):
+    """Squared Brunt–Väisälä (buoyancy) frequency ``N² = −(g/ρ₀) ∂ρ/∂z``.
+
+    Args:
+        density: Name of the (potential) density variable ``ρ``.
+        depth: Name of the vertical coordinate variable.
+        rho0: Reference density ``ρ₀`` (kg m⁻³).
+        g: Gravitational acceleration (m s⁻²). ``None`` uses the package
+            default.
+        positive: Orientation of ``depth`` — ``"down"`` (depth increases
+            downward) or ``"up"``.
+
+    Returns:
+        The input dataset with an ``n_squared`` variable (s⁻²).
+    """
+
     def __init__(
         self,
         density: str = "rho",
@@ -325,6 +638,18 @@ class BruntVaisalaFrequency(Operator):
 
 
 class LapseRate(Operator):
+    """Vertical lapse rate ``Γ = −∂T/∂z`` (z positive upward).
+
+    Args:
+        temperature: Name of the temperature variable.
+        depth: Name of the vertical coordinate variable.
+        positive: Orientation of ``depth`` — ``"down"`` (depth increases
+            downward) or ``"up"``.
+
+    Returns:
+        The input dataset with a ``lapse_rate`` variable (K m⁻¹).
+    """
+
     def __init__(
         self,
         temperature: str = "T",
@@ -352,6 +677,23 @@ class LapseRate(Operator):
 
 
 class MixedLayerDepth(Operator):
+    """Mixed-layer depth via the de Boyer Montégut density threshold.
+
+    Finds the depth at which density first exceeds the ``reference_depth``
+    value by ``threshold`` (kg m⁻³).
+
+    Args:
+        density: Name of the (potential) density variable.
+        depth: Name of the vertical coordinate variable.
+        reference_depth: Near-surface reference depth (m) the threshold is
+            measured from.
+        threshold: Density increase defining the mixed-layer base
+            (kg m⁻³).
+
+    Returns:
+        The input dataset with an ``mld`` variable (m).
+    """
+
     def __init__(
         self,
         density: str = "rho",


### PR DESCRIPTION
## What

Cleanup sweep **PR 3**. Documents the `ocn` operator layer — the
worst-documented module in the audit (**27 of 28 operators had no
docstring**). Adds a high-quality Google-style docstring to every operator,
the shared `_UVOperator` base, and the module itself. **Docstrings only — no
code or behaviour change.**

## Each docstring states

- **The physics**, with the governing expression — e.g. relative vorticity
  `ζ = ∂v/∂x − ∂u/∂y`, Okubo–Weiss `W = S_n² + S_s² − ζ²`, Brunt–Väisälä
  `N² = −(g/ρ₀) ∂ρ/∂z`.
- **`Args`** — the constructor's variable / coordinate names.
- **`Returns`** — the exact output variable name, each one **verified against
  the underlying `ocn._src` primitive** (`ke`, `vort_r`, `div`, `ow`, `psi`,
  `ens`, `strain`, `n_squared`, `mld`, `pv_barotropic`, `u_a`/`v_a`,
  `<scalar>_advection`, `<scalar>_frontogenesis`, …). Caught and fixed several
  names I'd initially guessed (geostrophic → `u`/`v`, ageostrophic → `u_a`/`v_a`,
  advection → `<scalar>_advection`, `coriolis_normalized` replaces in place).

Follows the docstring template from the convention note (PR #228) and the
`geo.Reduce` exemplar.

## Verification

| Check | Result |
|---|---|
| every ocn operator has a docstring | **29/29, none missing** |
| `pytest tests/test_ocn.py` | **67 passed** |
| `ruff check` / `format` | passed |
| `ty check src/xrtoolz` | exit 0 |

Independent of PR 1 (#228) and PR 2 (#229).

https://claude.ai/code/session_01BiceP8WMSTKWdkcLQ4vrqz

---
_Generated by [Claude Code](https://claude.ai/code/session_01BiceP8WMSTKWdkcLQ4vrqz)_