### PR TITLE
docs(einx,budgets): operator docstrings (cleanup sweep PR 3b)

### DIFF
--- a/src/xrtoolz/budgets/operators.py
+++ b/src/xrtoolz/budgets/operators.py
@@ -18,7 +18,25 @@ from xrtoolz.budgets._src.volume_budget import volume_budget_residual
 
 
 class ControlVolumeIntegral(Operator):
-    """Operator wrapper for :func:`control_volume_integral`."""
+    """Volume-weighted integral of a field over a control volume.
+
+    Integrates ``variable`` over ``dims`` weighted by the cell volumes in
+    ``volume_metrics`` (optionally masked to ``region``). The metrics are
+    explicit, never auto-derived — build them with
+    :func:`xrtoolz.calc.grid_metrics_from_coords` if the data does not ship
+    them.
+
+    Args:
+        variable: Name of the field to integrate.
+        volume_metrics: Dataset carrying the ``cell_volume_var`` weights.
+        region: Optional boolean mask selecting the control volume.
+        dims: Dimensions integrated over.
+        cell_volume_var: Name of the cell-volume variable in
+            ``volume_metrics``.
+
+    Returns:
+        The volume integral as a DataArray (reduced over ``dims``).
+    """
 
     def __init__(
         self,
@@ -56,7 +74,22 @@ class ControlVolumeIntegral(Operator):
 
 
 class BoundaryFlux(Operator):
-    """Operator wrapper for :func:`boundary_flux`."""
+    """Advective flux through the faces of a control volume.
+
+    Integrates the ``velocity_vars`` (optionally carrying ``variable``) over
+    the face areas in ``face_metrics``, optionally restricted to ``region``.
+    The metrics are explicit, never auto-derived.
+
+    Args:
+        variable: Tracer carried by the flow, or ``None`` for a pure volume
+            (velocity) flux.
+        velocity_vars: Mapping of face direction → velocity variable name.
+        face_metrics: Dataset carrying the face-area weights.
+        region: Optional boolean mask selecting the control volume.
+
+    Returns:
+        Dataset of per-boundary fluxes.
+    """
 
     def __init__(
         self,
@@ -90,7 +123,22 @@ class BoundaryFlux(Operator):
 
 
 class BudgetResidual(Operator):
-    """Operator wrapper for :func:`budget_residual`."""
+    """Generic conservation residual ``∂φ/∂t + ∇·F − source + sink``.
+
+    Combines a precomputed tendency and flux divergence (with optional
+    source / sink terms) into the budget-closure residual; a perfectly
+    closed budget is zero. Inputs are passed to ``__call__``, not the
+    constructor.
+
+    Args:
+        tendency: Local time tendency ``∂φ/∂t``.
+        flux_divergence: Divergence of the flux ``∇·F``.
+        source: Optional source term.
+        sink: Optional sink term.
+
+    Returns:
+        The budget-closure residual DataArray.
+    """
 
     def _apply(
         self,
@@ -107,7 +155,12 @@ class BudgetResidual(Operator):
 
 
 class _TracerBudgetOp(Operator):
-    """Shared init for the per-tracer budget operators."""
+    """Shared ``__init__`` / ``get_config`` for per-tracer budget operators.
+
+    Holds the tracer, velocity, surface-flux, and coordinate-name
+    configuration common to :class:`HeatBudgetResidual` and
+    :class:`SaltBudgetResidual`.
+    """
 
     def __init__(
         self,
@@ -147,7 +200,27 @@ class _TracerBudgetOp(Operator):
 
 
 class HeatBudgetResidual(_TracerBudgetOp):
-    """Operator wrapper for :func:`heat_budget_residual`."""
+    """Per-cell heat-budget residual ``∂θ/∂t + ∇·(u θ) − Q``.
+
+    Uses the spherical-metric divergence from :mod:`xrtoolz.calc`; returns
+    the per-cell residual (zero for a closed budget). It does **not** consume
+    volume/face metrics — multiply by ``cell_volume`` and integrate with
+    :class:`ControlVolumeIntegral` for a control-volume closure.
+
+    Args:
+        temp_var: Temperature (θ) variable name.
+        u_var: Eastward velocity variable name.
+        v_var: Northward velocity variable name.
+        w_var: Vertical velocity variable name, or ``None``.
+        surface_flux_var: Optional surface heat-flux variable name.
+        time_dim: Time dimension name.
+        lat: Latitude coordinate name.
+        lon: Longitude coordinate name.
+        depth: Vertical coordinate name, or ``None`` for a 2-D budget.
+
+    Returns:
+        The per-cell heat-budget residual DataArray.
+    """
 
     def __init__(self, *, temp_var: str = "theta", **kw: Any) -> None:
         super().__init__(tracer_var=temp_var, **kw)
@@ -168,7 +241,25 @@ class HeatBudgetResidual(_TracerBudgetOp):
 
 
 class SaltBudgetResidual(_TracerBudgetOp):
-    """Operator wrapper for :func:`salt_budget_residual`."""
+    """Per-cell salt-budget residual ``∂S/∂t + ∇·(u S) − F``.
+
+    Like :class:`HeatBudgetResidual` but for salinity; returns the per-cell
+    residual (zero for a closed budget).
+
+    Args:
+        salt_var: Salinity (S) variable name.
+        u_var: Eastward velocity variable name.
+        v_var: Northward velocity variable name.
+        w_var: Vertical velocity variable name, or ``None``.
+        surface_flux_var: Optional surface salt-flux variable name.
+        time_dim: Time dimension name.
+        lat: Latitude coordinate name.
+        lon: Longitude coordinate name.
+        depth: Vertical coordinate name, or ``None`` for a 2-D budget.
+
+    Returns:
+        The per-cell salt-budget residual DataArray.
+    """
 
     def __init__(self, *, salt_var: str = "so", **kw: Any) -> None:
         super().__init__(tracer_var=salt_var, **kw)
@@ -189,7 +280,22 @@ class SaltBudgetResidual(_TracerBudgetOp):
 
 
 class VolumeBudgetResidual(Operator):
-    """Operator wrapper for :func:`volume_budget_residual`."""
+    """Per-cell volume (continuity) residual ``∇·u``.
+
+    The horizontal + vertical velocity divergence; zero for a non-divergent
+    (volume-conserving) flow.
+
+    Args:
+        u_var: Eastward velocity variable name.
+        v_var: Northward velocity variable name.
+        w_var: Vertical velocity variable name, or ``None``.
+        lat: Latitude coordinate name.
+        lon: Longitude coordinate name.
+        depth: Vertical coordinate name, or ``None`` for a 2-D budget.
+
+    Returns:
+        The per-cell continuity residual DataArray.
+    """
 
     def __init__(
         self,
@@ -231,7 +337,25 @@ class VolumeBudgetResidual(Operator):
 
 
 class KineticEnergyBudgetResidual(Operator):
-    """Operator wrapper for :func:`kinetic_energy_budget_residual`."""
+    """Per-cell kinetic-energy budget residual.
+
+    Residual of ``∂KE/∂t + ∇·(u KE) − forcing`` with ``KE = ½(u² + v²)``;
+    zero for a closed KE budget.
+
+    Args:
+        u_var: Eastward velocity variable name.
+        v_var: Northward velocity variable name.
+        forcing_vars: Optional forcing / dissipation variable names summed as
+            the source term.
+        time_dim: Time dimension name.
+        lat: Latitude coordinate name.
+        lon: Longitude coordinate name.
+        depth: Vertical coordinate name, or ``None`` for a 2-D budget.
+        w_var: Vertical velocity variable name, or ``None``.
+
+    Returns:
+        The per-cell KE-budget residual DataArray.
+    """
 
     def __init__(
         self,

--- a/src/xrtoolz/einx/operators.py
+++ b/src/xrtoolz/einx/operators.py
@@ -56,7 +56,22 @@ def _coords_config(coords: Mapping[str, Any] | None) -> dict[str, Any] | None:
 
 
 class Einsum(Operator):
-    """Layer-1 wrapper around :func:`xrtoolz.einx.einsum` (variadic)."""
+    """Named-tensor Einstein summation over one or more DataArrays.
+
+    Applies :func:`xrtoolz.einx.einsum` using DataArray dim names as the
+    pattern's axis tokens, e.g. ``"b i j, b j k -> b i k"``.
+
+    Args:
+        pattern: einx einsum pattern; axis tokens are DataArray dim names.
+        coords: Optional coordinates to attach to newly created output dims.
+        align: When ``True``, broadcast-align inputs on shared dims before
+            contracting.
+        **shape_kwargs: Sizes for composite/unknown axes in ``pattern``.
+
+    Returns:
+        The contracted DataArray with the dims named on the pattern's
+        right-hand side.
+    """
 
     def __init__(
         self,
@@ -99,7 +114,19 @@ class Einsum(Operator):
 
 
 class Rearrange(Operator):
-    """Layer-1 wrapper around :func:`xrtoolz.einx.rearrange` (single-input)."""
+    """Reshape / transpose a DataArray by a named-tensor pattern.
+
+    Applies :func:`xrtoolz.einx.rearrange`, e.g. ``"(h w) c -> h w c"`` to
+    split a flattened axis into named dims.
+
+    Args:
+        pattern: einx rearrange pattern over DataArray dim names.
+        coords: Optional coordinates for newly created dims.
+        **shape_kwargs: Sizes for composite axes that cannot be inferred.
+
+    Returns:
+        The rearranged DataArray.
+    """
 
     def __init__(
         self,
@@ -134,7 +161,25 @@ class Rearrange(Operator):
 
 
 class Reduce(Operator):
-    """Layer-1 wrapper around :func:`xrtoolz.einx.reduce` (single-input)."""
+    """Reduce a DataArray over named axes with a chosen reduction.
+
+    Applies :func:`xrtoolz.einx.reduce`, e.g. ``"b [i] j -> b j"`` to reduce
+    the bracketed axis ``i``.
+
+    Note:
+        Distinct from :class:`xrtoolz.geo.Reduce`, which aggregates a whole
+        Dataset over xarray dims; this reduces a single DataArray by an einx
+        pattern.
+
+    Args:
+        pattern: einx reduce pattern; bracketed axes are reduced.
+        op: Reduction — a name (``"sum"``, ``"mean"``, ``"max"``, …) or a
+            callable accepting an ``axis`` argument.
+        **shape_kwargs: Sizes for composite axes that cannot be inferred.
+
+    Returns:
+        The reduced DataArray.
+    """
 
     def __init__(
         self,
@@ -170,7 +215,19 @@ class Reduce(Operator):
 
 
 class Repeat(Operator):
-    """Layer-1 wrapper around :func:`xrtoolz.einx.repeat` (single-input)."""
+    """Broadcast / tile a DataArray along new named axes.
+
+    Applies :func:`xrtoolz.einx.repeat`, e.g. ``"h w -> h w c"`` with
+    ``c=3`` to add and fill a new dimension.
+
+    Args:
+        pattern: einx repeat pattern over DataArray dim names.
+        coords: Optional coordinates for the repeated dims.
+        **shape_kwargs: Sizes of the new axes introduced by ``pattern``.
+
+    Returns:
+        The repeated DataArray.
+    """
 
     def __init__(
         self,
@@ -227,7 +284,17 @@ class _BinaryLinalgOp(Operator):
 
 
 class Matmul(_BinaryLinalgOp):
-    """Layer-1 wrapper around :func:`xrtoolz.einx.matmul` (two-input)."""
+    """Contract two DataArrays over a shared dimension (matrix multiply).
+
+    Applies :func:`xrtoolz.einx.matmul`: sums the product over ``dim``,
+    keeping all other (broadcast) dims.
+
+    Args:
+        dim: Name of the shared dimension contracted over.
+
+    Returns:
+        The matrix product, with ``dim`` removed.
+    """
 
     def __init__(self, *, dim: str) -> None:
         self.dim = dim
@@ -252,7 +319,14 @@ class Matmul(_BinaryLinalgOp):
 
 
 class Outer(_BinaryLinalgOp):
-    """Layer-1 wrapper around :func:`xrtoolz.einx.outer` (two-input)."""
+    """Outer product of two DataArrays over their disjoint dims.
+
+    Applies :func:`xrtoolz.einx.outer`: the result carries every dim of the
+    first input followed by every dim of the second.
+
+    Returns:
+        The outer-product DataArray.
+    """
 
     def _apply(self, a: xr.DataArray, b: xr.DataArray) -> xr.DataArray:
         return outer(a, b)
@@ -271,7 +345,19 @@ class Outer(_BinaryLinalgOp):
 
 
 class BatchMatmul(_BinaryLinalgOp):
-    """Layer-1 wrapper around :func:`xrtoolz.einx.batch_matmul` (two-input)."""
+    """Batched matrix multiply: contract ``dim`` within shared batch dims.
+
+    Applies :func:`xrtoolz.einx.batch_matmul`, contracting ``dim`` while
+    broadcasting over ``batch_dims`` (which are kept on the output).
+
+    Args:
+        dim: Name of the shared dimension contracted over.
+        batch_dims: Dimensions broadcast over (not contracted), kept on the
+            output.
+
+    Returns:
+        The batched matrix product, with ``dim`` removed.
+    """
 
     def __init__(self, *, dim: str, batch_dims: Sequence[str] = ()) -> None:
         self.dim = dim


### PR DESCRIPTION
## What

Cleanup sweep **PR 3b** — finishes the docstring gaps after `ocn` (#230).
The `einx` and `budgets` operator layers had thin one-liner docstrings
(`"Operator wrapper for ..."`) with no `Args`/`Returns`. **Docstrings only —
no code or behaviour change.**

## einx (named-tensor algebra)

Every operator now documents a pattern example + `Args` + `Returns`:
`Einsum`, `Rearrange`, `Reduce`, `Repeat`, `Matmul`, `Outer`, `BatchMatmul`.
`Reduce` also calls out the **`geo.Reduce` vs `einx.Reduce`** distinction (the
one name collision the duplication audit flagged — Dataset aggregation vs
einx-pattern reduction).

## budgets (conservation diagnostics)

Every operator documents the governing expression + `Args` + `Returns`, drawn
from the module's authoritative physics description:
`ControlVolumeIntegral`, `BoundaryFlux`, `BudgetResidual`,
`HeatBudgetResidual`, `SaltBudgetResidual`, `VolumeBudgetResidual`,
`KineticEnergyBudgetResidual` (e.g. `∂θ/∂t + ∇·(u θ) − Q`).

Follows the convention note (#228) and the `geo.Reduce` exemplar.

## Verification

| Check | Result |
|---|---|
| docstring coverage | all einx + budgets operators documented (none thin/missing) |
| `pytest tests/einx` | **46 passed** |
| `ruff check .` / `format` | passed |
| `ty check src/xrtoolz` | exit 0 |

Independent of the other cleanup PRs (#228, #229, #230).

https://claude.ai/code/session_01BiceP8WMSTKWdkcLQ4vrqz

---
_Generated by [Claude Code](https://claude.ai/code/session_01BiceP8WMSTKWdkcLQ4vrqz)_