### PR TITLE
docs: render docstring doctests as code blocks

### DIFF
--- a/src/xrtoolz/einx/__init__.py
+++ b/src/xrtoolz/einx/__init__.py
@@ -16,8 +16,10 @@ Two surfaces:
   :class:`BatchMatmul`.
 
 Example:
+    ```pycon
     >>> import xrtoolz.einx as xnx
     >>> total = xnx.einsum("time lat lon, lat lon -> time", field, mask)
+    ```
 """
 
 from __future__ import annotations

--- a/src/xrtoolz/einx/_src/core.py
+++ b/src/xrtoolz/einx/_src/core.py
@@ -61,7 +61,9 @@ def einsum(
         forwarded from the first input carrying each surviving dim.
 
     Example:
+        ```pycon
         >>> total = einsum("time lat lon, lat lon -> time", field, mask)
+        ```
     """
     import einx
 
@@ -93,11 +95,13 @@ def rearrange(
     supplies them.
 
     Example:
+        ```pycon
         >>> patches = rearrange(
         ...     "time (lat_blk lat_in) (lon_blk lon_in) "
         ...     "-> time (lat_blk lon_blk) lat_in lon_in",
         ...     field, lat_in=4, lon_in=4,
         ... )
+        ```
     """
     import einx
 
@@ -126,9 +130,11 @@ def reduce(
             einx's numpy-like reduce adapter for the input's backend.
 
     Example:
+        ```pycon
         >>> climatology = reduce(
         ...     "time lat lon -> lat lon", sst, op="mean",
         ... )
+        ```
     """
     parsed = parse_pattern(pattern)
     if len(parsed.inputs) != 1:
@@ -152,9 +158,11 @@ def repeat(
     New dims are unindexed unless ``coords`` supplies them.
 
     Example:
+        ```pycon
         >>> seasonal = repeat(
         ...     "lat lon -> month lat lon", mean_field, month=12,
         ... )
+        ```
     """
     import einx
 

--- a/src/xrtoolz/einx/_src/linalg.py
+++ b/src/xrtoolz/einx/_src/linalg.py
@@ -23,8 +23,10 @@ def matmul(a: xr.DataArray, b: xr.DataArray, *, dim: str) -> xr.DataArray:
     with ``a``'s remaining dims first.
 
     Example:
+        ```pycon
         >>> # (time, k) · (k, mode) -> (time, mode)
         >>> scores = matmul(field, basis, dim="k")
+        ```
     """
     if dim not in a.dims or dim not in b.dims:
         raise PatternError(
@@ -50,7 +52,9 @@ def outer(a: xr.DataArray, b: xr.DataArray) -> xr.DataArray:
     """Outer product. Output carries ``a``'s dims then ``b``'s dims.
 
     Example:
+        ```pycon
         >>> weights = outer(lat_weights, lon_weights)
+        ```
     """
     overlap = set(a.dims) & set(b.dims)
     if overlap:
@@ -74,8 +78,10 @@ def batch_matmul(
     """``matmul`` along ``dim`` broadcast over shared ``batch_dims``.
 
     Example:
+        ```pycon
         >>> # contract 'k', broadcast over shared 'ensemble'
         >>> out = batch_matmul(a, b, dim="k", batch_dims=["ensemble"])
+        ```
     """
     batch = list(batch_dims)
     for name in (dim, *batch):

--- a/src/xrtoolz/interpolate/_src/grid_to_grid.py
+++ b/src/xrtoolz/interpolate/_src/grid_to_grid.py
@@ -62,8 +62,10 @@ def coarsen_conservative(
         Coarsened dataset or data array with the same dimension names.
 
     Examples:
+        ```pycon
         >>> coarsen_conservative(da, {"lat": 4, "lon": 4})
         >>> coarsen_conservative(ds, {"latitude": 2}, lat="latitude")
+        ```
     """
     factor_dict = _validate_coarsen_factor(factor)
     if isinstance(ds, xr.Dataset):
@@ -186,7 +188,9 @@ def refine_2d(
             outside 0..5, or either resize factor is non-positive.
 
     Examples:
+        ```pycon
         >>> refined = refine_2d(da, factor={"lat": 2, "lon": 2}, order=3)
+        ```
     """
     resize = _get_skimage_resize()
     if lat not in da.dims or lon not in da.dims:

--- a/src/xrtoolz/metrics/_src/composite.py
+++ b/src/xrtoolz/metrics/_src/composite.py
@@ -32,7 +32,9 @@ def rmse_skill_scores(
         ``error_stability``.
 
     Examples:
+        ```pycon
         >>> rmse_skill_scores(pred_da, ref_da)
+        ```
 
     ``error_stability`` uses xarray's default ``std(..., ddof=0)`` to
     match the upstream OSSE report.
@@ -91,7 +93,9 @@ def psd_score_spacetime(
         and ``summary`` contains the min/max resolved wavelengths.
 
     Examples:
+        ```pycon
         >>> score, summary = psd_score_spacetime(pred_da, ref_da)
+        ```
     """
     if xrft_kwargs.get("isotropic"):
         # Isotropic mode collapses the two spatial axes into a single

--- a/src/xrtoolz/metrics/_src/dm.py
+++ b/src/xrtoolz/metrics/_src/dm.py
@@ -164,9 +164,11 @@ class DieboldMariano(Operator):
         hln_correction: Apply the Harvey–Leybourne–Newbold correction.
 
     Example:
+        ```pycon
         >>> op = DieboldMariano("error", dim="time")
         >>> result = op(ds_errors_a, ds_errors_b)
         >>> result["statistic"], result["p_value"]
+        ```
     """
 
     def __init__(

--- a/src/xrtoolz/metrics/_src/forecast.py
+++ b/src/xrtoolz/metrics/_src/forecast.py
@@ -90,9 +90,11 @@ class SkillByLeadTime(Operator):
             dataset. Defaults to ``"lead_time"``.
 
     Example:
+        ```pycon
         >>> from xrtoolz.metrics import RMSE, SkillByLeadTime
         >>> op = SkillByLeadTime(RMSE("ssh", dims=("lat", "lon")))
         >>> skill = op(pred_ds, ref_ds)  # DataArray indexed by lead_time
+        ```
     """
 
     def __init__(self, metric: Operator, *, lead_dim: str = "lead_time") -> None:

--- a/src/xrtoolz/metrics/_src/masked.py
+++ b/src/xrtoolz/metrics/_src/masked.py
@@ -57,12 +57,14 @@ class MaskedMetric(Operator):
             be supplied via ``__call__(pred, ref, mask=...)``.
 
     Example:
+        ```pycon
         >>> from xrtoolz.metrics import RMSE, MaskedMetric
         >>> op = MaskedMetric(RMSE("ssh", ("lat", "lon")), mask=ocean)
         >>> op(pred_ds, ref_ds)
         >>>
         >>> op2 = MaskedMetric(RMSE("sst", ("lat", "lon")))
         >>> op2(pred_ds, ref_ds, mask=cloud_free_today)
+        ```
     """
 
     def __init__(self, metric: Operator, mask: xr.DataArray | None = None) -> None:

--- a/src/xrtoolz/metrics/_src/multiscale.py
+++ b/src/xrtoolz/metrics/_src/multiscale.py
@@ -189,8 +189,10 @@ class EvaluateByRegion(Operator):
     Pre-normalize once and reuse via :func:`normalize_regions` if you
     intend to evaluate multiple metrics over the same regions:
 
+        ```pycon
         >>> mask, names = normalize_regions(natural_earth, ds)
         >>> EvaluateByRegion(RMSE(...), regions=mask)
+        ```
     """
 
     def __init__(self, metric: Operator, *, regions: Any) -> None:

--- a/src/xrtoolz/metrics/_src/spectral.py
+++ b/src/xrtoolz/metrics/_src/spectral.py
@@ -181,7 +181,9 @@ def resolved_scale_2d(
         exists at ``level``, all entries are ``NaN``.
 
     Examples:
+        ```pycon
         >>> resolved_scale_2d(score, level=0.5)
+        ```
     """
     score_da = score["score"] if isinstance(score, xr.Dataset) else score
     segments = find_intercept_2D(

--- a/src/xrtoolz/signature.py
+++ b/src/xrtoolz/signature.py
@@ -19,6 +19,7 @@ is left as-is, and anything that fails to construct via :func:`np.dtype`
 falls back to ``str(dtype)`` for forward compatibility.
 
 Example:
+    ```pycon
     >>> sig = Signature({"time": 365, "lat": 181, "lon": 360}, dtype="float32")
     >>> sig.format()
     '(time=365, lat=181, lon=360); dtype=float32'
@@ -26,6 +27,7 @@ Example:
     '(lat=181, lon=360); dtype=float32'
     >>> sig.replace_dims({"lat": None}).format()
     '(time=365, lat=?, lon=360); dtype=float32'
+    ```
 """
 
 from __future__ import annotations
@@ -73,6 +75,7 @@ class Signature:
             ``int | None``.
 
     Example:
+        ```pycon
         >>> import numpy as np
         >>> from xrtoolz import Signature
         >>> Signature({"time": 12}, dtype="float32") == Signature(
@@ -83,6 +86,7 @@ class Signature:
         ...     {"lat": 4, "time": 12}, dtype="float32",
         ... )
         True
+        ```
     """
 
     dims: Mapping[str, int | None]
@@ -145,9 +149,11 @@ class Signature:
                 that don't carry the optional dim.
 
         Example:
+            ```pycon
             >>> sig = Signature({"time": 12, "lat": 4})
             >>> sig.replace_dims({"time": None}).format()
             '(time=?, lat=4)'
+            ```
         """
         if strict:
             unknown = set(updates) - set(self.dims)
@@ -166,9 +172,11 @@ class Signature:
         """Return a copy with dimension names renamed by ``mapping``.
 
         Example:
+            ```pycon
             >>> sig = Signature({"lon": 360, "lat": 181})
             >>> sig.rename_dims({"lon": "longitude"}).format()
             '(longitude=360, lat=181)'
+            ```
         """
         return Signature(
             {mapping.get(name, name): size for name, size in self.dims.items()},
@@ -179,9 +187,11 @@ class Signature:
         """Return a copy without the requested dimensions.
 
         Example:
+            ```pycon
             >>> sig = Signature({"time": 12, "lat": 4, "lon": 8})
             >>> sig.drop_dims(("time", "lat")).format()
             '(lon=8)'
+            ```
         """
         drop = {names} if isinstance(names, str) else set(names)
         return Signature(

--- a/src/xrtoolz/transforms/operators.py
+++ b/src/xrtoolz/transforms/operators.py
@@ -155,8 +155,10 @@ class KESpectralFlux(Operator):
         when requested.
 
     Examples:
+        ```pycon
         >>> op = KESpectralFlux("u", "v", ("x", "y"), avg_dims="time")
         >>> flux_ds = op(ds)
+        ```
     """
 
     def __init__(
@@ -224,8 +226,10 @@ class EnstrophySpectralFlux(Operator):
         variables, plus ``transfer_2d`` when requested.
 
     Examples:
+        ```pycon
         >>> op = EnstrophySpectralFlux("u", "v", ("x", "y"))
         >>> flux_ds = op(ds)
+        ```
     """
 
     def __init__(

--- a/src/xrtoolz/utils/_src/sklearn_accessor.py
+++ b/src/xrtoolz/utils/_src/sklearn_accessor.py
@@ -8,10 +8,12 @@ is no parallel marshalling path. Importing :mod:`xrtoolz.utils` is
 enough to register the accessors.
 
 Example:
+    ```pycon
     >>> import xarray as xr
     >>> from sklearn.preprocessing import StandardScaler
     >>> import xrtoolz.utils  # registers the .sklearn accessor  # noqa: F401
     >>> scaled = ssh.sklearn.fit_transform(StandardScaler(), sample_dim="time")
+    ```
 """
 
 from __future__ import annotations
@@ -44,26 +46,34 @@ class _SklearnAccessor:
     through the shortcut path and produces a generic
     ``(sample_dim, component)`` layout instead.
 
+    ```pycon
     >>> from xrtoolz.utils import XarrayEstimator
     >>> from sklearn.decomposition import PCA
     >>> wrap = XarrayEstimator(PCA(n_components=2), sample_dim="time").fit(da)
     >>> # Fit once, reuse via the accessor — wrap is forwarded as-is:
     >>> scores = da.sklearn.transform(wrap)              # → (time, component)
     >>> recon = scores.sklearn.inverse_transform(wrap)   # → (time, lat, lon)
+    ```
 
     Example:
+        ```pycon
         >>> # Fit-and-transform directly off a DataArray
         >>> scores = da.sklearn.fit_transform(
         ...     PCA(n_components=3),
         ...     sample_dim="time",
         ...     nan_policy="mask",
         ... )
+        ```
 
+        ```pycon
         >>> # Score a fitted estimator against a held-out slice
         >>> r2 = da_test.sklearn.score(fitted_regressor, y_test, sample_dim="time")
+        ```
 
+        ```pycon
         >>> # Dataset variant: column-concat data_vars before fitting
         >>> scaled = ds.sklearn.fit_transform(StandardScaler(), sample_dim="time")
+        ```
     """
 
     def __init__(self, xarray_obj: xr.DataArray | xr.Dataset) -> None:

--- a/src/xrtoolz/utils/_src/sklearn_wrap.py
+++ b/src/xrtoolz/utils/_src/sklearn_wrap.py
@@ -289,15 +289,18 @@ class XarrayEstimator(BaseEstimator):
         Decompose an SSH cube with PCA, recover the original grid, and
         reach into the fitted estimator's attributes::
 
+            ```pycon
             >>> from sklearn.decomposition import PCA
             >>> wrap = XarrayEstimator(PCA(n_components=3), sample_dim="time")
             >>> scores = wrap.fit_transform(da)            # (time, component)
             >>> recon = wrap.inverse_transform(scores)     # (time, lat, lon)
             >>> wrap.components_.shape                     # passthrough attr
             (3, lat*lon)
+            ```
 
         Cluster a multi-variable Dataset (column-concatenated)::
 
+            ```pycon
             >>> from sklearn.cluster import KMeans
             >>> wrap = XarrayEstimator(
             ...     KMeans(n_clusters=4, n_init="auto"),
@@ -305,15 +308,18 @@ class XarrayEstimator(BaseEstimator):
             ... )
             >>> labels = wrap.fit(ds).predict(ds)          # (time,)
             >>> wrap.cluster_centers_.shape                # (4, n_concat_features)
+            ```
 
         NaN-tolerant fit on a land-masked grid::
 
+            ```pycon
             >>> wrap = XarrayEstimator(
             ...     PCA(n_components=5),
             ...     sample_dim="time",
             ...     nan_policy="mask",       # drop NaN rows pre-fit, re-insert post
             ... )
             >>> scores = wrap.fit_transform(ssh)           # land cells stay NaN
+            ```
     """
 
     def __init__(


### PR DESCRIPTION
## What

Fixes the mangled rendering of docstring examples (e.g. `Signature.replace_dims`).

## Why

Bare `>>>` doctest lines inside Google-style `Example:` sections were parsed by **Markdown as nested blockquotes** — `>>>` is three levels of `>` blockquote — so an example like:

```
>>> sig.replace_dims({"time": None}).format()
'(time=?, lat=4)'
```

rendered as a triple-nested, unhighlighted, line-collapsed paragraph instead of code. (Examples using indented/`::` code blocks, like `ApplyToEach`, rendered fine — hence the inconsistency.)

## Change

Wrap every docstring doctest block in a fenced ` ```pycon ` code block across the documented modules (`signature`, `einx`, `transforms`, `metrics`, `interpolate`, `utils`). Indentation and `...` continuations are preserved; blank-separated examples become separate fenced blocks. Now they render as highlighted console sessions (`>>>` prompts + output styled correctly).

Docs-only effect — no code paths touched.

## Verification

- Confirmed in the built HTML: `replace_dims` (and the other 30+ examples) now render as `pycon` code blocks rather than blockquotes.
- `mkdocs build` clean of real warnings; package imports; `ruff check` / `ruff format --check` pass.

https://claude.ai/code/session_01BiceP8WMSTKWdkcLQ4vrqz

---
_Generated by [Claude Code](https://claude.ai/code/session_01BiceP8WMSTKWdkcLQ4vrqz)_