### PR TITLE
test(dask): dask-compat foundation — numpy/dask parity sweep + CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,18 @@ jobs:
         with:
           files: ./coverage.xml
           fail_ci_if_error: false
+
+  dask:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: uv sync --group dev --extra image
+      - name: Run dask compatibility sweep
+        # Focused marker job; the matrix job above owns coverage. Known
+        # Tier-2/3 gaps are registered as strict xfails, so this job stays
+        # green and flips automatically as each remediation lands.
+        run: uv run pytest -m dask -v --no-cov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,10 @@ classifiers = [
 ]
 dependencies = [
     "numpy>=1.26",
+    # Lazy/chunked xarray backend. Operators stay lazy where their kernel is
+    # naturally per-chunk; the rest accept dask input and materialise
+    # internally. See the Dask page in the docs for the per-operator tiers.
+    "dask[array]>=2024.10",
     # Shape-and-dtype annotations for the numpy kernels (Layer 0). Used as
     # documentation/static types only — no runtime enforcement — so it adds
     # negligible weight. See docs/design/conventions/array-typing.md.
@@ -181,6 +185,9 @@ unresolved-attribute = "warn"
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "--cov=src/xrtoolz --cov-report=term-missing --cov-report=xml:coverage.xml"
+markers = [
+    "dask: exercises dask-backed (chunked) xarray inputs",
+]
 
 [tool.coverage.run]
 source = ["src/xrtoolz"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,46 @@
+"""Shared pytest fixtures, including the numpy/dask backend matrix.
+
+The ``array_backend`` / ``maybe_chunk`` pair lets a single test body run
+against both an eager numpy-backed xarray object and a lazy dask-backed one,
+so dask compatibility is exercised without duplicating test logic. See
+``tests/test_dask_compat.py`` for the repo-wide operator parity sweep.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from typing import Literal, cast
+
+import pytest
+import xarray as xr
+
+
+ArrayBackend = Literal["numpy", "dask"]
+MaybeChunk = Callable[
+    [xr.DataArray | xr.Dataset, ArrayBackend, Mapping[str, int] | None],
+    xr.DataArray | xr.Dataset,
+]
+
+
+@pytest.fixture(params=["numpy", "dask"])
+def array_backend(request: pytest.FixtureRequest) -> ArrayBackend:
+    """Parametrize a test over the ``"numpy"`` and ``"dask"`` backends."""
+    return cast(ArrayBackend, request.param)
+
+
+def _maybe_chunk(
+    obj: xr.DataArray | xr.Dataset,
+    backend: ArrayBackend,
+    chunks: Mapping[str, int] | None = None,
+) -> xr.DataArray | xr.Dataset:
+    """Chunk ``obj`` for the ``"dask"`` backend; return it as-is otherwise."""
+    if backend == "dask":
+        pytest.importorskip("dask.array")
+        return obj.chunk(chunks or {})
+    return obj
+
+
+@pytest.fixture
+def maybe_chunk() -> MaybeChunk:
+    """Return a helper that chunks an xarray object for the dask backend."""
+    return _maybe_chunk

--- a/tests/test_dask_compat.py
+++ b/tests/test_dask_compat.py
@@ -1,0 +1,188 @@
+"""Repo-wide numpy/dask parity sweep.
+
+Each :class:`Case` runs one operator against an eager numpy input and the
+same input chunked with dask, then asserts the two results match. Where an
+operator is expected to *stay lazy* (its kernel is naturally per-chunk),
+``lazy=True`` additionally asserts the dask output is not eagerly computed.
+
+Operators that cannot yet accept dask input are registered with an ``xfail``
+mark so the matrix stays complete; the corresponding remediation flips them
+to passing.
+
+See ``docs/`` (the Dask page) for the per-operator tier table.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+import xrtoolz.calc as calc
+from xrtoolz.geo.operators import (
+    CalculateClimatology,
+    RemoveMean,
+    ValidateLongitude,
+)
+from xrtoolz.interpolate.operators import (
+    Coarsen,
+    FillNaNLaplacian,
+    FillNaNRBF,
+    FillNaNSpatial,
+    GaussianSmooth,
+    MovingAverage,
+)
+from xrtoolz.metrics.operators import MAE, RMSE, Bias, Correlation
+from xrtoolz.ocn.operators import (
+    Divergence,
+    GeostrophicVelocities,
+    KineticEnergy,
+    OkuboWeiss,
+    RelativeVorticity,
+    Streamfunction,
+    VelocityMagnitude,
+)
+from xrtoolz.transforms.operators import PowerSpectrum
+
+
+pytestmark = pytest.mark.dask
+pytest.importorskip("dask.array")
+
+# Chunk the leading (time) axis and keep each 2-D spatial slice whole — the
+# realistic pattern for per-slice kernels.
+CHUNKS = {"time": 1, "lat": -1, "lon": -1}
+
+
+def _grid(*, gap: bool = False) -> xr.Dataset:
+    """Deterministic ``(time, lat, lon)`` dataset with standard var names."""
+    rng = np.random.default_rng(0)
+    t, na, no = 6, 24, 32
+    lat = np.linspace(-10.0, 10.0, na)
+    lon = np.linspace(-50.0, -30.0, no)
+    time = pd.date_range("2020-01-01", periods=t, freq="D")
+
+    def field(scale: float = 1.0, offset: float = 0.0) -> xr.DataArray:
+        data = rng.standard_normal((t, na, no)) * scale + offset
+        return xr.DataArray(
+            data,
+            dims=("time", "lat", "lon"),
+            coords={"time": time, "lat": lat, "lon": lon},
+        )
+
+    ds = xr.Dataset(
+        {
+            "ssh": field(0.1),
+            "u": field(),
+            "v": field(),
+            "sst": field(5.0, 15.0),
+        }
+    )
+    if gap:
+        holed = ds["ssh"].copy()
+        holed.values[:, 12, 16] = np.nan
+        ds["ssh"] = holed
+    return ds
+
+
+@dataclass(frozen=True)
+class Case:
+    """A single operator invocation to check for numpy/dask parity."""
+
+    id: str
+    run: Callable[..., xr.DataArray | xr.Dataset]
+    gapped: bool = False
+    needs_ref: bool = False
+    lazy: bool = False
+    xfail: str | None = None
+
+
+CASES: list[Case] = [
+    # -- calc: works under dask, materialises (finitediffx kernels) ----------
+    Case("calc.gradient", lambda d: calc.gradient(d["ssh"], dims=("lat", "lon"))),
+    Case("calc.laplacian", lambda d: calc.laplacian(d["ssh"], dims=("lat", "lon"))),
+    # -- geo: lazy --------------------------------------------------------------
+    Case("geo.RemoveMean", RemoveMean("time"), lazy=True),
+    Case("geo.ValidateLongitude", ValidateLongitude(), lazy=True),
+    Case("geo.CalculateClimatology", CalculateClimatology(), lazy=True),
+    # -- ocn: a mix of lazy and (correct) eager --------------------------------
+    Case("ocn.KineticEnergy", KineticEnergy(), lazy=True),
+    Case("ocn.VelocityMagnitude", VelocityMagnitude(), lazy=True),
+    Case("ocn.Streamfunction", Streamfunction(), lazy=True),
+    Case("ocn.RelativeVorticity", RelativeVorticity()),
+    Case("ocn.Divergence", Divergence()),
+    Case("ocn.GeostrophicVelocities", GeostrophicVelocities()),
+    Case("ocn.OkuboWeiss", OkuboWeiss()),
+    # -- transforms: lazy -------------------------------------------------------
+    Case("transforms.PowerSpectrum", PowerSpectrum("ssh", ("lat", "lon")), lazy=True),
+    # -- interpolate: smoothing works (eager); coarsen lazy --------------------
+    Case("interpolate.GaussianSmooth", GaussianSmooth(dim="lat", sigma=1.0)),
+    Case("interpolate.MovingAverage", MovingAverage(dim="lon", window=3)),
+    Case("interpolate.Coarsen", Coarsen({"lat": 2, "lon": 2}), lazy=True),
+    # -- metrics: lazy ----------------------------------------------------------
+    Case("metrics.RMSE", RMSE("ssh", ("lat", "lon")), needs_ref=True, lazy=True),
+    Case("metrics.MAE", MAE("ssh", ("lat", "lon")), needs_ref=True, lazy=True),
+    Case("metrics.Bias", Bias("ssh", ("lat", "lon")), needs_ref=True, lazy=True),
+    Case(
+        "metrics.Correlation",
+        Correlation("ssh", ("lat", "lon")),
+        needs_ref=True,
+        lazy=True,
+    ),
+    # -- gap-fill: not yet dask-aware (Tier-2 remediation flips these) ----------
+    Case(
+        "interpolate.FillNaNLaplacian",
+        FillNaNLaplacian(),
+        gapped=True,
+        xfail="gap-fill apply_ufunc lacks dask handling (Tier-2)",
+    ),
+    Case(
+        "interpolate.FillNaNSpatial",
+        FillNaNSpatial(method="linear"),
+        gapped=True,
+        xfail="gap-fill apply_ufunc lacks dask handling (Tier-2)",
+    ),
+    Case(
+        "interpolate.FillNaNRBF",
+        FillNaNRBF(),
+        gapped=True,
+        xfail="gap-fill apply_ufunc lacks dask handling (Tier-2)",
+    ),
+]
+
+
+def _params() -> list[Any]:
+    out = []
+    for c in CASES:
+        marks = (pytest.mark.xfail(reason=c.xfail, strict=True),) if c.xfail else ()
+        out.append(pytest.param(c, id=c.id, marks=marks))
+    return out
+
+
+def _compute(obj: Any) -> Any:
+    return obj.compute() if hasattr(obj, "compute") else obj
+
+
+def _is_lazy(obj: xr.DataArray | xr.Dataset) -> bool:
+    values = obj.data_vars.values() if isinstance(obj, xr.Dataset) else [obj]
+    return any(getattr(v, "chunks", None) is not None for v in values)
+
+
+@pytest.mark.parametrize("case", _params())
+def test_operator_dask_parity(case: Case) -> None:
+    """Every operator must produce identical results on numpy and dask input."""
+    ds = _grid(gap=case.gapped)
+    args_np: tuple[xr.Dataset, ...] = (ds, ds * 1.01) if case.needs_ref else (ds,)
+    args_dk = tuple(a.chunk(CHUNKS) for a in args_np)
+
+    out_np = case.run(*args_np)
+    out_dk = case.run(*args_dk)
+
+    if case.lazy:
+        assert _is_lazy(out_dk), f"{case.id}: expected a lazy (dask) result"
+
+    xr.testing.assert_allclose(_compute(out_np), _compute(out_dk))

--- a/uv.lock
+++ b/uv.lock
@@ -3246,6 +3246,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "cartopy" },
+    { name = "dask", extra = ["array"] },
     { name = "einx" },
     { name = "finitediffx" },
     { name = "jaxtyping" },
@@ -3305,6 +3306,7 @@ typecheck = [
 [package.metadata]
 requires-dist = [
     { name = "cartopy", specifier = ">=0.22" },
+    { name = "dask", extras = ["array"], specifier = ">=2024.10" },
     { name = "einx", specifier = ">=0.4" },
     { name = "finitediffx", specifier = ">=0.1.0" },
     { name = "jaxtyping", specifier = ">=0.2.34" },


### PR DESCRIPTION
## What

**Phase 1 of 4** of the dask-compatibility revamp (supersedes the stale, narrow #211). This lands the *safety net* the rest of the pass rests on — no operator code changes yet.

## The goal (and its honest limit)

"Make everything dask-compatible" splits into three empirically-verified tiers:

| Tier | With dask | Examples |
|------|-----------|----------|
| **1 — already lazy** | stays lazy, nothing to do | `geo` (RemoveMean, climatology, validate), `ocn` (KE, streamfunction, velocity-mag), `transforms.PowerSpectrum`, `Coarsen`, pixel metrics |
| **2 — make lazy** | per-slice kernels → `dask="parallelized"` | gap-fill, smoothing, morphology, wavelet, extremes, basis encoders |
| **3 — dask-safe, not lazy** | must materialise (global neighbour/fit/mask) | KNN/IDW, griddata, RBF, binning, sklearn, regionmask |

Tier 3 **can't** be fully lazy without distributed KD-trees/fits — out of scope. The achievable goal: *every operator accepts dask input without crashing, stays lazy where the algorithm allows, materialises explicitly where it must.*

## This PR

- `tests/conftest.py` — `array_backend` (numpy/dask) + `maybe_chunk` fixtures.
- `tests/test_dask_compat.py` — a registry-driven **parity sweep**: each operator runs on an eager numpy input and the same input chunked with dask, and the two results must match (`assert_allclose`). Lazy-tier operators additionally assert the dask output stays chunked. The gap-fill family is registered as **strict `xfail`s** so the matrix is complete and flips automatically as Tier-2 lands.
- `dask[array]` promoted to a core dependency.
- `dask` pytest marker + a focused `pytest -m dask` CI job.

## Verification

- `pytest -m dask`: **20 passed, 3 xfailed** (the gap-fill family).
- Full suite: **1179 passed, 3 xfailed, 0 failures**.
- `ruff check` / `ruff format --check` clean; `ty check src/xrtoolz` unchanged (no `src/` edits).

## Next

- **Phase 2** — declare `dask=`/`output_dtypes` on the per-slice `apply_ufunc` sites (gap-fill, smoothing, morphology, wavelet, extremes); flip their xfails to lazy passes.
- **Phase 3** — make the Tier-3 materialisation family accept dask gracefully.
- **Phase 4** — a Dask docs page with the per-operator tier table; close #211.

https://claude.ai/code/session_01BiceP8WMSTKWdkcLQ4vrqz

---
_Generated by [Claude Code](https://claude.ai/code/session_01BiceP8WMSTKWdkcLQ4vrqz)_